### PR TITLE
Set correct value for `aria-live` in DpNotifyContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### Fixed
+
+- Set correct value for `aria-live` in DpNotifyContainer when document becomes visible
+
 ## v0.0.12 - 2023-02-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Set correct value for `aria-live` in DpNotifyContainer when document becomes visible
+- ([#100](https://github.com/demos-europe/demosplan-ui/pull/100)) Set correct value for `aria-live` in DpNotifyContainer when document becomes visible ([@spiess-demos](https://github.com/spiess-demos))
 
 ## v0.0.12 - 2023-02-13
 

--- a/src/components/core/notify/DpNotifyContainer.vue
+++ b/src/components/core/notify/DpNotifyContainer.vue
@@ -98,7 +98,7 @@ export default {
         }
       }
 
-      document.addEventListener('visibilitychange', () => { this.isVisible = document.hidden })
+      document.addEventListener('visibilitychange', () => { this.isVisible = !document.hidden })
     },
 
     removeMessage (message) {


### PR DESCRIPTION
This PR sets the correct value for `aria-live` in DpNotifyContainer when document becomes visible. The logic was mistakenly inverted before.