### PR TITLE
refactor(refs T29004): pass label props as object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED
 
+- **Breaking:** Refactor DpRadio props: bundle label related props in a single object
 - Fix DpEditor "TypeError: Class constructor cannot be invoked without 'new'"
 
 ## v0.0.5 - 2023-01-05

--- a/src/components/core/form/DpRadio.vue
+++ b/src/components/core/form/DpRadio.vue
@@ -14,8 +14,15 @@
       :data-cy="dataCy !== '' ? dataCy : false"
       @change="$emit('change', $event.target.checked)"><!--
  --><dp-label
+      v-if="label.text"
       :class="prefixClass('o-form__label')"
-      v-bind="labelProps" />
+      v-bind="{
+        bold: false,
+        text: '',
+        for: id,
+        required: required,
+        ...label,
+      }" />
   </div>
 </template>
 
@@ -74,9 +81,11 @@ export default {
     },
 
     label: {
-      type: String,
-      required: false,
-      default: ''
+      type: Object,
+      default: () => ({}),
+      validator: (prop) => {
+        return Object.keys(prop).every(key => ['bold', 'hint', 'text'].includes(key))
+      }
     },
 
     name: {
@@ -101,18 +110,6 @@ export default {
       type: String,
       required: false,
       default: '1'
-    }
-  },
-
-  computed: {
-    labelProps () {
-      return {
-        for: this.id,
-        hint: this.hint,
-        text: this.label,
-        required: this.required,
-        bold: this.bold
-      }
     }
   }
 }


### PR DESCRIPTION
As was implemented for other form components previously, the label props are now passed in a single object. That way it's easier to understand what they are used for.

**Breaking**: The `label` prop expects an `object` now (previously a `string`)