### PR TITLE
fix: Make async Components work again.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "./dist/demosplan-ui.umd.js",
   "dependencies": {
     "@braintree/sanitize-url": "^6.0.1",
-    "@demos-europe/demosplan-utils": "github:demos-europe/demosplan-js-utils#69b455e6e2818169aa3c2dfa83f97cc4537e4477",
+    "@demos-europe/demosplan-utils": "github:demos-europe/demosplan-js-utils#93b3875b81fbfd367d6ca68cb710d50eb2d3ca2a",
     "@uppy/core": "^3.0.1",
     "@uppy/drag-drop": "^3.0.0",
     "@uppy/progress-bar": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "vue-omnibox": "^0.3.7",
     "vue-sliding-pagination": "^1.3.2",
     "vuedraggable": "^2.24.3",
+    "vuex": "^3.6.2",
     "@babel/core": "^7.20.2",
     "@babel/preset-env": "^7.20.2",
     "@storybook/addon-actions": "6.5.13",
@@ -52,9 +53,14 @@
     "style-loader": "^3.3.1",
     "vue-loader": "^15",
     "vue-template-compiler": "^2.7.14",
-    "vuex": "^3.6.2",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.0"
+  },
+  "peerDependencies": {
+    "tiptap": "^1.32.2",
+    "tiptap-commands": "^1.17.0",
+    "tiptap-extensions": "^1.35.2",
+    "vue": "^2.7.14"
   },
   "scripts": {
     "build-css": "tailwindcss -i ./style/index.css -o ./style/style.css",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "./dist/demosplan-ui.umd.js",
   "dependencies": {
     "@braintree/sanitize-url": "^6.0.1",
-    "@demos-europe/demosplan-utils": "github:demos-europe/demosplan-js-utils#57b112bdfe54a0f0f870d7f46148fd9197d0e371",
+    "@demos-europe/demosplan-utils": "github:demos-europe/demosplan-js-utils#86b11570ce9287cd62457c8071cf959b1674a8bf",
     "@uppy/core": "^3.0.1",
     "@uppy/drag-drop": "^3.0.0",
     "@uppy/progress-bar": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "./dist/demosplan-ui.umd.js",
   "dependencies": {
     "@braintree/sanitize-url": "^6.0.1",
-    "@demos-europe/demosplan-utils": "github:demos-europe/demosplan-js-utils#93b3875b81fbfd367d6ca68cb710d50eb2d3ca2a",
+    "@demos-europe/demosplan-utils": "github:demos-europe/demosplan-js-utils#57b112bdfe54a0f0f870d7f46148fd9197d0e371",
     "@uppy/core": "^3.0.1",
     "@uppy/drag-drop": "^3.0.0",
     "@uppy/progress-bar": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "./dist/demosplan-ui.umd.js",
   "dependencies": {
     "@braintree/sanitize-url": "^6.0.1",
-    "@demos-europe/demosplan-utils": "github:demos-europe/demosplan-js-utils#main",
+    "@demos-europe/demosplan-utils": "github:demos-europe/demosplan-js-utils#69b455e6e2818169aa3c2dfa83f97cc4537e4477",
     "@uppy/core": "^3.0.1",
     "@uppy/drag-drop": "^3.0.0",
     "@uppy/progress-bar": "^3.0.0",

--- a/src/components/DpLabel/DpLabel.vue
+++ b/src/components/DpLabel/DpLabel.vue
@@ -32,7 +32,7 @@ export default {
 
   directives: {
     cleanhtml: CleanHtml,
-    tootip: Tooltip
+    tooltip: Tooltip
   },
 
   mixins: [prefixClassMixin],

--- a/src/components/DpLabel/DpLabel.vue
+++ b/src/components/DpLabel/DpLabel.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script>
-import { CleanHtml } from '../../directives/CleanHtml/CleanHtml'
+import { CleanHtml, Tooltip } from '../../directives'
 import { de } from '../shared/translations'
 import { prefixClassMixin } from '@demos-europe/demosplan-utils'
 
@@ -31,7 +31,8 @@ export default {
   name: 'DpLabel',
 
   directives: {
-    cleanhtml: CleanHtml
+    cleanhtml: CleanHtml,
+    tootip: Tooltip
   },
 
   mixins: [prefixClassMixin],

--- a/src/components/core/DpButtonIcon.vue
+++ b/src/components/core/DpButtonIcon.vue
@@ -14,6 +14,8 @@
 </template>
 
 <script>
+import Tooltip from './../../directives/Tooltip/Tooltip'
+
 export default {
   name: 'DpButtonIcon',
 
@@ -27,6 +29,10 @@ export default {
       type: String,
       required: true
     }
+  },
+
+  directives: {
+    tootip: Tooltip
   },
 
   computed: {

--- a/src/components/core/DpButtonIcon.vue
+++ b/src/components/core/DpButtonIcon.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script>
-import { Tooltip } from './../../directives'
+import { Tooltip } from '../../directives'
 
 export default {
   name: 'DpButtonIcon',

--- a/src/components/core/DpButtonIcon.vue
+++ b/src/components/core/DpButtonIcon.vue
@@ -32,7 +32,7 @@ export default {
   },
 
   directives: {
-    tootip: Tooltip
+    tooltip: Tooltip
   },
 
   computed: {

--- a/src/components/core/DpButtonIcon.vue
+++ b/src/components/core/DpButtonIcon.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script>
-import Tooltip from './../../directives/Tooltip/Tooltip'
+import { Tooltip } from './../../directives'
 
 export default {
   name: 'DpButtonIcon',

--- a/src/components/core/DpCheckboxGroup.vue
+++ b/src/components/core/DpCheckboxGroup.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script>
-import { CleanHtml } from '../../directives/'
+import { CleanHtml } from '../../directives'
 import DpCheckbox from './form/DpCheckbox'
 
 export default {

--- a/src/components/core/DpContextualHelp.vue
+++ b/src/components/core/DpContextualHelp.vue
@@ -1,5 +1,5 @@
 <script>
-import { Tooltip } from './../../directives'
+import { Tooltip } from '../../directives'
 
 export default {
   name: 'DpContextualHelp',

--- a/src/components/core/DpContextualHelp.vue
+++ b/src/components/core/DpContextualHelp.vue
@@ -1,4 +1,6 @@
 <script>
+import Tooltip from './../../directives/Tooltip/Tooltip'
+
 export default {
   name: 'DpContextualHelp',
 
@@ -13,6 +15,10 @@ export default {
       type: String,
       required: true
     }
+  },
+
+  directives: {
+    tootip: Tooltip
   },
 
   render: function (h, { props, data }) {

--- a/src/components/core/DpContextualHelp.vue
+++ b/src/components/core/DpContextualHelp.vue
@@ -1,5 +1,5 @@
 <script>
-import Tooltip from './../../directives/Tooltip/Tooltip'
+import { Tooltip } from './../../directives'
 
 export default {
   name: 'DpContextualHelp',

--- a/src/components/core/DpContextualHelp.vue
+++ b/src/components/core/DpContextualHelp.vue
@@ -18,7 +18,7 @@ export default {
   },
 
   directives: {
-    tootip: Tooltip
+    tooltip: Tooltip
   },
 
   render: function (h, { props, data }) {

--- a/src/components/core/DpEditor/DpBoilerPlate.vue
+++ b/src/components/core/DpEditor/DpBoilerPlate.vue
@@ -45,6 +45,7 @@
 <script>
 import { CleanHtml } from '../../../directives/CleanHtml/CleanHtml'
 import DpMultiselect from '../form/DpMultiselect'
+import { Tooltip } from '../../../directives'
 
 export default {
   name: 'DpBoilerPlate',
@@ -53,7 +54,8 @@ export default {
   },
 
   directives: {
-    cleanhtml: CleanHtml
+    cleanhtml: CleanHtml,
+    tootip: Tooltip
   },
 
   props: {

--- a/src/components/core/DpEditor/DpBoilerPlate.vue
+++ b/src/components/core/DpEditor/DpBoilerPlate.vue
@@ -54,7 +54,7 @@ export default {
 
   directives: {
     cleanhtml: CleanHtml,
-    tootip: Tooltip
+    tooltip: Tooltip
   },
 
   props: {

--- a/src/components/core/DpEditor/DpBoilerPlate.vue
+++ b/src/components/core/DpEditor/DpBoilerPlate.vue
@@ -43,9 +43,8 @@
 </template>
 
 <script>
-import { CleanHtml } from '../../../directives/CleanHtml/CleanHtml'
+import { CleanHtml, Tooltip } from '../../../directives'
 import DpMultiselect from '../form/DpMultiselect'
-import { Tooltip } from '../../../directives'
 
 export default {
   name: 'DpBoilerPlate',

--- a/src/components/core/DpEditor/DpEditor.vue
+++ b/src/components/core/DpEditor/DpEditor.vue
@@ -357,14 +357,12 @@ import {
   TableRow,
   Underline
 } from 'tiptap-extensions'
-
+import { CleanHtml, Tooltip } from '../../../directives/'
 import {
   Editor, // Wrapper for prosemirror state
   EditorContent, // Renderless content element
   EditorMenuBar // Renderless menubar
 } from 'tiptap'
-
-import { CleanHtml } from '../../../directives/'
 import { createSuggestion } from './libs/editorBuildSuggestion'
 import DpIcon from '../../DpIcon/DpIcon'
 import EditorCustomDelete from './libs/editorCustomDelete'

--- a/src/components/core/DpEditor/DpEditor.vue
+++ b/src/components/core/DpEditor/DpEditor.vue
@@ -357,7 +357,7 @@ import {
   TableRow,
   Underline
 } from 'tiptap-extensions'
-import { CleanHtml, Tooltip } from '../../../directives/'
+import { CleanHtml, Tooltip } from '../../../directives'
 import {
   Editor, // Wrapper for prosemirror state
   EditorContent, // Renderless content element
@@ -390,7 +390,8 @@ export default {
   },
 
   directives: {
-    cleanhtml: CleanHtml
+    cleanhtml: CleanHtml,
+    tootip: Tooltip
   },
 
   mixins: [prefixClassMixin],

--- a/src/components/core/DpEditor/DpEditor.vue
+++ b/src/components/core/DpEditor/DpEditor.vue
@@ -391,7 +391,7 @@ export default {
 
   directives: {
     cleanhtml: CleanHtml,
-    tootip: Tooltip
+    tooltip: Tooltip
   },
 
   mixins: [prefixClassMixin],

--- a/src/components/core/DpEditor/DpRecommendationModal/DpInsertableRecommendation.vue
+++ b/src/components/core/DpEditor/DpRecommendationModal/DpInsertableRecommendation.vue
@@ -40,7 +40,7 @@
 </template>
 
 <script>
-import { CleanHtml } from '../../../../directives/'
+import { CleanHtml, Tooltip } from '../../../../directives/'
 
 // This number is used to shorten long texts.
 const SHORT_TEXT_CHAR_LENGTH = 300
@@ -49,7 +49,8 @@ export default {
   name: 'DpInsertableRecommendation',
 
   directives: {
-    cleanhtml: CleanHtml
+    cleanhtml: CleanHtml,
+    tootip: Tooltip
   },
 
   props: {

--- a/src/components/core/DpEditor/DpRecommendationModal/DpInsertableRecommendation.vue
+++ b/src/components/core/DpEditor/DpRecommendationModal/DpInsertableRecommendation.vue
@@ -40,7 +40,7 @@
 </template>
 
 <script>
-import { CleanHtml, Tooltip } from '../../../../directives/'
+import { CleanHtml, Tooltip } from '../../../../directives'
 
 // This number is used to shorten long texts.
 const SHORT_TEXT_CHAR_LENGTH = 300

--- a/src/components/core/DpEditor/DpRecommendationModal/DpInsertableRecommendation.vue
+++ b/src/components/core/DpEditor/DpRecommendationModal/DpInsertableRecommendation.vue
@@ -50,7 +50,7 @@ export default {
 
   directives: {
     cleanhtml: CleanHtml,
-    tootip: Tooltip
+    tooltip: Tooltip
   },
 
   props: {

--- a/src/components/core/DpTabs/DpTabs.vue
+++ b/src/components/core/DpTabs/DpTabs.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script>
-import { CleanHtml } from '../../../directives/'
+import { CleanHtml } from '../../../directives'
 
 export default {
   name: 'DpTabs',

--- a/src/components/core/DpTooltipIcon.vue
+++ b/src/components/core/DpTooltipIcon.vue
@@ -6,6 +6,8 @@
 </template>
 
 <script>
+import Tooltip from './../../directives/Tooltip/Tooltip'
+
 export default {
   name: 'DpTooltipIcon',
 

--- a/src/components/core/DpTooltipIcon.vue
+++ b/src/components/core/DpTooltipIcon.vue
@@ -6,10 +6,14 @@
 </template>
 
 <script>
-import Tooltip from './../../directives/Tooltip/Tooltip'
+import { Tooltip } from '../../directives'
 
 export default {
   name: 'DpTooltipIcon',
+
+  directives: {
+    tooltip: Tooltip
+  },
 
   props: {
     icon: {

--- a/src/components/core/DpTreeList/DpTreeListNode.vue
+++ b/src/components/core/DpTreeList/DpTreeListNode.vue
@@ -103,7 +103,7 @@ import DpIcon from '../../DpIcon/DpIcon'
 import DpTreeListCheckbox from './DpTreeListCheckbox'
 import DpTreeListToggle from './DpTreeListToggle'
 import draggable from 'vuedraggable'
-import { Tooltip } from './../../../directives'
+import { Tooltip } from '../../../directives'
 
 export default {
   name: 'DpTreeListNode',

--- a/src/components/core/DpTreeList/DpTreeListNode.vue
+++ b/src/components/core/DpTreeList/DpTreeListNode.vue
@@ -103,7 +103,7 @@ import DpIcon from '../../DpIcon/DpIcon'
 import DpTreeListCheckbox from './DpTreeListCheckbox'
 import DpTreeListToggle from './DpTreeListToggle'
 import draggable from 'vuedraggable'
-import { Tooltip } from './../../directives'
+import { Tooltip } from './../../../directives'
 
 export default {
   name: 'DpTreeListNode',

--- a/src/components/core/DpTreeList/DpTreeListNode.vue
+++ b/src/components/core/DpTreeList/DpTreeListNode.vue
@@ -103,6 +103,7 @@ import DpIcon from '../../DpIcon/DpIcon'
 import DpTreeListCheckbox from './DpTreeListCheckbox'
 import DpTreeListToggle from './DpTreeListToggle'
 import draggable from 'vuedraggable'
+import { Tooltip } from './../../directives'
 
 export default {
   name: 'DpTreeListNode',
@@ -112,6 +113,10 @@ export default {
     DpTreeListCheckbox,
     DpTreeListToggle,
     draggable
+  },
+
+  directives: {
+    tootip: Tooltip
   },
 
   props: {

--- a/src/components/core/DpTreeList/DpTreeListNode.vue
+++ b/src/components/core/DpTreeList/DpTreeListNode.vue
@@ -116,7 +116,7 @@ export default {
   },
 
   directives: {
-    tootip: Tooltip
+    tooltip: Tooltip
   },
 
   props: {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
-import { attributes, length } from './shared/'
-import { exactlengthHint, maxlengthHint, minlengthHint } from './utils/'
-import { Tooltip, VPopover } from './directives/'
-import { CleanHtml } from './directives/'
+import { attributes, length } from './shared'
+import { exactlengthHint, maxlengthHint, minlengthHint } from './utils'
+import { Tooltip, VPopover } from './directives'
+import { CleanHtml } from './directives'
 
 import {
   DpButton,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,13 +12,6 @@ function resolve (dir) {
 
 const config = {
   entry: resolve('./src/index.js'),
-  output: {
-    path: path.resolve(__dirname, "dist"),
-    filename: 'demosplan-ui.umd.js',
-    library: '@demos-europe/demosplan-ui',
-    libraryTarget: 'umd',
-    libraryExport: 'default'
-  },
   resolve: {
     extensions: ['.js', '.vue'],
     symlinks: false
@@ -54,11 +47,39 @@ const config = {
   },
 };
 
+const esmConfig = {
+  ...config,
+  output: {
+    path: path.resolve(__dirname, "dist"),
+    filename: 'demosplan-ui.esm.js',
+    library: '@demos-europe/demosplan-ui',
+    libraryExport: 'default'
+  },
+}
+
+const umdConfig = {
+  ...config,
+  experiments: {
+    outputModule: true,
+  },
+  output: {
+    path: path.resolve(__dirname, "dist"),
+    filename: 'demosplan-ui.umd.js',
+    library: {
+      type: 'module',
+      export: 'default',
+      umdNamedDefine: true,
+    }
+  },
+}
+
 module.exports = () => {
   if (isProduction) {
-    config.mode = 'production';
+    umdConfig.mode = 'production';
+    esmConfig.mode = 'production';
   } else {
-    config.mode = 'development';
+    umdConfig.mode = 'development';
+    esmConfig.mode = 'development';
   }
-  return config;
+  return [umdConfig];
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,18 @@ const config = {
     new MiniCssExtractPlugin(),
     new VueLoaderPlugin(),
   ],
+  experiments: {
+    outputModule: true,
+  },
+  output: {
+    path: path.resolve(__dirname, "dist"),
+    filename: 'demosplan-ui.umd.js',
+    library: {
+      type: 'module',
+      export: 'default',
+      umdNamedDefine: true,
+    }
+  },
   module: {
     rules: [
       {
@@ -47,39 +59,12 @@ const config = {
   },
 };
 
-const esmConfig = {
-  ...config,
-  output: {
-    path: path.resolve(__dirname, "dist"),
-    filename: 'demosplan-ui.esm.js',
-    library: '@demos-europe/demosplan-ui',
-    libraryExport: 'default'
-  },
-}
-
-const umdConfig = {
-  ...config,
-  experiments: {
-    outputModule: true,
-  },
-  output: {
-    path: path.resolve(__dirname, "dist"),
-    filename: 'demosplan-ui.umd.js',
-    library: {
-      type: 'module',
-      export: 'default',
-      umdNamedDefine: true,
-    }
-  },
-}
-
 module.exports = () => {
   if (isProduction) {
-    umdConfig.mode = 'production';
-    esmConfig.mode = 'production';
+    config.mode = 'production';
   } else {
-    umdConfig.mode = 'development';
-    esmConfig.mode = 'development';
+    config.mode = 'development';
   }
-  return [umdConfig];
+
+  return config;
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,17 +12,12 @@ function resolve (dir) {
 
 const config = {
   entry: resolve('./src/index.js'),
-  experiments: {
-    outputModule: true,
-  },
   output: {
     path: path.resolve(__dirname, "dist"),
     filename: 'demosplan-ui.umd.js',
-    library: {
-      type: 'module',
-      export: 'default',
-      umdNamedDefine: true,
-    }
+    library: '@demos-europe/demosplan-ui',
+    libraryTarget: 'umd',
+    libraryExport: "default"
   },
   resolve: {
     extensions: ['.js', '.vue'],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,14 +12,6 @@ function resolve (dir) {
 
 const config = {
   entry: resolve('./src/index.js'),
-  resolve: {
-    extensions: ['.js', '.vue'],
-    symlinks: false
-  },
-  plugins: [
-    new MiniCssExtractPlugin(),
-    new VueLoaderPlugin(),
-  ],
   experiments: {
     outputModule: true,
   },
@@ -32,6 +24,14 @@ const config = {
       umdNamedDefine: true,
     }
   },
+  resolve: {
+    extensions: ['.js', '.vue'],
+    symlinks: false
+  },
+  plugins: [
+    new MiniCssExtractPlugin(),
+    new VueLoaderPlugin(),
+  ],
   module: {
     rules: [
       {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,8 @@
-const path = require("path");
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
-const { VueLoaderPlugin } = require("vue-loader");
+const path = require('path');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const { VueLoaderPlugin } = require('vue-loader');
 
-const isProduction = process.env.NODE_ENV == "production";
+const isProduction = process.env.NODE_ENV == 'production';
 
 const stylesHandler = MiniCssExtractPlugin.loader;
 
@@ -13,11 +13,11 @@ function resolve (dir) {
 const config = {
   entry: resolve('./src/index.js'),
   output: {
-    path: path.resolve(__dirname, "dist"),
+    path: path.resolve(__dirname, 'dist'),
     filename: 'demosplan-ui.umd.js',
     library: '@demos-europe/demosplan-ui',
     libraryTarget: 'umd',
-    libraryExport: "default"
+    libraryExport: 'default'
   },
   resolve: {
     extensions: ['.js', '.vue'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1120,9 +1120,9 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@demos-europe/demosplan-utils@github:demos-europe/demosplan-js-utils#main":
+"@demos-europe/demosplan-utils@github:demos-europe/demosplan-js-utils#86b11570ce9287cd62457c8071cf959b1674a8bf":
   version "0.0.3"
-  resolved "https://codeload.github.com/demos-europe/demosplan-js-utils/tar.gz/4c47b6106b2f69e12298963dd7af44ca7c7d75cd"
+  resolved "https://codeload.github.com/demos-europe/demosplan-js-utils/tar.gz/86b11570ce9287cd62457c8071cf959b1674a8bf"
   dependencies:
     axios "^0.27.2"
     fscreen "^1.2.0"
@@ -9664,9 +9664,9 @@ prosemirror-collab@^1.2.2:
     prosemirror-state "^1.0.0"
 
 prosemirror-commands@^1.1.4:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/prosemirror-commands/-/prosemirror-commands-1.3.1.tgz#926c88801eebaa50363d4658850b41406d375a31"
-  integrity sha512-XTporPgoECkOQACVw0JTe3RZGi+fls3/byqt+tXwGTkD7qLuB4KdVrJamDMJf4kfKga3uB8hZ+kUUyZ5oWpnfg==
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/prosemirror-commands/-/prosemirror-commands-1.5.0.tgz#d10efece1647c1d984fef6f65d52fdc77785560b"
+  integrity sha512-zL0Fxbj3fh71GPNHn5YdYgYGX2aU2XLecZYk2ekEF0oOD259HcXtM+96VjPVi5o3h4sGUdDfEEhGiREXW6U+4A==
   dependencies:
     prosemirror-model "^1.0.0"
     prosemirror-state "^1.0.0"
@@ -9742,9 +9742,9 @@ prosemirror-state@^1.0.0, prosemirror-state@^1.2.2, prosemirror-state@^1.3.1, pr
     prosemirror-view "^1.27.0"
 
 prosemirror-tables@^1.1.1:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/prosemirror-tables/-/prosemirror-tables-1.2.5.tgz#f140d4491acad4f8d9ebbdede65c933fe13f3c51"
-  integrity sha512-UB5XkWQC7YHJ2qubriOnKGxdVe+KujmoSatFyBlV8odVT/G++61XB1JXiU3ZAKJ60lTdq9WsowUhINSFeE7BoA==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/prosemirror-tables/-/prosemirror-tables-1.3.0.tgz#262fa7d030f7bebef7b5fd9a045bce9a786c198c"
+  integrity sha512-ujzOb37O2ahmqI626Y0N0V/SZxuA9OGNYnsIMWdfecwkc8S8OShOqeD4kKUxpD0JcP81Z8qy/ulrXQuKhS4WUg==
   dependencies:
     prosemirror-keymap "^1.1.2"
     prosemirror-model "^1.8.1"


### PR DESCRIPTION
We had to make `tiptap` a peerDependency, so `prosemirror` ca be resolved properly in `demosplan-core`

Declaring the Directives within shouldn't part of this PR, but When I try to make a new one, without these Changes , it looks like it doesn't work anymore.

Related in dplan-core: https://github.com/demos-europe/demosplan-core/pull/387