### PR TITLE
Fix(refs T32170): refactor dynamic imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## UNRELEASED
+
+### Fixed
+
+- ([#148](https://github.com/demos-europe/demosplan-ui/pull/148)) Replace dynamic imports with static imports to avoid race conditional bugs ([@muellerdemos](https://github.com/muellerdemos))
+
 ## v0.0.18 - 2023-03-29
 
 - ([#139](https://github.com/demos-europe/demosplan-ui/pull/139)) REVERT: ([#133](https://github.com/demos-europe/demosplan-ui/pull/133)) Import `a11y-datepicker` not as es Module anymore, to make it resolveable

--- a/src/components/DpTimePicker/DpTimePicker.vue
+++ b/src/components/DpTimePicker/DpTimePicker.vue
@@ -78,6 +78,9 @@
 
 <script>
 import ClickOutside from 'vue-click-outside'
+import DpInput from '../DpInput/DpInput'
+import DpLabel from '../DpLabel/DpLabel'
+import DpResettableInput from '../DpResettableInput/DpResettableInput'
 import isMobile from 'ismobilejs'
 
 const DEFAULT_TIME = '00:00'
@@ -86,13 +89,9 @@ export default {
   name: 'DpTimePicker',
 
   components: {
-    DpInput: async () => {
-      return await import('../DpInput/DpInput')
-    },
-    DpLabel: async () => {
-      return await import('../DpLabel/DpLabel')
-    },
-    DpResettableInput: () => import('../DpResettableInput/DpResettableInput')
+    DpInput,
+    DpLabel,
+    DpResettableInput
   },
 
   directives: {

--- a/src/components/core/DpAutocomplete.vue
+++ b/src/components/core/DpAutocomplete.vue
@@ -22,12 +22,13 @@
 <script>
 import { dpApi } from '../../lib'
 import { prefixClassMixin } from '../../mixins'
+import VueOmnibox from 'vue-omnibox'
 
 export default {
   name: 'DpAutocomplete',
 
   components: {
-    VueOmnibox: () => import('vue-omnibox')
+    VueOmnibox
   },
 
   mixins: [prefixClassMixin],

--- a/src/components/core/DpCard.vue
+++ b/src/components/core/DpCard.vue
@@ -15,11 +15,12 @@
 </template>
 
 <script>
+import DpContextualHelp from '../DpContextualHelp/DpContextualHelp'
 export default {
   name: 'DpCard',
 
   components: {
-    DpContextualHelp: () => import('../DpContextualHelp/DpContextualHelp')
+    DpContextualHelp
   },
 
   props: {

--- a/src/components/core/DpEditor/DpEditor.vue
+++ b/src/components/core/DpEditor/DpEditor.vue
@@ -338,6 +338,8 @@ import {
 } from 'tiptap'
 import { createSuggestion } from './libs/editorBuildSuggestion'
 import DpIcon from '../../DpIcon/DpIcon'
+import DpLinkModal from './DpLinkModal'
+import DpUploadModal from './DpUploadModal'
 import EditorCustomDelete from './libs/editorCustomDelete'
 import EditorCustomImage from './libs/editorCustomImage'
 import EditorCustomInsert from './libs/editorCustomInsert'
@@ -356,8 +358,8 @@ export default {
     DpIcon,
     EditorMenuBar,
     EditorContent,
-    DpLinkModal: () => import('./DpLinkModal'),
-    DpUploadModal: () => import('./DpUploadModal')
+    DpLinkModal,
+    DpUploadModal
   },
 
   directives: {

--- a/src/components/core/DpTableCardList/DpTableCardListHeader.vue
+++ b/src/components/core/DpTableCardList/DpTableCardListHeader.vue
@@ -28,6 +28,7 @@
 
 <script>
 import DpCheckbox from '../../DpCheckbox/DpCheckbox'
+import DpSearchField from '../../DpSearchField/DpSearchField'
 import DpStickyElement from '../shared/DpStickyElement'
 
 export default {
@@ -35,7 +36,7 @@ export default {
 
   components: {
     DpCheckbox,
-    DpSearchField: () => import('../../DpSearchField/DpSearchField'),
+    DpSearchField,
     DpStickyElement
   },
 

--- a/src/components/core/DpToggleForm.vue
+++ b/src/components/core/DpToggleForm.vue
@@ -17,6 +17,7 @@
 
 <script>
 import DpAccordion from '../DpAccordion/DpAccordion'
+import DpButtonRow from '../DpButtonRow/DpButtonRow'
 import { dpValidateMixin } from '../../mixins'
 
 export default {
@@ -24,7 +25,7 @@ export default {
 
   components: {
     DpAccordion,
-    DpButtonRow: () => import('../DpButtonRow/DpButtonRow')
+    DpButtonRow
   },
 
   mixins: [dpValidateMixin],


### PR DESCRIPTION
Ticket: https://yaits.demos-deutschland.de/T32170

Dynamic imports are causing bugs every now and then, hence we decided is to refactor them and replace those with static imports to avoid future bugs. There is a tradeoff however since the bundle output will be slightly bigger this way but we decided it is still worth it, to adjust these imports.