### PR TITLE
bug(refs T33153): Add missing props for multiselect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - ([#269](https://github.com/demos-europe/demosplan-ui/pull/269)) DpIcon: new selector `landscape`, `portrait`, or `square`, based on icon proportions ([@spiess-demos](https://github.com/spiess-demos))
 - ([#270](https://github.com/demos-europe/demosplan-ui/pull/270)) DpIcon: new icons (ai, copy) ([@spiess-demos](https://github.com/spiess-demos))
 
+### Fixed
+- ([#290](https://github.com/demos-europe/demosplan-ui/pull/290)) Add missing props to DpMultiselect ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
+
 ## v0.1.3 - 2032-05-31
 
 ### Removed

--- a/src/components/DpMultiselect/DpMultiselect.vue
+++ b/src/components/DpMultiselect/DpMultiselect.vue
@@ -2,15 +2,22 @@
   <div>
     <vue-multiselect
       :close-on-select="closeOnSelect"
+      :custom-label="customLabel"
+      :data-cy="dataCy"
       :deselect-group-label="deselectGroupLabel"
       :deselect-label="deselectLabel"
+      :disabled="disabled"
       :group-label="groupLabel"
       :group-select="groupSelect"
       :group-values="groupValues"
+      :id="id"
       :label="label"
+      :loading="loading"
+      :max-height="maxHeight"
       :multiple="multiple"
+      :name="name"
       :options="options"
-      :placeholder="Translator.trans('choose')"
+      :placeholder="placeholder"
       :searchable="searchable"
       :select-group-label="selectGroupLabel"
       :select-label="selectLabel"
@@ -90,6 +97,18 @@ export default {
       default: true
     },
 
+    customLabel: {
+      type: Function,
+      required: false,
+      default: () => {}
+    },
+
+    dataCy: {
+      type: String,
+      required: false,
+      default: ''
+    },
+
     deselectLabel: {
       type: String,
       required: false,
@@ -100,6 +119,12 @@ export default {
       type: String,
       required: false,
       default: ''
+    },
+
+    disabled: {
+      type: Boolean,
+      required: false,
+      default: false
     },
 
     groupLabel: {
@@ -120,10 +145,28 @@ export default {
       default: ''
     },
 
+    id: {
+      type: String,
+      required: false,
+      default: ''
+    },
+
     label: {
       type: String,
       required: false,
       default: ''
+    },
+
+    loading: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+
+    maxHeight: {
+      type: Number,
+      required: false,
+      default: 300
     },
 
     multiple: {
@@ -132,9 +175,21 @@ export default {
       default: false
     },
 
+    name: {
+      type: String,
+      required: false,
+      default: ''
+    },
+
     options: {
       type: Array,
       required: true
+    },
+
+    placeholder: {
+      type: String,
+      required: false,
+      default: Translator.trans('choose')
     },
 
     required: {

--- a/src/components/DpMultiselect/DpMultiselect.vue
+++ b/src/components/DpMultiselect/DpMultiselect.vue
@@ -189,7 +189,7 @@ export default {
     placeholder: {
       type: String,
       required: false,
-      default: Translator.trans('choose')
+      default: () => Translator.trans('choose')
     },
 
     required: {

--- a/src/components/DpMultiselect/DpMultiselect.vue
+++ b/src/components/DpMultiselect/DpMultiselect.vue
@@ -1,30 +1,32 @@
 <template>
   <div>
     <vue-multiselect
-      :close-on-select="closeOnSelect"
-      v-bind="conditionalProps"
-      :data-cy="dataCy"
-      :deselect-group-label="deselectGroupLabel"
-      :deselect-label="deselectLabel"
-      :disabled="disabled"
-      :group-label="groupLabel"
-      :group-select="groupSelect"
-      :group-values="groupValues"
-      :id="id"
-      :label="label"
-      :loading="loading"
-      :max-height="maxHeight"
-      :multiple="multiple"
-      :name="name"
-      :options="options"
-      :placeholder="placeholder"
-      :searchable="searchable"
-      :select-group-label="selectGroupLabel"
-      :select-label="selectLabel"
-      :selected-label="selectedLabel"
-      :tag-placeholder="Translator.trans('tag.create')"
-      :track-by="trackBy"
-      :value="value"
+      v-bind="{
+        closeOnSelect,
+        customLabel,
+        dataCy,
+        deselectGroupLabel,
+        deselectLabel,
+        disabled,
+        groupLabel,
+        groupSelect,
+        groupValues,
+        id,
+        label,
+        loading,
+        maxHeight,
+        multiple,
+        name,
+        options,
+        placeholder,
+        searchable,
+        selectGroupLabel,
+        selectLabel,
+        selectedLabel,
+        tagPlaceholder,
+        trackBy,
+        value
+      }"
       v-dp-validate-multiselect="required"
       @close="newVal => $emit('close', newVal)"
       @input="newVal => $emit('input', newVal)"
@@ -98,9 +100,9 @@ export default {
     },
 
     customLabel: {
-      type: [Function, null],
+      type: Function,
       required: false,
-      default: null
+      default: undefined
     },
 
     dataCy: {
@@ -228,6 +230,12 @@ export default {
       default: ''
     },
 
+    tagPlaceholder: {
+      type: String,
+      required: false,
+      default: () => Translator.trans('tag.create')
+    },
+
     trackBy: {
       type: [String, null],
       required: false,
@@ -238,18 +246,6 @@ export default {
       type: [String, Number, Array, Object],
       required: false,
       default: ''
-    }
-  },
-
-  computed: {
-    /**
-     * If these props are not given by the parent, we don't want to give them to vue-multiselect, because
-     * otherwise we get empty results
-     */
-    conditionalProps() {
-      return {
-        ...(this.customLabel ? this.customLabel : {})
-      }
     }
   }
 }

--- a/src/components/DpMultiselect/DpMultiselect.vue
+++ b/src/components/DpMultiselect/DpMultiselect.vue
@@ -2,7 +2,7 @@
   <div>
     <vue-multiselect
       :close-on-select="closeOnSelect"
-      :custom-label="customLabel"
+      v-bind="conditionalProps"
       :data-cy="dataCy"
       :deselect-group-label="deselectGroupLabel"
       :deselect-label="deselectLabel"
@@ -229,15 +229,32 @@ export default {
     },
 
     trackBy: {
-      type: [String, null],
+      type: String,
       required: false,
-      default: null
+      default: ''
     },
 
     value: {
       type: [String, Number, Array, Object],
       required: false,
       default: ''
+    }
+  },
+
+  computed: {
+    /**
+     * If these props are not given by the parent, we don't want to give them to vue-multiselect, because
+     * otherwise we get empty results
+     */
+    conditionalProps() {
+      return {
+        ...(this.customLabel ? this.customLabel : {}),
+        ...(this.groupLabel ? this.groupLabel : {}),
+        ...(this.groupValues ? this.groupValues : {}),
+        ...(this.label ? this.label : {}),
+        ...(this.id ? this.id : {}),
+        ...(this.trackBy ? this.trackBy : {})
+      }
     }
   }
 }

--- a/src/components/DpMultiselect/DpMultiselect.vue
+++ b/src/components/DpMultiselect/DpMultiselect.vue
@@ -4,6 +4,9 @@
       :close-on-select="closeOnSelect"
       :deselect-group-label="deselectGroupLabel"
       :deselect-label="deselectLabel"
+      :group-label="groupLabel"
+      :group-select="groupSelect"
+      :group-values="groupValues"
       :label="label"
       :multiple="multiple"
       :options="options"
@@ -94,6 +97,24 @@ export default {
     },
 
     deselectGroupLabel: {
+      type: String,
+      required: false,
+      default: ''
+    },
+
+    groupLabel: {
+      type: String,
+      required: false,
+      default: ''
+    },
+
+    groupSelect: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+
+    groupValues: {
       type: String,
       required: false,
       default: ''

--- a/src/components/DpMultiselect/DpMultiselect.vue
+++ b/src/components/DpMultiselect/DpMultiselect.vue
@@ -98,9 +98,9 @@ export default {
     },
 
     customLabel: {
-      type: Function,
+      type: [Function, null],
       required: false,
-      default: (option) => `${option.title}`
+      default: null
     },
 
     dataCy: {

--- a/src/components/DpMultiselect/DpMultiselect.vue
+++ b/src/components/DpMultiselect/DpMultiselect.vue
@@ -229,9 +229,9 @@ export default {
     },
 
     trackBy: {
-      type: String,
+      type: [String, null],
       required: false,
-      default: ''
+      default: null
     },
 
     value: {
@@ -248,12 +248,7 @@ export default {
      */
     conditionalProps() {
       return {
-        ...(this.customLabel ? this.customLabel : {}),
-        ...(this.groupLabel ? this.groupLabel : {}),
-        ...(this.groupValues ? this.groupValues : {}),
-        ...(this.label ? this.label : {}),
-        ...(this.id ? this.id : {}),
-        ...(this.trackBy ? this.trackBy : {})
+        ...(this.customLabel ? this.customLabel : {})
       }
     }
   }

--- a/src/components/DpMultiselect/DpMultiselect.vue
+++ b/src/components/DpMultiselect/DpMultiselect.vue
@@ -100,13 +100,13 @@ export default {
     customLabel: {
       type: Function,
       required: false,
-      default: () => {}
+      default: (option) => `${option.title}`
     },
 
     dataCy: {
       type: String,
       required: false,
-      default: ''
+      default: 'multiselect'
     },
 
     deselectLabel: {


### PR DESCRIPTION
Ticket: https://yaits.demos-deutschland.de/T33153

Add some missing props to wrapper component to pass to vue-multiselect. `custom-label` needs to have `undefined` as default, because otherwise we get an empty label if the parent didn't give one.

