### PR TITLE
Transpile tiptap esm modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+- Fix DpEditor "TypeError: Class constructor cannot be invoked without 'new'"
+
 ## v0.0.5 - 2023-01-05
 
 - Move modules that are also present within demosplan to externals to reduce compiled filesize

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,12 @@ function resolve (dir) {
   return path.join(__dirname, dir)
 }
 
+const transpileNodeModules = [
+  'tiptap',
+  'tiptap-commands',
+  'tiptap-extensions',
+].map(module => resolve('node_modules/' + module))
+
 const config = {
   entry: resolve('./src/index.js'),
   output: {
@@ -59,6 +65,7 @@ const config = {
       {
         test: /\.(js|jsx)$/i,
         exclude: /node_modules/,
+        include: transpileNodeModules,
         loader: 'babel-loader'
       },
       {


### PR DESCRIPTION
Ticket: https://yaits.demos-deutschland.de/T30430

To not run into conflicts between es6 and es5, the tiptap modules (that export esm bundles) must be included for babel-loader. This was already the case in the demosplan-core build but got overseen when moving DpEditor into demosplan-ui.

See https://stackoverflow.com/a/51860850/6234391