### PR TITLE
fix: Make posthook Work without publishing the Package

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,7 @@
     "vue-multiselect": "^2.1.6",
     "vue-omnibox": "^0.3.7",
     "vue-sliding-pagination": "^1.3.2",
-    "vuedraggable": "^2.24.3"
-  },
-  "devDependencies": {
+    "vuedraggable": "^2.24.3",
     "@babel/core": "^7.20.2",
     "@babel/preset-env": "^7.20.2",
     "@storybook/addon-actions": "6.5.13",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "build-tokens": "node buildTokens.js",
     "postinstall": "yarn build && yarn build-tokens",
     "storybook": "start-storybook -p 6006",
-    "build": "@build:prod",
+    "build": "build:prod",
     "build:dev": "webpack --mode=development",
     "build:prod": "webpack --mode=production --define-process-env-node-env=production",
     "watch": "webpack --watch"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "build-tokens": "node buildTokens.js",
     "postinstall": "yarn build && yarn build-tokens",
     "storybook": "start-storybook -p 6006",
-    "build": "build:prod",
+    "build": "yarn build:prod",
     "build:dev": "webpack --mode=development",
     "build:prod": "webpack --mode=production --define-process-env-node-env=production",
     "watch": "webpack --watch"

--- a/package.json
+++ b/package.json
@@ -62,9 +62,9 @@
     "build-css": "tailwindcss -i ./style/index.css -o ./style/style.css",
     "build-storybook": "build-storybook",
     "build-tokens": "node buildTokens.js",
-    "postcompress": "yarn build && yarn build-tokens",
+    "postinstall": "yarn build && yarn build-tokens",
     "storybook": "start-storybook -p 6006",
-    "build": "webpack --mode=production --define-process-env-node-env=production",
+    "build": "@build:prod",
     "build:dev": "webpack --mode=development",
     "build:prod": "webpack --mode=production --define-process-env-node-env=production",
     "watch": "webpack --watch"


### PR DESCRIPTION
though we need a working Dev, we can't wait to publish all the time. Therefore we need something that works on install.