### PR TITLE
chore: (refs T33353) replace linebreaks to blanks during paste

### DIFF
--- a/src/components/core/DpEditor/libs/handleWordPaste.js
+++ b/src/components/core/DpEditor/libs/handleWordPaste.js
@@ -264,10 +264,10 @@ function buildListAsHtmlString (list) {
  */
 function prepareDataBeforeParsingMso (slice) {
   return slice
-    // Strip line breaks
-    .replace(/(&nbsp;|\r|\n)/gmi, ' ')
     // Strip head
     .replace(/<head>(.|\n|\r)*?<\/head>/mi, '')
+    // Strip line breaks
+    .replace(/(\r\n)+/gmi, ' ')
     // Strip html wrapper and remove conentless and non html like elements "<o:p>"
     .replace(/<(\/)?(html|o:p)[^>]*>/gmi, '')
     /*


### PR DESCRIPTION
This PR reapplies a fix that was made in core in https://github.com/demos-europe/demosplan-core/pull/1657

**How to review/test**

Paste Text from Word (not office365) into some editor (e.g. "Textbausteine Anlegen"). All blank spaces should be preserved.

As a Dev, this can't be tested, only reviewed since there is no real word on linux.