### PR TITLE
fix(refs: T32865): checkbox at wrong position and console errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 !.storybook
 tokens/scss
 
+.idea
 node_modules/
 npm-debug.log*
 yarn-debug.log*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 ### Fixed
+- ([#249](https://github.com/demos-europe/demosplan-ui/pull/249)) Fix console errors, use correct lifecycle hook and remove `this` from template  ([@muellerdemos](https://github.com/muellerdemos))
 - ([#237](https://github.com/demos-europe/demosplan-ui/pull/237)) Allow number, array and object as value for DpMultiselect ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
 - ([#234](https://github.com/demos-europe/demosplan-ui/pull/237)) Add event listener for all events in DpMultiselect ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
 - ([#234](https://github.com/demos-europe/demosplan-ui/pull/234)) Add prop for searchable for DpMultiselect ([@gruenbergerdemos](https://github.com/gruenbergerdemos))

--- a/src/components/core/DpDataTable/DpTableHeader.vue
+++ b/src/components/core/DpDataTable/DpTableHeader.vue
@@ -152,7 +152,7 @@ export default {
     }
   },
 
-  mounted() {
+  beforeUpdate() {
     this.setIndeterminate()
   }
 }

--- a/src/components/core/DpDataTable/DpTableHeader.vue
+++ b/src/components/core/DpDataTable/DpTableHeader.vue
@@ -15,8 +15,8 @@
       scope="col"
       class="c-data-table__cell--narrow">
       <input
-        :aria-label="this.translations.headerSelectHint"
-        :title="this.translations.headerSelectHint"
+        :aria-label="translations.headerSelectHint"
+        :title="translations.headerSelectHint"
         type="checkbox"
         data-cy="selectAll"
         ref="selectAll"


### PR DESCRIPTION
Ticket: https://yaits.demos-deutschland.de/T32865

- `this` is not valid in template and causes console errors hence has been removed
- On `mounted` can be problematic when working with `$refs` since refs are filled after the component mounts. Hence, to avoid a race condition like scenario, we can simply use another lifecycle hook here. Since `beforeUpdate` was documented here https://vuejs.org/guide/essentials/lifecycle.html#lifecycle-diagram as the hook to use when data changes, this has been implemented accordingly
- updated gitignore to not track irrelevant folders anymore
