### PR TITLE
Do not unregister boilerplates module 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Do not unregister boilerplates store module beforeDestroy
+- ([#95](https://github.com/demos-europe/demosplan-ui/pull/95)) Do not unregister boilerplates store module beforeDestroy ([@spiess-demos](https://github.com/spiess-demos))
 
 ## v0.0.10 - 2023-02-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### Fixed
+
+- Do not unregister boilerplates store module beforeDestroy
+
 ## v0.0.10 - 2023-02-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 ## UNRELEASED
 
+## v0.0.10 - 2023-02-07
+
+### Fixed
+
+- ([#93](https://github.com/demos-europe/demosplan-ui/pull/93)) Keep empty spaces after copy/pasting from MS Word ([@hwiem](https://github.com/hwiem))
+- ([#93](https://github.com/demos-europe/demosplan-ui/pull/93)) Ensure EditorObscure is imported before using it ([@hwiem](https://github.com/hwiem))
+
 ## v0.0.9 - 2023-01-23
 
 ### Fixed
-- ([#93](https://github.com/demos-europe/demosplan-ui/pull/93)) Keep empty spaces after copy/pasting from MS Word ([@hwiem](https://github.com/hwiem))
-- ([#93](https://github.com/demos-europe/demosplan-ui/pull/93)) Ensure EditorObscure is imported before using it ([@hwiem](https://github.com/hwiem))
+
 - ([#73](https://github.com/demos-europe/demosplan-ui/pull/73)) DpTreeList bulk edit: emit correct selection ([@muellerdemos](https://github.com/muellerdemos))
 
 ## v0.0.8 - 2023-01-19

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demos-europe/demosplan-ui",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "license": "MIT",
   "private": false,
   "description": "Vue components, Vue directives, Design Token and Scss files to build interfaces for demosPlan.",

--- a/src/components/core/DpEditor/DpBoilerPlateModal.vue
+++ b/src/components/core/DpEditor/DpBoilerPlateModal.vue
@@ -131,11 +131,6 @@ export default {
     if (this.getBoilerplatesRequestFired === false) {
       this.getBoilerPlates(this.procedureId)
     }
-  },
-
-  beforeDestroy () {
-    this.$store.unregisterModule('boilerplates')
   }
-
 }
 </script>


### PR DESCRIPTION
It is not needed anymore, as the boilerplates store is registered in bundle entrypoints now.

Also, it caused a bug when an outer component was destroyed but remounted afterwards.