### PR TITLE
Fix: Add a default export to index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,25 +1,25 @@
-export * from './shared'
+export * from './components'
 export * from './directives'
+export * from './lib'
+export * from './mixins'
+export * from './shared'
 export * from './utils'
-export * from './components/'
-export * from './mixins/'
-export * from './lib/'
-export * from './lib/validation/'
+export * from './lib/validation'
 
-import * as shared from './shared'
+import * as components from './components'
 import * as directives from './directives'
+import * as lib from './lib'
+import * as mixins from './mixins'
+import * as shared from './shared'
 import * as utils from './utils'
-import * as components from './components/'
-import * as mixins from './mixins/'
-import * as lib from './lib/'
-import * as validation from './lib/validation/'
+import * as validation from './lib/validation'
 
 export default {
-  ...shared,
-  ...directives,
-  ...utils,
   ...components,
-  ...mixins,
+  ...directives,
   ...lib,
+  ...mixins,
+  ...shared,
+  ...utils,
   ...validation
 }

--- a/src/index.js
+++ b/src/index.js
@@ -6,3 +6,20 @@ export * from './mixins/'
 export * from './lib/'
 export * from './lib/validation/'
 
+import * as shared from './shared'
+import * as directives from './directives'
+import * as utils from './utils'
+import * as components from './components/'
+import * as mixins from './mixins/'
+import * as lib from './lib/'
+import * as validation from './lib/validation/'
+
+export default {
+  ...shared,
+  ...directives,
+  ...utils,
+  ...components,
+  ...mixins,
+  ...lib,
+  ...validation
+}


### PR DESCRIPTION
For some reasons we need both. Named and default exports. This should fix the Bugs wich leaded to the role back of 1.8. 

since I ordered the entries alphabetically, the changes look more than they are.

Only the second and third block is new. The upper block is just sorted