### PR TITLE
fix(refs T31024): keep empty spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ## v0.0.9 - 2023-01-23
 
-- Fix DpTreeList bulk edit: emit correct selection
+### Fixed
+- ([#93](https://github.com/demos-europe/demosplan-ui/pull/93)) Keep empty spaces after copy/pasting from MS Word ([@hwiem](https://github.com/hwiem))
+- ([#93](https://github.com/demos-europe/demosplan-ui/pull/93)) Ensure EditorObscure is imported before using it ([@hwiem](https://github.com/hwiem))
+- ([#73](https://github.com/demos-europe/demosplan-ui/pull/73)) DpTreeList bulk edit: emit correct selection ([@muellerdemos](https://github.com/muellerdemos))
 
 ## v0.0.8 - 2023-01-19
 

--- a/src/components/core/DpEditor/DpEditor.vue
+++ b/src/components/core/DpEditor/DpEditor.vue
@@ -371,6 +371,7 @@ import EditorCustomInsert from './libs/editorCustomInsert'
 import EditorCustomLink from './libs/editorCustomLink'
 import EditorCustomMark from './libs/editorCustomMark'
 import EditorInsertAtCursorPos from './libs/editorInsertAtCursorPos'
+import EditorObscure from './libs/editorObscure'
 import { handleWordPaste } from './libs/handleWordPaste'
 import { maxlengthHint } from '../../../utils/'
 import { prefixClassMixin } from '../../../mixins'
@@ -1053,7 +1054,6 @@ export default {
     }
 
     if (this.toolbar.obscure) {
-      const { EditorObscure } = import('./libs/editorObscure')
       extensions.push(new EditorObscure())
     }
 

--- a/src/components/core/DpEditor/libs/handleWordPaste.js
+++ b/src/components/core/DpEditor/libs/handleWordPaste.js
@@ -265,7 +265,7 @@ function buildListAsHtmlString (list) {
 function prepareDataBeforeParsingMso (slice) {
   return slice
     // Strip line breaks
-    .replace(/(\r|\n)/gmi, '')
+    .replace(/(&nbsp;|\r|\n)/gmi, ' ')
     // Strip head
     .replace(/<head>(.|\n|\r)*?<\/head>/mi, '')
     // Strip html wrapper and remove conentless and non html like elements "<o:p>"


### PR DESCRIPTION
Ticket: https://yaits.demos-deutschland.de/T31024

- when copy/pasting from word, empty spaces are no longer removed
- another bug was fixed along the way (dynamically importing `EditorObscure` made it unavailable, so when testing in demosplan, the editor was not rendered)
