### PR TITLE
chore (refs T30597): Add missing E2E attr for DpCheckbox.

### DIFF
--- a/src/components/core/form/DpCheckbox.vue
+++ b/src/components/core/form/DpCheckbox.vue
@@ -11,6 +11,7 @@
       autocomplete="off"
       :checked="checked"
       :value="valueToSend"
+      :data-cy="dataCy !== '' ? dataCy : false"
       @change="$emit('change', $event.target.checked)"
       true-value="1"
       false-value="0">
@@ -50,6 +51,12 @@ export default {
       type: Boolean,
       required: false,
       default: false
+    },
+
+    dataCy: {
+      type: String,
+      required: false,
+      default: ''
     },
 
     disabled: {


### PR DESCRIPTION
- Add missing E2E attr for DpCheckbox.

If you want for DpCheckbox `data-cy` attr add then this attr added for div container not for input field