### PR TITLE
fix(refs T31010): Handle ES5/ES6 issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,9 +68,9 @@
     "build-css": "tailwindcss -i ./style/index.css -o ./style/style.css",
     "build-storybook": "build-storybook",
     "build-tokens": "node buildTokens.js",
-    "prepack": "yarn build && yarn build-tokens",
+    "preinstall": "yarn build && yarn build-tokens",
     "storybook": "start-storybook -p 6006",
-    "build": "yarn build:prod",
+    "build": "yarn build:dev",
     "build:dev": "webpack --mode=development",
     "build:prod": "webpack --mode=production --define-process-env-node-env=production",
     "watch": "webpack --watch"

--- a/package.json
+++ b/package.json
@@ -29,9 +29,7 @@
     "vue-omnibox": "^0.3.7",
     "vue-sliding-pagination": "^1.3.2",
     "vuedraggable": "^2.24.3",
-    "vuex": "^3.6.2"
-  },
-  "devDependencies": {
+    "vuex": "^3.6.2",
     "@babel/core": "^7.20.2",
     "@babel/preset-env": "^7.20.2",
     "@storybook/addon-actions": "6.5.15",

--- a/src/components/core/DpEditor/DpResizableImage.vue
+++ b/src/components/core/DpEditor/DpResizableImage.vue
@@ -10,7 +10,7 @@
       :alt="node.attrs.alt"
       ref="image"
       :src="node.attrs.src"
-      :title="Translator.trans('image.alt.edit.hint')"
+      :title="imageTitle"
       :width="node.attrs.width">
   </span>
 </template>
@@ -62,6 +62,7 @@ export default {
   data () {
     return {
       id: uuid(),
+      imageTitle: Translator.trans('image.alt.edit.hint'),
       observer: null,
       ratioFactor: 1
     }
@@ -97,9 +98,14 @@ export default {
   },
 
   mounted () {
-    // Observe changes to image wrapper to update image size
-    this.observer = new ResizeObserver(e => this.updateImageDimensions(e[0].target.offsetWidth))
-    this.observer.observe(this.$refs.imagewrapper)
+    /*
+     * Observe changes to image wrapper to update image size
+     * We have to wait for the nextTick to ensure, that the ref is set
+     */
+    this.$nextTick(()=> {
+      this.observer = new ResizeObserver(e => this.updateImageDimensions(e[0].target.offsetWidth))
+      this.observer.observe(this.$refs.imagewrapper)
+    })
 
     this.$root.$on('update-image:' + this.id, data => {
       this.updateAttrs(data)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { VueLoaderPlugin } = require('vue-loader');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
+const DefinePlugin = require('webpack').DefinePlugin
 
 const bundleAnalyzer = new BundleAnalyzerPlugin({
   analyzerMode: 'static',
@@ -55,6 +56,9 @@ const config = {
   plugins: [
     new MiniCssExtractPlugin(),
     new VueLoaderPlugin(),
+    new DefinePlugin({
+      'process.env.FOO': 'process.env.FOO' // @see https://github.com/webpack/webpack/issues/2933
+    })
   ],
   module: {
     rules: [


### PR DESCRIPTION
On some Pages we found strange behavior resolving some external Dependencies. We thought, they where already fixed by transpiling them during the buildstep, but it turned out that it wasn't enough.

here https://github.com/webpack/webpack/issues/2933 I found another solution on top, which I applied and which looks like it works.

You can test this in demosplan-core -> /einstellungen/plattform (as Support)

ATM there are still changes to make it localy testable.
(changes in package.json)

refs https://yaits.demos-deutschland.de/T31010