### PR TITLE
fix: use correct translation values

### DIFF
--- a/tests/form/DpSelect.spec.js
+++ b/tests/form/DpSelect.spec.js
@@ -1,4 +1,5 @@
 import DpSelect from '../../src/components/DpSelect/DpSelect'
+import { de } from '../../src/components/shared/translations'
 import { runBooleanAttrTests } from './shared/Attributes'
 import shallowMountWithGlobalMocks from '../../jest/shallowMountWithGlobalMocks'
 
@@ -23,7 +24,7 @@ describe('DpSelect', () => {
   runBooleanAttrTests(wrapper, select, 'disabled')
 
   it('displays a placeholder if showPlaceholder is true', () => {
-    const placeholder = 'somePlaceholder'
+    const placeholder = de.selectPlaceholder
     const componentWrapper = shallowMountWithGlobalMocks(DpSelect, {
       propsData: {
         options,
@@ -38,7 +39,7 @@ describe('DpSelect', () => {
   })
 
   it('does not display a placeholder if showPlaceholder is false', () => {
-    const placeholder = 'somePlaceholder'
+    const placeholder = de.selectPlaceholder
     const componentWrapper = shallowMountWithGlobalMocks(DpSelect, {
       propsData: {
         options,


### PR DESCRIPTION
We broke the test by changing the value of the placeholder option. Now we use the translation file to not have to duplicate strings here.