### PR TITLE
chore(refs T32012): Use native setter instead of vue.set

### DIFF
--- a/src/components/DpCheckboxGroup/DpCheckboxGroup.vue
+++ b/src/components/DpCheckboxGroup/DpCheckboxGroup.vue
@@ -72,7 +72,7 @@ export default {
   methods: {
     setSelected () {
       this.options.forEach(option => {
-        Vue.set(this.selected, option.id, false)
+        this.selected[option.id] = false
       })
     }
   },


### PR DESCRIPTION
in preparation for vue3. this does the same and is deprecated in vue3