### PR TITLE
chore: fix Validate directive in DpMultiselect.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Changed
 
+- ([#412](https://github.com/demos-europe/demosplan-ui/pull/412)) Adjust dpValidate directive in DpMultiselect ([@ahmad-demos](https://github.com/@ahmad-demos))
 - ([#381](https://github.com/demos-europe/demosplan-ui/pull/381)) Change z-index values and var names to match Tailwind convention ([@spiess-demos](https://github.com/spiess-demos))
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+
+- ([#412](https://github.com/demos-europe/demosplan-ui/pull/412)) Import missing directive in DpMultiselect ([@ahmad-demos](https://github.com/@ahmad-demos))
+
 ### Changed
 
-- ([#412](https://github.com/demos-europe/demosplan-ui/pull/412)) Adjust dpValidate directive in DpMultiselect ([@ahmad-demos](https://github.com/@ahmad-demos))
 - ([#381](https://github.com/demos-europe/demosplan-ui/pull/381)) Change z-index values and var names to match Tailwind convention ([@spiess-demos](https://github.com/spiess-demos))
 
 ### Added

--- a/src/components/DpMultiselect/DpMultiselect.vue
+++ b/src/components/DpMultiselect/DpMultiselect.vue
@@ -83,6 +83,7 @@
 </template>
 
 <script>
+import { dpValidateMultiselectDirective } from '../../lib/validation'
 import VueMultiselect from 'vue-multiselect'
 
 export default {
@@ -90,6 +91,10 @@ export default {
 
   components: {
     VueMultiselect
+  },
+
+  directives: {
+    dpValidateMultiselectDirective
   },
 
   props: {


### PR DESCRIPTION
- fix Validate directive in DpMultiselect.

With Storybook https://github.com/demos-europe/demosplan-ui/pull/408 there was an error with dpValidate directive.
`[Vue warn]: Failed to resolve directive: dp-validate-multiselect`

See in: https://github.com/demos-europe/demosplan-ui/pull/408#discussion_r1283999579