### PR TITLE
chore(refs T19787, T19759): Rebuild template for selectPageItemCount

### DIFF
--- a/src/components/core/DpDataTable/DpSelectPageItemCount.vue
+++ b/src/components/core/DpDataTable/DpSelectPageItemCount.vue
@@ -3,11 +3,13 @@
     <select
       id="item-count"
       class="o-form__control-select width-auto u-mr-0_25"
-      @change="e => $emit('change-count', parseInt(e.target.value))">
+      @change="e => $emit('changed-count', parseInt(e.target.value))">
       <option
         v-for="option in pageCountOptions"
         :value="option"
-        :selected="option === currentItemCount" />
+        :selected="option === currentItemCount">
+        {{ option }}
+      </option>
     </select>
     <label
       for="item-count"

--- a/src/components/core/DpDataTable/DpSelectPageItemCount.vue
+++ b/src/components/core/DpDataTable/DpSelectPageItemCount.vue
@@ -1,8 +1,25 @@
+<template>
+  <div>
+    <select
+      id="item-count"
+      class="o-form__control-select width-auto u-mr-0_25"
+      @change="e => $emit('change-count', parseInt(e.target.value))">
+      <option
+        v-for="option in pageCountOptions"
+        :value="option"
+        :selected="option === currentItemCount" />
+    </select>
+    <label
+      for="item-count"
+      class="display--inline u-mb-0">
+      {{ translations.pagerElementsPerPage }}
+    </label>
+  </div>
+</template>
+
 <script>
 export default {
   name: 'DpSelectPageItemCount',
-
-  functional: true,
 
   props: {
     currentItemCount: {
@@ -19,43 +36,6 @@ export default {
       type: Object,
       required: true
     }
-  },
-
-  render: function (h, { props, listeners, data }) {
-    const selectEl = h('select', {
-      attrs: {
-        id: 'item-count',
-        class: 'o-form__control-select width-auto u-mr-0_25'
-      },
-      on: {
-        change: (e) => {
-          listeners['changed-count'](parseInt(e.target.value))
-        }
-      }
-    }, [
-      ...props.pageCountOptions.map(option => {
-        return h('option', {
-          domProps: {
-            value: option,
-            selected: option === props.currentItemCount
-          }
-        }, option)
-      })
-    ])
-
-    const selectHintEl = h('label', {
-      attrs: {
-        for: 'item-count',
-        class: 'display--inline u-mb-0'
-      }
-    },
-    props.translations.pagerElementsPerPage)
-
-    return h('div', {
-      attrs: {
-        class: data.staticClass
-      }
-    }, [selectEl, selectHintEl])
   }
 }
 </script>

--- a/src/components/core/DpDataTable/DpSelectPageItemCount.vue
+++ b/src/components/core/DpDataTable/DpSelectPageItemCount.vue
@@ -12,7 +12,7 @@
     <label
       for="item-count"
       class="display--inline u-mb-0">
-      {{ translations.pagerElementsPerPage }}
+      {{ labelText }}
     </label>
   </div>
 </template>
@@ -32,8 +32,8 @@ export default {
       required: true
     },
 
-    translations: {
-      type: Object,
+    labelText: {
+      type: String,
       required: true
     }
   }


### PR DESCRIPTION
As Part of the migration to Vue3 we move all functional components to "classic" Compontents. There changed an lot and for sake of simplicity and consistancy having a template is great.

This PR moves only the render function content to the template

