### PR TITLE
Tweak z-index var names + values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Changed
+
+- ([#381](https://github.com/demos-europe/demosplan-ui/pull/381)) Change z-index values and var names to match Tailwind convention ([@spiess-demos](https://github.com/spiess-demos))
+
 ### Added
+
 - ([#291](https://github.com/demos-europe/demosplan-ui/pull/291)) Add Typescript Config ([@ahmad-demos](https://github.com/ahmad-demos))
 
 ## v0.1.10 - 2023-17-07

--- a/buildTokens.js
+++ b/buildTokens.js
@@ -23,6 +23,11 @@ StyleDictionary.registerTransform({
     if (token.path[0] === 'color' || token.path[0] === 'font-size') {
       token.path.splice(1, 1)
     }
+    // The key "z-index" should be shortened in the variable name to match Tailwind syntax
+    if (token.path[0] === 'z-index') {
+      token.path[0] = 'z'
+    }
+    // "DEFAULT" is a Tailwind convention that should not be part of the Scss name
     if (token.path[1] === 'DEFAULT') {
       token.path.splice(1, 1)
     }

--- a/src/components/DpStickyElement/DpStickyElement.vue
+++ b/src/components/DpStickyElement/DpStickyElement.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="{'o-sticky--border': border, 'u-z-fixed': applyZIndex}"
+    :class="{'o-sticky--border': border, 'z-fixed': applyZIndex}"
     class="o-sticky bg-color--white">
     <slot />
   </div>

--- a/tokens/src/zIndex.json
+++ b/tokens/src/zIndex.json
@@ -2,7 +2,7 @@
   "z-index": {
     "below-zero": {
       "$description": "Stack an element behind elements that do not have a stacking order applied.",
-      "value": "-1"
+      "value": "-10"
     },
     "zero": {
       "$description": "Stack an element on the default layer.",
@@ -10,7 +10,7 @@
     },
     "above-zero": {
       "$description": "Stack an element above elements that do not have a stacking order applied, but below elements with other z-indexes applied.",
-      "value": "1"
+      "value": "10"
     },
     "tooltip": {
       "$description": "Use for tooltip components.",

--- a/tokens/tokens.zIndex.stories.mdx
+++ b/tokens/tokens.zIndex.stories.mdx
@@ -16,14 +16,14 @@ import { Meta } from '@storybook/addon-docs'
 To be able to manage stacking order within demosplan UI, the following global z-index variables can be used:
 
 ```
-$dp-z-index-ultimate
-$dp-z-index-modal
-$dp-z-index-fixed
-$dp-z-index-flyout
-$dp-z-index-tooltip
-$dp-z-index-above-zero
-$dp-z-index-zero
-$dp-z-index-below-zero
+$dp-z-ultimate
+$dp-z-modal
+$dp-z-fixed
+$dp-z-flyout
+$dp-z-tooltip
+$dp-z-above-zero
+$dp-z-zero
+$dp-z-below-zero
 ```
 
 ## How to use z-index tokens
@@ -45,7 +45,7 @@ Then, tokens can be used within Scss code:
 
 ```
 .flyout-container {
-  z-index: $dp-z-index-flyout;
+  z-index: $dp-z-flyout;
 }
 ```
 


### PR DESCRIPTION
- adapt utility classes to Tailwind naming
- use -10/+10 for z-indexes around zero to acommodate for the fact that there will be cases where users may squeeze something in there
- shorten scss var name according to the respective Tailwind naming