### PR TITLE
Fix(T34111): permanently opened dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Changed
 
+- ([#409](https://github.com/demos-europe/demosplan-ui/pull/409)) Change the way to show/hide the dropdown menu in DpTimePicker by using the 'hidden' class instead of the 'v-show' directive ([@sakutademos](https://github.com/sakutademos))
 - ([#381](https://github.com/demos-europe/demosplan-ui/pull/381)) Change z-index values and var names to match Tailwind convention ([@spiess-demos](https://github.com/spiess-demos))
 
 ### Added

--- a/src/components/DpTimePicker/DpTimePicker.vue
+++ b/src/components/DpTimePicker/DpTimePicker.vue
@@ -35,8 +35,8 @@
 
     <div
       ref="flyout"
-      v-show="showFlyout"
       class="flex items-start justify-evenly c-timepicker__flyout font-size-small"
+      :class="{ 'hidden': !showFlyout }"
       tabindex="0">
       <ul class="u-m-0_25 u-mr-0 u-pr-0_25 overflow-y-scroll height-130">
         <li


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34111

**Description:** This PR fixes issue with the permanently opened dropdown menu. After adding Tailwind CSS and adjusting new classes, the v-show directive with the style `'display: none;'` does not win in the specificity hierarchy. As a result, it has no impact on the flyout element:
- add a `hidden` class from the Tailwind library when the showFlyout variable has a negative value.