### PR TITLE
feat(refs T12070): Make IconSize a prop for DpButton

### DIFF
--- a/src/components/DpButton/DpButton.stories.mdx
+++ b/src/components/DpButton/DpButton.stories.mdx
@@ -23,7 +23,11 @@ import DpButton from './DpButton'
     variant: {
       options: ['solid', 'outline', 'subtle'],
       control: { type: 'select' }
-    }
+    },
+    iconSize: {
+          options: ['small', 'medium', 'large'],
+          control: { type: 'select' }
+        }
   }}
   title="Components/Button"
   component={DpButton} />

--- a/src/components/DpButton/DpButton.vue
+++ b/src/components/DpButton/DpButton.vue
@@ -11,7 +11,7 @@
       v-if="icon"
       aria-hidden="true"
       :icon="icon"
-      size="small" />
+      :size="iconSize" />
     <span
       :class="{'hide-visually': hideText}"
       v-text="text" />
@@ -86,6 +86,16 @@ export default {
       required: false,
       type: String,
       default: ''
+    },
+
+    /**
+     * Icon that will be placed before button text.
+     */
+    iconSize: {
+      required: false,
+      type: String,
+      default: 'small',
+      validator: prop => ['small', 'medium', 'large'].includes(prop)
     },
 
     /**


### PR DESCRIPTION
To be more flexible when using the DpButton Component for clickable Icons, we have to make use of the different icon sizes which DpIcon allready provides.