### PR TITLE
Generalize column selection tracking

### DIFF
--- a/src/components/core/DpDataTable/DpColumnSelector.vue
+++ b/src/components/core/DpDataTable/DpColumnSelector.vue
@@ -99,7 +99,7 @@ export default {
      */
     trackSelection () {
       if (hasOwnProp(window, '_paq')) {
-        window._paq.push(['trackEvent', 'Column Selection', 'Segments List', this.selectedColumns])
+        window._paq.push(['trackEvent', 'Column Selection', `View: ${this.localStorageKey}`, `Selected: ${this.selectedColumns.join(', ')}`])
       }
     }
   },


### PR DESCRIPTION
- use localStorageKey to generate distinct Event Actions
- passing a Set as Event Name did not work, so it has to be converted to string first 