### PR TITLE
Fix(T32651): Vue migration: adjust Header to work with DpDataTable template-based component

### DIFF
--- a/src/components/core/DpDataTable/DpTableHeader.vue
+++ b/src/components/core/DpDataTable/DpTableHeader.vue
@@ -20,7 +20,7 @@
         type="checkbox"
         data-cy="selectAll"
         ref="selectAll"
-        @click="$listeners.toggleSelectAll()"
+        @click="toggleSelectAll()"
         :checked="checked" />
     </th>
     <template v-for="(hf, idx) in headerFields">
@@ -48,14 +48,14 @@
       v-if="isExpandable"
       scope="col"
       class="c-data-table__cell--narrow"
-      @click="$listeners.toggleExpandAll()">
+      @click="toggleExpandAll()">
       <dp-wrap-trigger :title="translations.headerExpandHint" />
     </th>
     <th
       v-if="isTruncatable"
       scope="col"
       class="c-data-table__cell--narrow"
-      @click="$listeners.toggleWrapAll()">
+      @click="toggleWrapAll()">
       <dp-wrap-trigger :title="translations.headerExpandHint" />
     </th>
   </tr>
@@ -149,6 +149,18 @@ export default {
       if (this.isSelectable) {
         this.$refs.selectAll.indeterminate = this.indeterminate
       }
+    },
+
+    toggleExpandAll () {
+      this.$emit('toggle-expand-all')
+    },
+
+    toggleSelectAll () {
+      this.$emit('toggle-select-all')
+    },
+
+    toggleWrapAll () {
+      this.$emit('toggle-wrap-all')
     }
   },
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T19759

**Description:** This code defines three methods: `toggleExpandAll`, `toggleSelectAll`, and `toggleWrapAll`.

- `toggleExpandAll` emits the event 'toggle-expand-all' using $emit
- `toggleSelectAll` emits the event 'toggle-select-all' using $emit
- `toggleWrapAll`emits the event 'toggle-wrap-all' using $emit

**Important:** This PR depends on https://github.com/demos-europe/demosplan-ui/pull/230 and can only be merged after PR #230 is merged.