### PR TITLE
chore(refs T19787, T19759):  Rebuild template for DpSlidingPagination

### DIFF
--- a/src/components/DpSlidingPagination/DpSlidingPagination.vue
+++ b/src/components/DpSlidingPagination/DpSlidingPagination.vue
@@ -45,10 +45,6 @@ export default {
     prefixClass (classList) {
       return prefixClass(classList)
     }
-  },
-
-    mounted() {
-        console.log(typeof Translator, typeof Translator.trans)
-    }
+  }
 }
 </script>

--- a/src/components/DpSlidingPagination/DpSlidingPagination.vue
+++ b/src/components/DpSlidingPagination/DpSlidingPagination.vue
@@ -1,36 +1,54 @@
+<template>
+  <sliding-pagination
+    :aria-pagination-label="Translator.trans('pager.label')"
+    :aria-goto-page-label="Translator.trans('pager.goto.page.from.pages', { page: current, total: total })"
+    :aria-previous-page-label="Translator.trans('pager.previous')"
+    :aria-next-page-label="Translator.trans('pager.next')"
+    :aria-current-page-label="Translator.trans('pager.page.from.pages.current.page', { page: current, total: total })"
+    :class-map="{
+      componentClass: prefixClass('c-sliding-pagination'),
+      list: prefixClass('c-sliding-pagination__list'),
+      element: prefixClass('c-sliding-pagination__list-element'),
+      elementDisabled: prefixClass('c-sliding-pagination__list-element--disabled'),
+      elementActive: prefixClass('c-sliding-pagination__list-element--active'),
+      page: prefixClass('c-sliding-pagination__page')
+    }"
+    :current="current"
+    :total="total"
+    @page-change="payload => $emit('page-change', payload)" />
+</template>
+
 <script>
 import { prefixClass } from '../../utils'
 import SlidingPagination from 'vue-sliding-pagination'
 
 export default {
   name: 'DpSlidingPagination',
-  functional: true,
+
+  components: {
+    SlidingPagination
+  },
+
+  props: {
+    current: {
+      type: Number,
+      required: true
+    },
+
+    total: {
+      type: Number,
+      required: true
+    }
+  },
+
   methods: {
     prefixClass (classList) {
       return prefixClass(classList)
     }
   },
-  render (createElement, context) {
-    const current = context.data.attrs.current
-    const total = context.data.attrs.total
-    const customizedProperties = {
-      ariaPaginationLabel: Translator.trans('pager.label'),
-      ariaGotoPageLabel: Translator.trans('pager.goto.page.from.pages', { page: current, total: total }),
-      ariaPreviousPageLabel: Translator.trans('pager.previous'),
-      ariaNextPageLabel: Translator.trans('pager.next'),
-      ariaCurrentPageLabel: Translator.trans('pager.page.from.pages.current.page', { page: current, total: total }),
-      classMap: {
-        componentClass: prefixClass('c-sliding-pagination'),
-        list: prefixClass('c-sliding-pagination__list'),
-        element: prefixClass('c-sliding-pagination__list-element'),
-        elementDisabled: prefixClass('c-sliding-pagination__list-element--disabled'),
-        elementActive: prefixClass('c-sliding-pagination__list-element--active'),
-        page: prefixClass('c-sliding-pagination__page')
-      }
-    }
-    context.data.attrs = { ...context.data.attrs, ...customizedProperties }
 
-    return createElement(SlidingPagination, context.data, context.children)
-  }
+    mounted() {
+        console.log(typeof Translator, typeof Translator.trans)
+    }
 }
 </script>

--- a/src/components/core/DpDataTable/DpDataTableExtended.vue
+++ b/src/components/core/DpDataTable/DpDataTableExtended.vue
@@ -18,7 +18,7 @@
             @input="updateFields(null)">
 
           <!-- pager -->
-          <sliding-pagination
+          <dp-sliding-pagination
             v-if="totalPages > 1"
             class="display--inline-block u-ml-0_5 u-mt-0_125"
             :current="currentPage"
@@ -104,9 +104,9 @@ import dataTableSearch from './DataTableSearch'
 import DomPurify from 'dompurify'
 import DpDataTable from './DpDataTable'
 import DpSelectPageItemCount from './DpSelectPageItemCount'
+import DpSlidingPagination from '../../DpSlidingPagination/DpSlidingPagination'
 import DpStickyElement from '../shared/DpStickyElement'
 import { hasOwnProp } from '../../../utils'
-import SlidingPagination from 'vue-sliding-pagination'
 import { tableSelectAllItems } from '../../../mixins'
 
 export default {
@@ -115,8 +115,8 @@ export default {
   components: {
     DpDataTable,
     DpSelectPageItemCount,
-    DpStickyElement,
-    SlidingPagination
+    DpSlidingPagination,
+    DpStickyElement
   },
 
   mixins: [tableSelectAllItems],


### PR DESCRIPTION
As Part of the migration to Vue3 we move all functional components to "classic" Compontents. There changed an lot and for sake of simplicity and consistancy having a template is great.

This PR moves only the render function content to the template.

With that The DpdataTableExtended now ueses the DpSlidingPagination and not the dependency directly so it benefits from the aria definitions.