### PR TITLE
fix(refs T30074): Resolve Path Issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change Log
+
+
+## v0.0.2
+2022-11-16
+
+### Bug Fixes
+- Fix path declarations to have a buildable package
+
+## v0.0.1 
+2022-11-15
+
+- This is unfinished and broken. We just need a startingpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Bug Fixes
 - Fix path declarations to have a buildable package
 
+### Features
+- Deprecate prefixClass and prefixClassMixin
+
 ## v0.0.1 
 2022-11-15
 

--- a/components/DpInput/DpInput.vue
+++ b/components/DpInput/DpInput.vue
@@ -48,7 +48,7 @@
 import { exactlengthHint, maxlengthHint, minlengthHint } from '../../utils/lengthHint'
 import DpLabel from '../DpLabel/DpLabel'
 import { length } from '../../shared/props'
-import { prefixClassMixin } from '../../mixins'
+import { prefixClassMixin } from '@demos-europe/demosplan-utils/mixins'
 
 export default {
   name: 'DpInput',

--- a/components/DpLabel/DpLabel.vue
+++ b/components/DpLabel/DpLabel.vue
@@ -32,9 +32,9 @@
 </template>
 
 <script>
-import { CleanHtml } from 'demosplan-ui/directives'
+import { CleanHtml } from '../../directives'
 import { de } from '../shared/translations'
-import { prefixClassMixin } from '../../mixins'
+import { prefixClassMixin } from '@demos-europe/demosplan-utils/mixins'
 
 export default {
   name: 'DpLabel',

--- a/components/core/DpAutocomplete.vue
+++ b/components/core/DpAutocomplete.vue
@@ -29,8 +29,7 @@
 </template>
 
 <script>
-import { dpApi } from 'demosplan-utils'
-import { prefixClassMixin } from 'demosplan-ui/mixins'
+import { dpApi, prefixClassMixin } from '@demos-europe/demosplan-utils'
 import VueOmnibox from 'vue-omnibox'
 
 export default {

--- a/components/core/DpButtonRow.vue
+++ b/components/core/DpButtonRow.vue
@@ -58,7 +58,7 @@
 </template>
 
 <script>
-import { DpButton } from 'demosplan-ui/components'
+import { DpButton } from '../index'
 
 export default {
   name: 'DpButtonRow',

--- a/components/core/DpChangeStateAtDate.vue
+++ b/components/core/DpChangeStateAtDate.vue
@@ -92,9 +92,9 @@
 </template>
 
 <script>
-import { formatDate, toDate } from 'demosplan-utils'
+import { formatDate, toDate } from '@demos-europe/demosplan-utils'
 import DpDatepicker from './form/DpDatepicker'
-import { DpLabel } from 'demosplan-ui/components'
+import { DpLabel } from '../index'
 import DpSelect from './form/DpSelect'
 
 export default {

--- a/components/core/DpCheckboxGroup.vue
+++ b/components/core/DpCheckboxGroup.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script>
-import { CleanHtml } from 'demosplan-ui/directives'
+import { CleanHtml } from '../../directives'
 import DpCheckbox from './form/DpCheckbox'
 
 export default {

--- a/components/core/DpDashboardTaskCard.vue
+++ b/components/core/DpDashboardTaskCard.vue
@@ -24,9 +24,9 @@
 </template>
 
 <script>
-import { checkResponse, dpApi } from 'demosplan-utils'
-import { CleanHtml } from 'demosplan-ui/directives'
-import { DpButton } from 'demosplan-ui/components'
+import { checkResponse, dpApi } from '@demos-europe/demosplan-utils'
+import { CleanHtml } from '../../directives/index'
+import { DpButton } from '../index'
 import DpCard from './DpCard'
 
 export default {

--- a/components/core/DpDataTable/DpColumnSelector.vue
+++ b/components/core/DpDataTable/DpColumnSelector.vue
@@ -47,7 +47,7 @@
 <script>
 import DpCheckbox from '../form/DpCheckbox'
 import DpFlyout from '../DpFlyout'
-import { hasOwnProp } from 'demosplan-utils'
+import { hasOwnProp } from '@demos-europe/demosplan-utils'
 
 export default {
   name: 'DpColumnSelector',

--- a/components/core/DpDataTable/DpDataTable.vue
+++ b/components/core/DpDataTable/DpDataTable.vue
@@ -67,9 +67,9 @@
 </documentation>
 
 <script>
-import { CleanHtml } from 'demosplan-ui/directives'
+import { CleanHtml } from '../../../directives'
 import DomPurify from 'dompurify'
-import { DpLoading } from 'demosplan-ui/components'
+import { DpLoading } from '../../index'
 import DpTableHeader from './DpTableHeader'
 import DpTableRow from './DpTableRow'
 import draggable from 'vuedraggable'

--- a/components/core/DpDataTable/DpDataTableExtended.vue
+++ b/components/core/DpDataTable/DpDataTableExtended.vue
@@ -146,9 +146,9 @@ import DomPurify from 'dompurify'
 import DpDataTable from './DpDataTable'
 import DpSelectPageItemCount from './DpSelectPageItemCount'
 import DpStickyElement from '../shared/DpStickyElement'
-import { hasOwnProp } from 'demosplan-utils'
+import { hasOwnProp } from '@demos-europe/demosplan-utils'
 import SlidingPagination from 'vue-sliding-pagination'
-import { tableSelectAllItems } from 'demosplan-utils/mixins'
+import { tableSelectAllItems } from '@demos-europe/demosplan-utils/mixins'
 
 export default {
   name: 'DpDataTableExtended',

--- a/components/core/DpDataTable/DpTableHeader.vue
+++ b/components/core/DpDataTable/DpTableHeader.vue
@@ -8,9 +8,9 @@
 </license>
 
 <script>
-import { DpIcon } from 'demosplan-ui/components'
+import { DpIcon } from '../index'
 import DpWrapTrigger from './DpWrapTrigger'
-import { hasOwnProp } from 'demosplan-utils'
+import { hasOwnProp } from '@demos-europe/demosplan-utils'
 import { renderResizeWrapper } from './lib/ResizableColumns'
 
 export default {

--- a/components/core/DpDataTable/DpTableRow.vue
+++ b/components/core/DpDataTable/DpTableRow.vue
@@ -9,9 +9,9 @@
 
 <script>
 import DomPurify from 'dompurify'
-import { DpIcon } from 'demosplan-ui/components'
+import { DpIcon } from '../../index'
 import DpWrapTrigger from './DpWrapTrigger'
-import { hasOwnProp } from 'demosplan-utils'
+import { hasOwnProp } from '@demos-europe/demosplan-utils'
 
 export default {
   name: 'DpTableRow',

--- a/components/core/DpDataTable/DpWrapTrigger.vue
+++ b/components/core/DpDataTable/DpWrapTrigger.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script>
-import { DpIcon } from 'demosplan-ui/components'
+import { DpIcon } from '../index'
 
 export default {
   name: 'DpWrapTrigger',

--- a/components/core/DpEditor/DpBoilerPlate.vue
+++ b/components/core/DpEditor/DpBoilerPlate.vue
@@ -58,7 +58,7 @@
 </template>
 
 <script>
-import { CleanHtml } from 'demosplan-ui/directives'
+import { CleanHtml } from '../../../directives'
 import DpMultiselect from '../form/DpMultiselect'
 
 export default {

--- a/components/core/DpEditor/DpBoilerPlateModal.vue
+++ b/components/core/DpEditor/DpBoilerPlateModal.vue
@@ -54,7 +54,7 @@ import BoilerplatesStore from '@DpJs/store/procedure/Boilerplates'
 import DpBoilerPlate from './DpBoilerPlate'
 import DpButtonRow from '../DpButtonRow'
 import DpModal from '../DpModal'
-import { hasOwnProp } from 'demosplan-utils'
+import { hasOwnProp } from '@demos-europe/demosplan-utils'
 
 export default {
   name: 'DpBoilerPlateModal',

--- a/components/core/DpEditor/DpEditor.vue
+++ b/components/core/DpEditor/DpEditor.vue
@@ -402,9 +402,9 @@ import {
   EditorMenuBar // Renderless menubar
 } from 'tiptap'
 
-import { CleanHtml } from 'demosplan-ui/directives'
+import { CleanHtml } from '../../../directives'
 import { createSuggestion } from './libs/editorBuildSuggestion'
-import { DpIcon } from 'demosplan-ui/components'
+import { DpIcon } from '../../index'
 import EditorCustomDelete from './libs/editorCustomDelete'
 import EditorCustomImage from './libs/editorCustomImage'
 import EditorCustomInsert from './libs/editorCustomInsert'
@@ -413,8 +413,8 @@ import EditorCustomMark from './libs/editorCustomMark'
 import EditorInsertAtCursorPos from './libs/editorInsertAtCursorPos'
 import EditorObscure from './libs/editorObscure'
 import { handleWordPaste } from './libs/handleWordPaste'
-import { maxlengthHint } from 'demosplan-ui/utils/lengthHint'
-import { prefixClassMixin } from 'demosplan-ui/mixins'
+import { maxlengthHint } from '../../../utils/lengthHint'
+import { prefixClassMixin } from '@demos-europe/demosplan-utils/mixins'
 
 export default {
   name: 'DpEditor',

--- a/components/core/DpEditor/DpLinkModal.vue
+++ b/components/core/DpEditor/DpLinkModal.vue
@@ -57,9 +57,9 @@
 <script>
 import DpButtonRow from '../DpButtonRow'
 import DpCheckbox from '../form/DpCheckbox'
-import { DpInput } from 'demosplan-ui/components'
+import { DpInput } from '../index'
 import DpModal from '../DpModal'
-import { dpValidateMixin } from 'demosplan-utils/mixins'
+import { dpValidateMixin } from '@demos-europe/demosplan-utils/mixins'
 
 export default {
   name: 'DpLinkModal',

--- a/components/core/DpEditor/DpRecommendationModal.vue
+++ b/components/core/DpEditor/DpRecommendationModal.vue
@@ -69,10 +69,10 @@
 </template>
 
 <script>
-import { DpLabel, DpLoading } from 'demosplan-ui/components'
+import { DpLabel, DpLoading } from '../index'
 import { mapMutations, mapState } from 'vuex'
 import dataTableSearch from '../DpDataTable/DataTableSearch'
-import { dpApi } from 'demosplan-utils'
+import { dpApi } from '@demos-europe/demosplan-utils'
 import DpInsertableRecommendation from './DpRecommendationModal/DpInsertableRecommendation'
 import DpModal from '../DpModal'
 import DpSearchField from '../form/DpSearchField'

--- a/components/core/DpEditor/DpRecommendationModal/DpInsertableRecommendation.vue
+++ b/components/core/DpEditor/DpRecommendationModal/DpInsertableRecommendation.vue
@@ -49,7 +49,7 @@
 </template>
 
 <script>
-import { CleanHtml } from 'demosplan-ui/directives'
+import { CleanHtml } from '../../../../directives'
 
 // This number is used to shorten long texts.
 const SHORT_TEXT_CHAR_LENGTH = 300

--- a/components/core/DpEditor/DpUploadModal.vue
+++ b/components/core/DpEditor/DpUploadModal.vue
@@ -59,7 +59,7 @@
 </template>
 
 <script>
-import { DpInput } from 'demosplan-ui/components'
+import { DpInput } from '../index'
 import DpModal from '../DpModal'
 import DpUploadFiles from '../DpUpload/DpUploadFiles'
 

--- a/components/core/DpInlineNotification.vue
+++ b/components/core/DpInlineNotification.vue
@@ -42,7 +42,7 @@
 </template>
 
 <script>
-import { DpIcon } from 'demosplan-ui/components'
+import { DpIcon } from '../index'
 import lscache from 'lscache'
 
 export default {

--- a/components/core/DpModal.vue
+++ b/components/core/DpModal.vue
@@ -50,8 +50,8 @@
 </template>
 
 <script>
-import { DpIcon } from 'demosplan-ui/components'
-import { prefixClassMixin } from 'demosplan-ui/mixins'
+import { DpIcon } from '../index'
+import { prefixClassMixin } from '@demos-europe/demosplan-utils/mixins'
 
 export default {
   name: 'DpModal',

--- a/components/core/DpResettableInput.vue
+++ b/components/core/DpResettableInput.vue
@@ -46,7 +46,7 @@ To provide the interface for dpInput all configuration attributes for the input 
 </template>
 
 <script>
-import { DpIcon, DpInput } from 'demosplan-ui/components'
+import { DpIcon, DpInput } from '../index'
 
 export default {
   name: 'DpResettableInput',

--- a/components/core/DpSlidebar.vue
+++ b/components/core/DpSlidebar.vue
@@ -39,8 +39,8 @@
 </template>
 
 <script>
-import { hasOwnProp, SideNav } from 'demosplan-utils'
-import { DpIcon } from 'demosplan-ui/components'
+import { hasOwnProp, SideNav } from '@demos-europe/demosplan-utils'
+import { DpIcon } from '../index'
 
 export default {
   name: 'DpSlidebar',

--- a/components/core/DpSlidingPagination.vue
+++ b/components/core/DpSlidingPagination.vue
@@ -8,7 +8,7 @@
 </license>
 
 <script>
-import { prefixClass } from 'demosplan-ui/lib'
+import { prefixClass } from '../../lib'
 import SlidingPagination from 'vue-sliding-pagination'
 
 export default {

--- a/components/core/DpTabs/DpTabs.vue
+++ b/components/core/DpTabs/DpTabs.vue
@@ -42,7 +42,7 @@
 </template>
 
 <script>
-import { CleanHtml } from 'demosplan-ui/directives'
+import { CleanHtml } from '../../../directives'
 
 export default {
   name: 'DpTabs',

--- a/components/core/DpTextWrapper.vue
+++ b/components/core/DpTextWrapper.vue
@@ -8,7 +8,7 @@
 </license>
 
 <script>
-import { DpLoading } from 'demosplan-ui/components'
+import { DpLoading } from '../index'
 
 export default {
   name: 'DpTextWrapper',

--- a/components/core/DpToggleForm.vue
+++ b/components/core/DpToggleForm.vue
@@ -26,7 +26,7 @@
 
 <script>
 import DpAccordion from './DpAccordion'
-import { dpValidateMixin } from 'demosplan-utils/mixins'
+import { dpValidateMixin } from '@demos-europe/demosplan-utils/mixins'
 
 export default {
   name: 'DpToggleForm',

--- a/components/core/DpTreeList/DpTreeList.vue
+++ b/components/core/DpTreeList/DpTreeList.vue
@@ -90,7 +90,7 @@
 </template>
 
 <script>
-import { deepMerge, hasOwnProp, Stickier } from 'demosplan-utils'
+import { deepMerge, hasOwnProp, Stickier } from '@demos-europe/demosplan-utils'
 import DpTreeListCheckbox from './DpTreeListCheckbox'
 import DpTreeListNode from './DpTreeListNode'
 import DpTreeListToggle from './DpTreeListToggle'

--- a/components/core/DpTreeList/DpTreeListNode.vue
+++ b/components/core/DpTreeList/DpTreeListNode.vue
@@ -108,7 +108,7 @@
 
 <script>
 import { checkboxWidth, dragHandleWidth, levelIndentationWidth } from './utils/constants'
-import { DpIcon } from 'demosplan-ui/components'
+import { DpIcon } from '../index'
 import DpTreeListCheckbox from './DpTreeListCheckbox'
 import DpTreeListToggle from './DpTreeListToggle'
 import draggable from 'vuedraggable'

--- a/components/core/DpUpload/DpUpload.vue
+++ b/components/core/DpUpload/DpUpload.vue
@@ -12,10 +12,9 @@
 </template>
 
 <script>
+import { getFileTypes, hasOwnProp } from '@demos-europe/demosplan-utils'
 import { de } from './utils/UppyTranslations'
 import DragDrop from '@uppy/drag-drop'
-import { getFileTypes } from 'demosplan-utils/lib/FileInfo'
-import { hasOwnProp } from 'demosplan-utils'
 import ProgressBar from '@uppy/progress-bar'
 import Tus from '@uppy/tus'
 import Uppy from '@uppy/core'

--- a/components/core/DpUpload/DpUploadFiles.vue
+++ b/components/core/DpUpload/DpUploadFiles.vue
@@ -51,10 +51,10 @@
 </template>
 
 <script>
-import { DpLabel } from 'demosplan-ui/components'
+import { DpLabel } from '../index'
 import DpUpload from './DpUpload'
 import DpUploadedFileList from './DpUploadedFileList'
-import { prefixClassMixin } from 'demosplan-ui/mixins'
+import { prefixClassMixin } from '@demos-europe/demosplan-utils/mixins'
 
 export default {
   name: 'DpUploadFiles',

--- a/components/core/DpUpload/DpUploadedFile.vue
+++ b/components/core/DpUpload/DpUploadedFile.vue
@@ -40,8 +40,8 @@
 </template>
 
 <script>
-import { getFileInfo } from 'demosplan-utils/lib/FileInfo'
-import { prefixClassMixin } from 'demosplan-ui/mixins'
+import { getFileInfo } from '@demos-europe/demosplan-utils'
+import { prefixClassMixin } from '@demos-europe/demosplan-utils/mixins'
 
 export default {
   name: 'DpUploadedFile',

--- a/components/core/DpUpload/DpUploadedFileList.vue
+++ b/components/core/DpUpload/DpUploadedFileList.vue
@@ -24,7 +24,7 @@
 
 <script>
 import DpUploadedFile from './DpUploadedFile'
-import { prefixClassMixin } from 'demosplan-ui/mixins'
+import { prefixClassMixin } from '@demos-europe/demosplan-utils/mixins'
 
 export default {
   name: 'DpUploadedFileList',

--- a/components/core/DpUpload/utils/GetFileIdsByHash.js
+++ b/components/core/DpUpload/utils/GetFileIdsByHash.js
@@ -7,7 +7,7 @@
  * All rights reserved
  */
 
-import { dpApi } from 'demosplan-utils'
+import { dpApi } from '@demos-europe/demosplan-utils'
 
 /**
  * Fetch File-Ids by their hashes

--- a/components/core/DpUpload/utils/UppyTranslations.js
+++ b/components/core/DpUpload/utils/UppyTranslations.js
@@ -7,7 +7,7 @@
  * All rights reserved
  */
 
-import { convertSize } from 'demosplan-utils/lib/FileInfo'
+import { convertSize } from '@demos-europe/demosplan-utils'
 const de = () => {
   return {
     strings: {

--- a/components/core/MultistepNav.vue
+++ b/components/core/MultistepNav.vue
@@ -60,7 +60,7 @@
 </template>
 
 <script>
-import { prefixClassMixin } from 'demosplan-ui/mixins'
+import { prefixClassMixin } from '@demos-europe/demosplan-utils/mixins'
 
 export default {
   name: 'MultistepNav',

--- a/components/core/form/DpCheckbox.vue
+++ b/components/core/form/DpCheckbox.vue
@@ -37,8 +37,8 @@
 </template>
 
 <script>
-import { DpLabel } from 'demosplan-ui/components'
-import { prefixClassMixin } from 'demosplan-ui/mixins'
+import { DpLabel } from '../index'
+import { prefixClassMixin } from '@demos-europe/demosplan-utils/mixins'
 
 export default {
   name: 'DpCheckbox',

--- a/components/core/form/DpDateRangePicker.vue
+++ b/components/core/form/DpDateRangePicker.vue
@@ -39,7 +39,7 @@
 
 <script>
 import DpDatepicker from './DpDatepicker'
-import { formatDate } from 'demosplan-utils'
+import { formatDate } from '@demos-europe/demosplan-utils'
 
 export default {
   name: 'DpDateRangePicker',

--- a/components/core/form/DpDatetimePicker.vue
+++ b/components/core/form/DpDatetimePicker.vue
@@ -57,7 +57,7 @@ export default {
   components: {
     DpDatepicker,
     DpLabel: async () => {
-      const { DpLabel } = await import('demosplan-ui/components')
+      const { DpLabel } = await import('../index')
       return DpLabel
     },
     DpTimePicker

--- a/components/core/form/DpRadio.vue
+++ b/components/core/form/DpRadio.vue
@@ -29,8 +29,8 @@
 </template>
 
 <script>
-import { DpLabel } from 'demosplan-ui/components'
-import { prefixClassMixin } from 'demosplan-ui/mixins'
+import { DpLabel } from '../index'
+import { prefixClassMixin } from '@demos-europe/demosplan-utils/mixins'
 
 export default {
   name: 'DpRadio',

--- a/components/core/form/DpSearchField.vue
+++ b/components/core/form/DpSearchField.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script>
-import { DpButton } from 'demosplan-ui/components'
+import { DpButton } from '../index'
 import DpResettableInput from '../DpResettableInput'
 
 export default {

--- a/components/core/form/DpSelect.vue
+++ b/components/core/form/DpSelect.vue
@@ -44,8 +44,8 @@
 </template>
 
 <script>
-import { DpLabel } from 'demosplan-ui/components'
-import { prefixClassMixin } from 'demosplan-ui/mixins'
+import { DpLabel } from '../index'
+import { prefixClassMixin } from '@demos-europe/demosplan-utils/mixins'
 
 export default {
   name: 'DpSelect',

--- a/components/core/form/DpTextArea.vue
+++ b/components/core/form/DpTextArea.vue
@@ -28,15 +28,15 @@
 </template>
 
 <script>
-import { attributes, length } from 'demosplan-ui/shared/props'
-import { maxlengthHint } from 'demosplan-ui/utils/lengthHint'
+import { attributes, length } from '../../../shared/props'
+import { maxlengthHint } from '../../../utils/lengthHint'
 
 export default {
   name: 'DpTextArea',
 
   components: {
     DpLabel: async () => {
-      const { DpLabel } = await import('demosplan-ui/components')
+      const { DpLabel } = await import('../index')
       return DpLabel
     }
   },

--- a/components/core/form/DpTimePicker.vue
+++ b/components/core/form/DpTimePicker.vue
@@ -96,11 +96,11 @@ export default {
 
   components: {
     DpInput: async () => {
-      const { DpInput } = await import('demosplan-ui/components')
+      const { DpInput } = await import('../index')
       return DpInput
     },
     DpLabel: async () => {
-      const { DpLabel } = await import('demosplan-ui/components')
+      const { DpLabel } = await import('../index')
       return DpLabel
     },
     DpResettableInput: () => import('../DpResettableInput')

--- a/components/core/notify/DpNotifyContainer.vue
+++ b/components/core/notify/DpNotifyContainer.vue
@@ -26,8 +26,8 @@
 <script>
 import { mapMutations, mapState } from 'vuex'
 import DpNotifyMessage from './DpNotifyMessage'
-import { hasOwnProp } from 'demosplan-utils'
-import { prefixClassMixin } from 'demosplan-ui/mixins'
+import { hasOwnProp } from '@demos-europe/demosplan-utils'
+import { prefixClassMixin } from '@demos-europe/demosplan-utils/mixins'
 
 export default {
   name: 'DpNotifyContainer',

--- a/components/core/notify/DpNotifyMessage.vue
+++ b/components/core/notify/DpNotifyMessage.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script>
-import { prefixClassMixin } from 'demosplan-ui/mixins'
+import { prefixClassMixin } from '@demos-europe/demosplan-utils/mixins'
 
 export default {
   name: 'DpNotifyMessage',

--- a/components/core/shared/DpStickyElement.vue
+++ b/components/core/shared/DpStickyElement.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script>
-import { Stickier } from 'demosplan-utils'
+import { Stickier } from '@demos-europe/demosplan-utils'
 
 export default {
   name: 'DpStickyElement',

--- a/directives/CleanHtml/CleanHtml.stories.mdx
+++ b/directives/CleanHtml/CleanHtml.stories.mdx
@@ -27,7 +27,7 @@ Malicious code is filtered out, according to the DOMPurify [default behavior](ht
     <span v-cleanhtml="someValue">
   </div>
 </template>
-import { CleanHtml } from 'demosplan-ui/directives'
+import { CleanHtml } from '@demos-europe/demosplan-ui/directives'
 
 export default {
   name: 'MyComponent',
@@ -50,7 +50,7 @@ Malicious code is filtered out, and only p and span tags are allowed.
     <span v-cleanhtml="{ content: someValue, options: { ALLOWED_TAGS: ['p', 'span'] }">
   </div>
 </template>
-import { CleanHtml } from 'demosplan-ui/directives'
+import { CleanHtml } from '@demos-europe/demosplan-ui/directives'
 
 export default {
   name: 'MyComponent',

--- a/directives/CleanHtml/CleanHtml.stories.mdx
+++ b/directives/CleanHtml/CleanHtml.stories.mdx
@@ -27,7 +27,7 @@ Malicious code is filtered out, according to the DOMPurify [default behavior](ht
     <span v-cleanhtml="someValue">
   </div>
 </template>
-import { CleanHtml } from '@demos-europe/demosplan-ui/directives'
+import { CleanHtml } from './CleanHtml'
 
 export default {
   name: 'MyComponent',
@@ -50,7 +50,7 @@ Malicious code is filtered out, and only p and span tags are allowed.
     <span v-cleanhtml="{ content: someValue, options: { ALLOWED_TAGS: ['p', 'span'] }">
   </div>
 </template>
-import { CleanHtml } from '@demos-europe/demosplan-ui/directives'
+import { CleanHtml } from './CleanHtml'
 
 export default {
   name: 'MyComponent',

--- a/directives/Tooltip/Tooltip.stories.mdx
+++ b/directives/Tooltip/Tooltip.stories.mdx
@@ -26,7 +26,7 @@ This directive adds a tooltip to the element it is used on.
   </div>
 </template>
 <script>
-import { Tooltip } from 'demosplan-ui/directives'
+import { Tooltip } from '@demos-europe/demosplan-ui/directives'
 
 export default {
   name: 'MyComponent',

--- a/directives/Tooltip/Tooltip.stories.mdx
+++ b/directives/Tooltip/Tooltip.stories.mdx
@@ -26,7 +26,7 @@ This directive adds a tooltip to the element it is used on.
   </div>
 </template>
 <script>
-import { Tooltip } from '@demos-europe/demosplan-ui/directives'
+import { Tooltip } from './Tooltip'
 
 export default {
   name: 'MyComponent',

--- a/lib/prefixClass.js
+++ b/lib/prefixClass.js
@@ -13,6 +13,8 @@
  * @param {String}  classList or querySelector
  *
  * @return {String} prefixed classList
+ *
+ * @deprecated USe prefixClass from demosplan-utils instead
  */
 export default function prefixClass (classList = '') {
   let prefix = ''

--- a/mixins/prefixClassMixin.js
+++ b/mixins/prefixClassMixin.js
@@ -10,6 +10,7 @@
 /**
  * This mixin can be to provide the prefixClass method and a prop to control when to prefix and when not.
  *
+ * @deprecated USe prefixClassMixin from demosplan-utils instead
  */
 import prefixClass from '../lib/prefixClass'
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "description": "Vue components, Vue directives, Design Token and Scss files to build interfaces for demosPlan.",
   "dependencies": {
     "@braintree/sanitize-url": "^6.0.1",
-    "@demos-europe/demosplan-ui": "^0.0.2",
     "@demos-europe/demosplan-utils": "^0.0.2",
     "@uppy/core": "^3.0.1",
     "@uppy/drag-drop": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@demos-europe/demosplan-ui",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "MIT",
   "private": false,
   "description": "Vue components, Vue directives, Design Token and Scss files to build interfaces for demosPlan.",
   "dependencies": {
     "@braintree/sanitize-url": "^6.0.1",
-    "@demos-europe/demosplan-utils": "0.0.1",
+    "@demos-europe/demosplan-ui": "^0.0.2",
+    "@demos-europe/demosplan-utils": "^0.0.2",
     "@uppy/core": "^3.0.1",
     "@uppy/drag-drop": "^3.0.0",
     "@uppy/progress-bar": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "description": "Vue components, Vue directives, Design Token and Scss files to build interfaces for demosPlan.",
   "dependencies": {
     "@braintree/sanitize-url": "^6.0.1",
+    "@demos-europe/demosplan-utils": "0.0.1",
     "@uppy/core": "^3.0.1",
     "@uppy/drag-drop": "^3.0.0",
     "@uppy/progress-bar": "^3.0.0",

--- a/shared/props.js
+++ b/shared/props.js
@@ -20,7 +20,7 @@
  *      // ...define prop
  *    }
  *    // In the component...
- *    import { myProp } from 'demosplan-ui/shared/props'
+ *    import { myProp } from '@demos-europe/demosplan-ui/shared/props'
  *    props: {
  *      myProp: myProp('otherValue'),
  *    }


### PR DESCRIPTION
Just clean up all the path declarations. Something got wrong during the move.

moved prefixClass and prefixClassMixin from 'demosplan-ui` to `demosplan-utils` to avoid a cross referencing (in demosplan-ui its now marked as deprecated, but not removed)


**Ticket** https://yaits.demos-deutschland.de/T30074