### PR TITLE
Expose isExpanded in scoped slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - ([#181](https://github.com/demos-europe/demosplan-ui/pull/181)) Move from Functional Component to Template in dpMultiselect ([@salisdemos](https://github.com/salisdemos))
 
 ### Added
-- Component: Expose `isExpanded` in DpFlyout trigger slot ([@spiess-demos](https://github.com/spiess-demos))
+- ([#212](https://github.com/demos-europe/demosplan-ui/pull/212)) Component: Expose `isExpanded` in DpFlyout trigger slot ([@spiess-demos](https://github.com/spiess-demos))
 
 ## v0.0.21 - 2023-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - ([#195](https://github.com/demos-europe/demosplan-ui/pull/195)) Move from Functional Component to Template in dpSelectPageItemCount ([@salisdemos](https://github.com/salisdemos))
 - ([#181](https://github.com/demos-europe/demosplan-ui/pull/181)) Move from Functional Component to Template in dpMultiselect ([@salisdemos](https://github.com/salisdemos))
 
+### Added
+- Component: Expose `isExpanded` in DpFlyout trigger slot ([@spiess-demos](https://github.com/spiess-demos))
+
 ## v0.0.21 - 2023-05-02
 
 ### Changed

--- a/src/components/DpFlyout/DpFlyout.vue
+++ b/src/components/DpFlyout/DpFlyout.vue
@@ -16,7 +16,9 @@
       aria-haspopup="true"
       class="o-flyout__trigger btn--blank o-link--default u-ph-0_25 line-height--2 whitespace--nowrap"
       @click="toggle">
-      <slot name="trigger">
+      <slot
+        name="trigger"
+        v-bind:isExpanded="isExpanded">
         <i class="fa fa-ellipsis-h" />
       </slot>
     </button>


### PR DESCRIPTION
To be able to use the expanded state of DpFlyout right within the consuming component, it must be exposed to the scoped slot.