### PR TITLE
Allow target blank in v-cleanhtml

### DIFF
--- a/src/directives/CleanHtml/CleanHtml.js
+++ b/src/directives/CleanHtml/CleanHtml.js
@@ -9,7 +9,8 @@ import DOMPurify from 'dompurify'
  * @see https://developer.chrome.com/docs/lighthouse/best-practices/external-anchors-use-rel-noopener/
  */
 DOMPurify.addHook('afterSanitizeAttributes', function (node) {
-  if (!'target' in node) {
+  const nodeHasTarget = 'target' in node
+  if (!nodeHasTarget) {
     return
   }
   const target = node.getAttribute('target')

--- a/src/directives/CleanHtml/CleanHtml.js
+++ b/src/directives/CleanHtml/CleanHtml.js
@@ -1,6 +1,24 @@
 import DOMPurify from 'dompurify'
 
 /**
+ * As we allow the target attr, we have to make sure that the link is safe.
+ * Chromium seems to add `rel="noopener"` automatically as of v88, however
+ * to also ensure correct behavior for other engines, the `rel` attr is added
+ * whenever a target is set to "_blank".
+ *
+ * @see https://developer.chrome.com/docs/lighthouse/best-practices/external-anchors-use-rel-noopener/
+ */
+DOMPurify.addHook('afterSanitizeAttributes', function (node) {
+  if (!'target' in node) {
+    return
+  }
+  const target = node.getAttribute('target')
+  if (target === '_blank') {
+    node.setAttribute('rel', 'noopener')
+  }
+})
+
+/**
  * Checks the type of value and always returns an object to be used with setInnerHTML.
  * If a string is passed, its value is used as content.
  * @param value {Object<content, options>|String}
@@ -24,7 +42,8 @@ const getOptions = (value) => {
  */
 const setSanitizedInnerHTML = (el, binding) => {
   const { content, options = {} } = getOptions(binding.value)
-  el.innerHTML = DOMPurify.sanitize(content, options)
+  const _options = {...options, ...{ ADD_ATTR: ['target'] } }
+  el.innerHTML = DOMPurify.sanitize(content, _options)
 }
 
 const CleanHtml = {

--- a/src/directives/CleanHtml/CleanHtml.js
+++ b/src/directives/CleanHtml/CleanHtml.js
@@ -9,8 +9,7 @@ import DOMPurify from 'dompurify'
  * @see https://developer.chrome.com/docs/lighthouse/best-practices/external-anchors-use-rel-noopener/
  */
 DOMPurify.addHook('afterSanitizeAttributes', function (node) {
-  const nodeHasTarget = 'target' in node
-  if (!nodeHasTarget) {
+  if (!('target' in node)) {
     return
   }
   const target = node.getAttribute('target')


### PR DESCRIPTION
As we allow the target attr, we have to make sure that the link is safe. Chromium seems to add `rel="noopener"` automatically as of v88, however to also ensure correct behavior for other engines, the `rel` attr is added whenever a target is set to "_blank".

See
- https://github.com/cure53/DOMPurify/issues/317
- https://developer.chrome.com/docs/lighthouse/best-practices/external-anchors-use-rel-noopener/