### PR TITLE
Tweak default offset for tooltip

### DIFF
--- a/src/directives/Tooltip/Tooltip.js
+++ b/src/directives/Tooltip/Tooltip.js
@@ -11,6 +11,7 @@ const tooltipConfig = {
     show: 300,
     hide: 100
   },
+  defaultOffset: 12,
   defaultTemplate: '<div class="tooltip" role="tooltip"><div class="tooltip__arrow"></div><div class="tooltip__inner"></div></div>',
   popover: {
     defaultPlacement: 'top',


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29863

By specifying the offset via javascript (instead of css), a bug is fixed where the tooltip arrow was misplaced when a tooltip appeared directly in a corner of the parent element.

:warning: The related PR that changes the CSS accordingly has to be merged, after a new version of demosplan-ui has been released.