### PR TITLE
fix(refs T31929): Make DpDatepicker loadable

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "vue-omnibox": "^0.3.7",
     "vue-sliding-pagination": "^1.3.2",
     "vuedraggable": "^2.24.3",
-    "vuex": "^3.6.2",
+    "vuex": "^3.6.2"
+  },
+  "devDependencies": {
     "@babel/core": "^7.20.2",
     "@babel/preset-env": "^7.20.2",
     "@storybook/addon-actions": "6.5.16",
@@ -69,9 +71,9 @@
     "build-css": "tailwindcss -i ./style/index.css -o ./style/style.css",
     "build-storybook": "build-storybook",
     "build-tokens": "node buildTokens.js",
-    "postinstall": "yarn build && yarn build-tokens",
+    "prepack": "yarn build && yarn build-tokens",
     "storybook": "start-storybook -p 6006",
-    "build": "yarn build:dev",
+    "build": "yarn build:prod",
     "build:dev": "webpack --mode=development",
     "build:prod": "webpack --mode=production --define-process-env-node-env=production",
     "watch": "webpack --watch"

--- a/package.json
+++ b/package.json
@@ -32,9 +32,7 @@
     "vue-omnibox": "^0.3.7",
     "vue-sliding-pagination": "^1.3.2",
     "vuedraggable": "^2.24.3",
-    "vuex": "^3.6.2"
-  },
-  "devDependencies": {
+    "vuex": "^3.6.2",
     "@babel/core": "^7.20.2",
     "@babel/preset-env": "^7.20.2",
     "@storybook/addon-actions": "6.5.16",
@@ -71,9 +69,9 @@
     "build-css": "tailwindcss -i ./style/index.css -o ./style/style.css",
     "build-storybook": "build-storybook",
     "build-tokens": "node buildTokens.js",
-    "prepack": "yarn build && yarn build-tokens",
+    "postinstall": "yarn build && yarn build-tokens",
     "storybook": "start-storybook -p 6006",
-    "build": "yarn build:prod",
+    "build": "yarn build:dev",
     "build:dev": "webpack --mode=development",
     "build:prod": "webpack --mode=production --define-process-env-node-env=production",
     "watch": "webpack --watch"

--- a/src/components/DpDatepicker/DpDatepicker.vue
+++ b/src/components/DpDatepicker/DpDatepicker.vue
@@ -7,7 +7,7 @@
 
 <script>
 // eslint-disable-next-line import/extensions
-import Datepicker from 'a11y-datepicker/dist/index.es.min'
+import Datepicker from 'a11y-datepicker/dist/index.min'
 
 export default {
   name: 'DpDatepicker',


### PR DESCRIPTION
The library we are using ([a11y-datepicker](https://github.com/mathislucka/a11y-datepicker/)) was iomported as es module. That didn't works with the current setup, so we just have to load the cjs module and everything is fine.

**Ticket** https://yaits.demos-deutschland.de/T31929