### PR TITLE
docs(refs T30969): add checkbox documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## UNRELEASED
 
 - docs: add documentation for DpCheckbox
-- **Breaking:** refactor: Move DpCheckbox to components root
+- refactor: Move DpCheckbox to components root
 
 ## v0.0.7 - 2023-01-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## UNRELEASED
 
 - docs: add documentation for DpCheckbox
-- refactor: Move DpCheckbox to components root
 
 ## v0.0.7 - 2023-01-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## UNRELEASED
 
+- docs: add documentation for DpCheckbox
+- **Breaking:** refactor: Move DpCheckbox to components root
+
 ## v0.0.7 - 2023-01-09
 
 - Make sure the built package contains the correct content

--- a/src/components/DpCheckbox/DpCheckbox.stories.mdx
+++ b/src/components/DpCheckbox/DpCheckbox.stories.mdx
@@ -9,6 +9,8 @@ import DpCheckbox from './DpCheckbox'
 
 The `DpCheckbox` component renders an input of type `checkbox`.
 
+Checkboxes are used when a user can select multiple options. It is possible to select zero, some, or all options.
+
 export const Template = (args, { argTypes }) => ({
     props: Object.keys(argTypes),
     components: { DpCheckbox },

--- a/src/components/DpCheckbox/DpCheckbox.stories.mdx
+++ b/src/components/DpCheckbox/DpCheckbox.stories.mdx
@@ -1,0 +1,113 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs'
+import DpCheckbox from './DpCheckbox'
+
+<Meta
+  title="Components/Checkbox"
+  component={DpCheckbox} />
+
+# Checkbox
+
+The `DpCheckbox` component renders an input of type `checkbox`.
+
+export const Template = (args, { argTypes }) => ({
+    props: Object.keys(argTypes),
+    components: { DpCheckbox },
+    template: `<dp-checkbox v-bind="$props" />`
+});
+
+### Default
+<Canvas>
+    <Story
+        name="Default"
+        args={{
+            id: 'checkboxId',
+            label: {
+              text: 'Checkbox label'
+            }
+        }}>
+        {Template.bind({})}
+    </Story>
+</Canvas>
+
+### Disabled
+<Canvas>
+    <Story
+        name="Disabled"
+        args={{
+            id: 'checkboxId',
+            label: {
+              text: 'Checkbox label'
+            },
+            disabled: true
+        }}>
+        {Template.bind({})}
+    </Story>
+</Canvas>
+
+### Checked
+<Canvas>
+    <Story
+        name="Checked"
+        args={{
+            id: 'checkboxId',
+            label: {
+              text: 'Checkbox label'
+            },
+            checked: true
+        }}>
+        {Template.bind({})}
+    </Story>
+</Canvas>
+
+### Required
+
+If a checkbox is `required`, an asterisk will be added to its label.
+
+<Canvas>
+    <Story
+        name="Required"
+        args={{
+            id: 'checkboxId',
+            label: {
+              text: 'Checkbox label'
+            },
+            required: true
+        }}>
+        {Template.bind({})}
+    </Story>
+</Canvas>
+
+### Hint
+<Canvas>
+    <Story
+        name="Hint"
+        args={{
+            id: 'checkboxId',
+            label: {
+              text: 'Checkbox label',
+              hint: "This is a hint"
+            }
+        }}>
+        {Template.bind({})}
+    </Story>
+</Canvas>
+
+### Tooltip
+
+The `tooltip` property adds a contextual help icon that reveals additional information on the input field when the user
+hovers over it with their mouse. It should be used sparingly and only to reveal non-critical information, whereas
+critical information should be presented immediately.
+
+<Canvas>
+    <Story
+        name="Tooltip"
+        args={{
+            id: 'checkboxId',
+            label: {
+              text: 'Checkbox label',
+              tooltip: "This is a tooltip"
+            }
+        }}>
+        {Template.bind({})}
+    </Story>
+</Canvas>

--- a/src/components/DpCheckbox/DpCheckbox.stories.mdx
+++ b/src/components/DpCheckbox/DpCheckbox.stories.mdx
@@ -10,8 +10,8 @@ import DpCheckbox from './DpCheckbox'
 The `DpCheckbox` component renders an input of type `checkbox`. Use it for a single option that the user can turn on or
 off.
 
-In order to display several checkboxes grouped together, use `DpCheckboxGroup`. It allows you to define a group
-label and have checkbox labels with normal `font-weight`.
+In order to display several checkboxes grouped together, use `DpCheckboxGroup`. 
+It allows for defining an additional group label and have checkbox labels with normal `font-weight`.
 
 export const Template = (args, { argTypes }) => ({
     props: Object.keys(argTypes),

--- a/src/components/DpCheckbox/DpCheckbox.stories.mdx
+++ b/src/components/DpCheckbox/DpCheckbox.stories.mdx
@@ -7,9 +7,11 @@ import DpCheckbox from './DpCheckbox'
 
 # Checkbox
 
-The `DpCheckbox` component renders an input of type `checkbox`.
+The `DpCheckbox` component renders an input of type `checkbox`. Use it for a single option that the user can turn on or
+off.
 
-Checkboxes are used when a user can select multiple options. It is possible to select zero, some, or all options.
+In order to display several checkboxes grouped together, use `DpCheckboxGroup`. It allows you to define a group
+label and have checkbox labels with normal `font-weight`.
 
 export const Template = (args, { argTypes }) => ({
     props: Object.keys(argTypes),

--- a/src/components/DpCheckbox/DpCheckbox.vue
+++ b/src/components/DpCheckbox/DpCheckbox.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script>
-import DpLabel from '../../DpLabel/DpLabel'
+import DpLabel from '../DpLabel/DpLabel'
 import { prefixClassMixin } from '@demos-europe/demosplan-utils'
 
 export default {

--- a/src/components/core/DpCheckboxGroup.vue
+++ b/src/components/core/DpCheckboxGroup.vue
@@ -21,7 +21,7 @@
 
 <script>
 import { CleanHtml } from '../../directives'
-import DpCheckbox from './form/DpCheckbox'
+import DpCheckbox from '../DpCheckbox/DpCheckbox'
 
 export default {
   name: 'DpCheckboxGroup',

--- a/src/components/core/DpDataTable/DpColumnSelector.vue
+++ b/src/components/core/DpDataTable/DpColumnSelector.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script>
-import DpCheckbox from '../form/DpCheckbox'
+import DpCheckbox from '../../DpCheckbox/DpCheckbox'
 import DpFlyout from '../DpFlyout'
 import { hasOwnProp } from '@demos-europe/demosplan-utils'
 

--- a/src/components/core/DpEditor/DpLinkModal.vue
+++ b/src/components/core/DpEditor/DpLinkModal.vue
@@ -47,7 +47,7 @@
 
 <script>
 import DpButtonRow from '../DpButtonRow'
-import DpCheckbox from '../form/DpCheckbox'
+import DpCheckbox from '../../DpCheckbox/DpCheckbox'
 import DpInput from '../../DpInput/DpInput'
 import DpModal from '../DpModal'
 import { dpValidateMixin } from '@demos-europe/demosplan-utils'

--- a/src/components/core/DpTableCardList/DpTableCardListHeader.vue
+++ b/src/components/core/DpTableCardList/DpTableCardListHeader.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script>
-import DpCheckbox from '../form/DpCheckbox'
+import DpCheckbox from '../../DpCheckbox/DpCheckbox'
 import DpStickyElement from '../shared/DpStickyElement'
 
 export default {

--- a/src/components/core/index.js
+++ b/src/components/core/index.js
@@ -7,7 +7,6 @@ import DpButtonIcon from './DpButtonIcon'
 import DpButtonRow from './DpButtonRow'
 import DpCard from './DpCard'
 import DpChangeStateAtDate from './DpChangeStateAtDate'
-import DpCheckbox from './form/DpCheckbox'
 import DpCheckboxGroup from './DpCheckboxGroup'
 import DpColumnSelector from './DpDataTable/DpColumnSelector'
 import DpContextualHelp from './DpContextualHelp'
@@ -69,7 +68,6 @@ export {
   DpButtonRow,
   DpCard,
   DpChangeStateAtDate,
-  DpCheckbox,
   DpCheckboxGroup,
   DpColumnSelector,
   DpContextualHelp,

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,5 @@
 import DpButton from './DpButton/DpButton'
+import DpCheckbox from './DpCheckbox/DpCheckbox'
 import DpDetails from './DpDetails/DpDetails'
 import DpIcon from './DpIcon/DpIcon'
 import DpInput from './DpInput/DpInput'
@@ -14,7 +15,6 @@ import {
   DpButtonRow,
   DpCard,
   DpChangeStateAtDate,
-  DpCheckbox,
   DpCheckboxGroup,
   DpColumnSelector,
   DpContextualHelp,

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import { attributes, length } from './shared'
 import { exactlengthHint, maxlengthHint, minlengthHint } from './utils'
-import { Tooltip, VPopover } from './directives'
-import { CleanHtml } from './directives'
+import { CleanHtml, Tooltip, VPopover } from './directives'
 
 import {
   DpButton,


### PR DESCRIPTION
Moves `DpCheckbox` to the `components` root and adds some basic documentation.

(Also, fixes a duplicated import statement)

Related tickets: https://yaits.demos-deutschland.de/T30969, https://yaits.demos-deutschland.de/T30976