### PR TITLE
fix: empty string is invalid for "variant" prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - ([#256](https://github.com/demos-europe/demosplan-ui/pull/256)) **Breaking**: Remove DpCopyPasteButton ([@hwiem](https://github.com/hwiem))
 
 ### Fixed
--  ([])() Fix invalid empty string for DpButtonRow ([@spiess-demos](https://github.com/spiess-demos))
+-  ([#304](https://github.com/demos-europe/demosplan-ui/pull/304)) Fix invalid empty string for DpButtonRow ([@spiess-demos](https://github.com/spiess-demos))
 
 ## v0.1.5 - 2023-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ## Removed
 - ([#256](https://github.com/demos-europe/demosplan-ui/pull/256)) **Breaking**: Remove DpCopyPasteButton ([@hwiem](https://github.com/hwiem))
 
+### Fixed
+-  ([])() Fix invalid empty string for DpButtonRow ([@spiess-demos](https://github.com/spiess-demos))
+
 ## v0.1.5 - 2023-06-16
 
 _Historic note: v0.1.4 was a bugfix release that contained picked changes from v0.1.5 at a state

--- a/src/components/DpButtonRow/DpButtonRow.vue
+++ b/src/components/DpButtonRow/DpButtonRow.vue
@@ -106,13 +106,14 @@ export default {
     },
 
     /**
-     * Variants of the button include `outline` (`text` to be implemented).
-     * When not specified, the default style (white on colored background) is applied.
+     * The buttons may have a variant of `solid`, `outline`, or `subtle`.
+     * When not specified, the `solid` variant (white on colored background) is applied.
      */
     variant: {
       required: false,
       type: String,
-      default: ''
+      default: 'solid',
+      validator: (prop) => ['solid', 'outline', 'subtle'].includes(prop)
     }
   }
 }


### PR DESCRIPTION
this went unnoticed when implementing the subtle button...