### PR TITLE
bug(refs T33411): Add prop for data-cy on its own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 - ([#256](https://github.com/demos-europe/demosplan-ui/pull/256)) **Breaking**: Remove DpCopyPasteButton ([@hwiem](https://github.com/hwiem))
 
 ### Fixed
--  ([#304](https://github.com/demos-europe/demosplan-ui/pull/304)) Fix invalid empty string for DpButtonRow ([@spiess-demos](https://github.com/spiess-demos))
+- ([#304](https://github.com/demos-europe/demosplan-ui/pull/304)) Fix invalid empty string for DpButtonRow ([@spiess-demos](https://github.com/spiess-demos))
+- ([#319](https://github.com/demos-europe/demosplan-ui/pull/319)) Fix data-cy prop on multiselect ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
 
 ## v0.1.5 - 2023-06-16
 

--- a/src/components/DpMultiselect/DpMultiselect.vue
+++ b/src/components/DpMultiselect/DpMultiselect.vue
@@ -27,6 +27,7 @@
         trackBy,
         value
       }"
+      :data-cy="dataCy"
       v-dp-validate-multiselect="required"
       @close="newVal => $emit('close', newVal)"
       @input="newVal => $emit('input', newVal)"

--- a/src/components/DpMultiselect/DpMultiselect.vue
+++ b/src/components/DpMultiselect/DpMultiselect.vue
@@ -4,7 +4,6 @@
       v-bind="{
         closeOnSelect,
         customLabel,
-        dataCy,
         deselectGroupLabel,
         deselectLabel,
         disabled,


### PR DESCRIPTION
Ticket: https://yaits.demos-deutschland.de/T33411

We need to give the data-cy prop on its own, because otherwise it will be added as `dataCy` instead of `data-cy`. 