### PR TITLE
Fix paths after failed merge

### DIFF
--- a/src/components/DpDateRangePicker/DpDateRangePicker.vue
+++ b/src/components/DpDateRangePicker/DpDateRangePicker.vue
@@ -30,7 +30,7 @@
 
 <script>
 import DpDatepicker from '../DpDatepicker/DpDatepicker'
-import { formatDate } from '../../../utils'
+import { formatDate } from '../../utils'
 
 export default {
   name: 'DpDateRangePicker',

--- a/src/components/DpRadio/DpRadio.vue
+++ b/src/components/DpRadio/DpRadio.vue
@@ -28,7 +28,7 @@
 
 <script>
 import DpLabel from '../DpLabel/DpLabel'
-import { prefixClassMixin } from '../../../mixins'
+import { prefixClassMixin } from '../../mixins'
 
 export default {
   name: 'DpRadio',

--- a/src/components/DpSearchField/DpSearchField.vue
+++ b/src/components/DpSearchField/DpSearchField.vue
@@ -19,7 +19,7 @@
 
 <script>
 import DpButton from '../DpButton/DpButton'
-import DpResettableInput from '../../DpResettableInput/DpResettableInput'
+import DpResettableInput from '../DpResettableInput/DpResettableInput'
 
 export default {
   name: 'DpSearchField',

--- a/src/components/DpSelect/DpSelect.vue
+++ b/src/components/DpSelect/DpSelect.vue
@@ -36,7 +36,7 @@
 
 <script>
 import DpLabel from '../DpLabel/DpLabel'
-import { prefixClassMixin } from '../../../mixins'
+import { prefixClassMixin } from '../../mixins'
 
 export default {
   name: 'DpSelect',

--- a/src/components/DpSlidingPagination/DpSlidingPagination.vue
+++ b/src/components/DpSlidingPagination/DpSlidingPagination.vue
@@ -1,5 +1,5 @@
 <script>
-import { prefixClass } from '../../lib'
+import { prefixClass } from '../../utils'
 import SlidingPagination from 'vue-sliding-pagination'
 
 export default {

--- a/src/components/DpTimePicker/DpTimePicker.vue
+++ b/src/components/DpTimePicker/DpTimePicker.vue
@@ -92,7 +92,7 @@ export default {
     DpLabel: async () => {
       return await import('../DpLabel/DpLabel')
     },
-    DpResettableInput: () => import('../../DpResettableInput/DpResettableInput')
+    DpResettableInput: () => import('../DpResettableInput/DpResettableInput')
   },
 
   directives: {

--- a/src/lib/ActionMenu.js
+++ b/src/lib/ActionMenu.js
@@ -31,7 +31,7 @@
  *  To enable highlighting of current item, drop data-actionmenu-current on an item
  *
  */
-import prefixClass from './prefixClass/prefixClass'
+import prefixClass from '../utils/prefixClass'
 
 class ActionMenu {
   constructor (actionMenuElement) {

--- a/src/lib/validation/utils/assignHandlerForTrigger.js
+++ b/src/lib/validation/utils/assignHandlerForTrigger.js
@@ -1,6 +1,20 @@
-import { addFormHiddenField } from '../../../index'
 import { scrollToVisibleElement } from './helpers'
 import validateForm from './validateForm'
+
+/**
+ *  Append hidden form field to a form
+ *  @param form DOM element
+ *  @param fieldName string
+ *  @param value string
+ */
+function addFormHiddenField (form, fieldName, value) {
+  const input = document.createElement('input')
+  const options = { type: 'hidden', name: fieldName, value: value, 'data-form-actions-added': '1' }
+  Object.keys(options).forEach(attr => {
+    input.setAttribute(attr, options[attr])
+  })
+  form.appendChild(input)
+}
 
 const submitAction = (form, triggerName) => {
   document.dispatchEvent(new CustomEvent('customValidationPassed', { detail: { form: form } }))

--- a/src/mixins/prefixClassMixin/prefixClassMixin.js
+++ b/src/mixins/prefixClassMixin/prefixClassMixin.js
@@ -3,7 +3,7 @@
  *
  * @deprecated USe prefixClassMixin from demosplan-utils instead
  */
-import { prefixClass } from '../../lib'
+import { prefixClass } from '../../utils'
 
 export default {
   methods: {


### PR DESCRIPTION
At the moment, **main** can't be build. As files have moved in both #76 and #71, resolving of conflicts was not happening as magically as it looked. This PR fixes these issues.

For the `addFormHiddenField` method, which has been moved to demosplan-core, we decided to duplicate it here (as long as "classic" forms have to be supported), because the only alternative approach that makes sense here would be to introduce some kind of hooks in the validation process, which is out of scope for dpValidate as of now.