### PR TITLE
Chore: Clean up and simplify tableRow condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 - ([#290](https://github.com/demos-europe/demosplan-ui/pull/290)) Add missing props to DpMultiselect ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
 
 ## v0.1.3 - 2032-05-31
-demosp
 ### Removed
 - ([#255](https://github.com/demos-europe/demosplan-ui/pull/255)) **Breaking**: Remove DpRegisterFlyout ([@hwiem](https://github.com/hwiem))
 - ([#259](https://github.com/demos-europe/demosplan-ui/pull/259)) **Breaking**: DpButton does not support slots anymore. Use the `icon` prop instead. ([@spiess-demos](https://github.com/spiess-demos))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@
 - ([#269](https://github.com/demos-europe/demosplan-ui/pull/269)) DpIcon: new selector `landscape`, `portrait`, or `square`, based on icon proportions ([@spiess-demos](https://github.com/spiess-demos))
 - ([#270](https://github.com/demos-europe/demosplan-ui/pull/270)) DpIcon: new icons (ai, copy) ([@spiess-demos](https://github.com/spiess-demos))
 
+### Changed
+- ([#292](https://github.com/demos-europe/demosplan-ui/pull/292)) DpDataTable: Clean V-if/v-for in Preparation for Vue3 ([@salis-demos](https://github.com/salis-demos))
+
 ### Fixed
 - ([#290](https://github.com/demos-europe/demosplan-ui/pull/290)) Add missing props to DpMultiselect ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
 
 ## v0.1.3 - 2032-05-31
-
+demosp
 ### Removed
 - ([#255](https://github.com/demos-europe/demosplan-ui/pull/255)) **Breaking**: Remove DpRegisterFlyout ([@hwiem](https://github.com/hwiem))
 - ([#259](https://github.com/demos-europe/demosplan-ui/pull/259)) **Breaking**: DpButton does not support slots anymore. Use the `icon` prop instead. ([@spiess-demos](https://github.com/spiess-demos))

--- a/src/components/core/DpDataTable/DpDataTable.vue
+++ b/src/components/core/DpDataTable/DpDataTable.vue
@@ -39,10 +39,8 @@
       </thead>
 
       <!-- not draggable -->
-      <tbody v-if="!isDraggable">
-        <template
-          v-if="!isLoading"
-          v-for="(item, idx) in items">
+      <tbody v-if="!isDraggable && !isLoading">
+        <template v-for="(item, idx) in items">
           <dp-table-row
             ref="tableRows"
             :index="idx"
@@ -52,7 +50,6 @@
             :header-fields="headerFields"
             :is-draggable="isDraggable"
             :is-expandable="isExpandable"
-            :is-loading="isLoading && items.length > 0"
             :is-locked="lockCheckboxBy ? item[lockCheckboxBy] : false"
             :is-locked-message="mergedTranslations.lockedForSelection"
             :is-resizable="isResizable"
@@ -106,8 +103,7 @@
         ghostClass="sortable-ghost"
         chosenClass="sortable-chosen"
         @change="(e) => $emit('changed-order', e)">
-        <template
-          v-for="(item, idx) in items">
+        <template v-for="(item, idx) in items">
           <dp-table-row
             :checked="elementSelections[item[trackBy]] || false"
             :expanded="expandedElements[item[trackBy]] || false"


### PR DESCRIPTION
in Vue3 having a v-if on the same element as a v-for causes trouble. And this Changes should not do any harm in vue2