### PR TITLE
Badges!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # DEMOSPLAN UI
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![Common Changelog](https://common-changelog.org/badge.svg)](https://common-changelog.org)
+
 Vue components, Vue directives, Design Token and Scss files to build interfaces for demosPlan.


### PR DESCRIPTION
To document that we agreed on the usage of common-changelog, the badge is added in the README. As this one badge looks very lonesome, a license badge is destined to accompany it.

The choice of displaying the MIT license badge with a green color expresses a permissive license.