### PR TITLE
fix(refs T32170): adjust layout of sliding dppager

### DIFF
--- a/src/components/DpPager/DpPager.vue
+++ b/src/components/DpPager/DpPager.vue
@@ -7,6 +7,7 @@
           v-if="totalItems > Math.min(...limits)"
           class="display--inline-block"
           :current="currentPage"
+          :nonSlidingSize="3"
           :total="totalPages || 1"
           @page-change="handlePageChange" />
       <div

--- a/src/components/DpPager/DpPager.vue
+++ b/src/components/DpPager/DpPager.vue
@@ -8,6 +8,8 @@
           class="display--inline-block"
           :current="currentPage"
           :nonSlidingSize="3"
+          :slidingEndingSize="1"
+          :slidingWindowSize="1"
           :total="totalPages || 1"
           @page-change="handlePageChange" />
       <div

--- a/src/components/DpPager/DpPager.vue
+++ b/src/components/DpPager/DpPager.vue
@@ -3,9 +3,12 @@
     <label
       class="c-pager__dropdown-label u-m-0 u-p-0 weight--normal display--inline-block"
       :aria-label="Translator.trans('pager.amount.multiple.label', { results: totalItems, items: Translator.trans('pager.amount.multiple.items') })">
-      <span aria-hidden="true">
-        {{ Translator.trans('pager.amount.multiple.show') }}
-      </span>
+        <dp-sliding-pagination
+          v-if="totalItems > Math.min(...limits)"
+          class="display--inline-block"
+          :current="currentPage"
+          :total="totalPages || 1"
+          @page-change="handlePageChange" />
       <div
         class="display--inline-block"
         v-if="totalItems > Math.min(...limits)">
@@ -24,12 +27,6 @@
         {{ Translator.trans('pager.amount.multiple.items') }}
       </span>
     </label>
-    <dp-sliding-pagination
-      v-if="totalItems > Math.min(...limits)"
-      class="display--inline-block"
-      :current="currentPage"
-      :total="totalPages || 1"
-      @page-change="handlePageChange" />
   </div>
 </template>
 


### PR DESCRIPTION
https://yaits.demos-deutschland.de/T31974

- the pagination selection should be before the dropdown and should not have a term between the pagination and the dropdown.