### PR TITLE
refactor(refs T31187): remove Translator usages

### DIFF
--- a/src/components/DpContextualHelp/DpContextualHelp.vue
+++ b/src/components/DpContextualHelp/DpContextualHelp.vue
@@ -27,9 +27,9 @@ export default {
     tooltip: Tooltip
   },
 
-  computed: {
-    ariaLabel () {
-      return de.contextualHelp
+  data () {
+    return {
+      ariaLabel: de.contextualHelp
     }
   }
 }

--- a/src/components/DpContextualHelp/DpContextualHelp.vue
+++ b/src/components/DpContextualHelp/DpContextualHelp.vue
@@ -1,11 +1,12 @@
 <template>
   <i
     class="fa fa-question-circle"
-    :aria-label="Translator.trans('contextual.help')"
+    :aria-label="ariaLabel"
     v-tooltip="text" />
 </template>
 
 <script>
+import { de } from '../shared/translations'
 import { Tooltip } from '../../directives'
 
 export default {
@@ -24,6 +25,12 @@ export default {
 
   directives: {
     tooltip: Tooltip
+  },
+
+  computed: {
+    ariaLabel () {
+      return de.contextualHelp
+    }
   }
 }
 </script>

--- a/src/components/DpDataTable/DpColumnSelector.vue
+++ b/src/components/DpDataTable/DpColumnSelector.vue
@@ -3,7 +3,7 @@
     :has-menu="false"
     @close="trackSelection">
     <template v-slot:trigger>
-      <span>{{ Translator.trans('table.cols.select') }}</span>
+      <span v-text="triggerText" />
       <i
         class="fa fa-caret-down u-ml-0_25"
         aria-hidden="true" />
@@ -25,10 +25,12 @@
 <script>
 import DpCheckbox from '../DpCheckbox/DpCheckbox'
 import DpFlyout from '../DpFlyout/DpFlyout'
+import { de } from '../shared/translations'
 import { hasOwnProp } from '../../utils'
 
 export default {
   name: 'DpColumnSelector',
+
   components: {
     DpCheckbox,
     DpFlyout
@@ -56,11 +58,19 @@ export default {
       default: false
     }
   },
+
   data () {
     return {
       selectedColumns: new Set()
     }
   },
+
+  computed: {
+    triggerText () {
+      return de.table.colsSelect
+    }
+  },
+
   methods: {
     broadcastSelection (column, shouldCheck = null) {
       if (shouldCheck === true) {

--- a/src/components/DpDataTable/DpColumnSelector.vue
+++ b/src/components/DpDataTable/DpColumnSelector.vue
@@ -61,13 +61,8 @@ export default {
 
   data () {
     return {
-      selectedColumns: new Set()
-    }
-  },
-
-  computed: {
-    triggerText () {
-      return de.table.colsSelect
+      selectedColumns: new Set(),
+      triggerText: de.table.colsSelect
     }
   },
 

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -170,7 +170,8 @@
 </template>
 
 <script>
-import { CleanHtml } from '../../directives/CleanHtml/CleanHtml'
+import { CleanHtml } from '../../directives'
+import { de } from '../shared/translations'
 import DomPurify from 'dompurify'
 import DpDraggable from '../DpDraggable/DpDraggable'
 import DpLoading from '../DpLoading/DpLoading'
@@ -381,7 +382,7 @@ export default {
         headerSelectHint: Translator.trans('aria.select.all'),
         lockedForSelection: Translator.trans('item.lockedForSelection'),
         searchNoResults: (searchTerm) => Translator.trans('search.no.results', { searchterm: searchTerm }),
-        tableLoadingData: Translator.trans('loading.data'),
+        tableLoadingData: de.loadingData,
         tableNoElements: Translator.trans('explanation.noentries')
       },
       elementSelections: {},

--- a/src/components/DpLabel/DpLabel.vue
+++ b/src/components/DpLabel/DpLabel.vue
@@ -74,10 +74,13 @@ export default {
     }
   },
 
+  data () {
+    return {
+      ariaLabel: de.contextualHelp
+    }
+  },
+
   computed: {
-    ariaLabel () {
-      return de.contextualHelp
-    },
     /**
      * List of Hints
      *

--- a/src/components/DpModal/DpModal.vue
+++ b/src/components/DpModal/DpModal.vue
@@ -13,8 +13,8 @@
         role="dialog">
         <button
           :class="prefixClass('btn--blank o-link--default absolute u-right-0')"
-          :aria-label="Translator.trans('close.window')"
-          :title="Translator.trans('close.window')"
+          :aria-label="title"
+          :title="title"
           @click.prevent.stop="toggle()">
           <dp-icon
             icon="close"
@@ -44,6 +44,7 @@
 
 <script>
 import DpIcon from '../DpIcon/DpIcon'
+import { de } from '../shared/translations'
 import { prefixClassMixin } from '../../mixins'
 
 export default {
@@ -99,6 +100,10 @@ export default {
   computed: {
     hasHeader () {
       return typeof this.$slots.header !== 'undefined'
+    },
+
+    title () {
+      return de.window.close
     }
   },
 

--- a/src/components/DpModal/DpModal.vue
+++ b/src/components/DpModal/DpModal.vue
@@ -93,17 +93,14 @@ export default {
     return {
       isOpenModal: false,
       lastFocusedElement: '',
-      focusableElements: []
+      focusableElements: [],
+      title: de.window.close
     }
   },
 
   computed: {
     hasHeader () {
       return typeof this.$slots.header !== 'undefined'
-    },
-
-    title () {
-      return de.window.close
     }
   },
 

--- a/src/components/DpMultiselect/DpMultiselect.vue
+++ b/src/components/DpMultiselect/DpMultiselect.vue
@@ -255,9 +255,9 @@ export default {
     }
   },
 
-  computed: {
-    translations () {
-      return {
+  data () {
+    return {
+      translations: {
         deselectAll: de.deselect.all,
         selectAll: de.select.all
       }

--- a/src/components/DpMultiselect/DpMultiselect.vue
+++ b/src/components/DpMultiselect/DpMultiselect.vue
@@ -65,7 +65,7 @@
             class="btn--blank weight--bold u-ph-0_5 u-pv-0_25"
             :disabled="value.length === options.length === 0"
             type="button"
-            v-text="Translator.trans('select.all')"
+            v-text="translations.selectAll"
             @click="$emit('select-all')">
           </button>
 
@@ -73,7 +73,7 @@
             class="btn--blank weight--bold u-ph-0_5 u-pv-0_25"
             :disabled="value.length === 0"
             type="button"
-            v-text="Translator.trans('unselect.all')"
+            v-text="translations.deselectAll"
             @click="$emit('unselect-all')">
           </button>
         </div>
@@ -83,6 +83,7 @@
 </template>
 
 <script>
+import { de } from '../shared/translations'
 import { dpValidateMultiselectDirective } from '../../lib/validation'
 import VueMultiselect from 'vue-multiselect'
 
@@ -251,6 +252,15 @@ export default {
       type: [String, Number, Array, Object],
       required: false,
       default: ''
+    }
+  },
+
+  computed: {
+    translations () {
+      return {
+        deselectAll: de.deselect.all,
+        selectAll: de.select.all
+      }
     }
   }
 }

--- a/src/components/DpSelect/DpSelect.vue
+++ b/src/components/DpSelect/DpSelect.vue
@@ -119,11 +119,13 @@ export default {
     }
   },
 
-  computed: {
-    selectPlaceholder () {
-      return de.selectPlaceholder
-    },
+  data () {
+    return {
+      selectPlaceholder: de.selectPlaceholder
+    }
+  },
 
+  computed: {
     nameOrId () {
       /*
        * As long as there is no necessity of having the id to differ from name,

--- a/src/components/DpTreeList/DpTreeListCheckbox.vue
+++ b/src/components/DpTreeList/DpTreeListCheckbox.vue
@@ -13,6 +13,8 @@
 </template>
 
 <script>
+import { de } from '../shared/translations'
+
 export default {
   name: 'DpTreeListCheckbox',
 
@@ -50,10 +52,10 @@ export default {
   computed: {
     label () {
       if (this.checkAll) {
-        return this.toggleCheckedStatus('aria.deselect_all', 'aria.select.all')
+        return this.toggleCheckedStatus(de.deselect.all, 'aria.select.all')
       }
 
-      return this.toggleCheckedStatus('aria.deselect', 'aria.select')
+      return this.toggleCheckedStatus(de.aria.deselect.element, de.aria.select.element)
     }
   },
 

--- a/src/components/core/DpAnonymizeText.vue
+++ b/src/components/core/DpAnonymizeText.vue
@@ -12,13 +12,13 @@
           v-if="isActive.anonymize()"
           class="editor-menububble__button is-active"
           @click="commands.unanonymize">
-          {{ Translator.trans('statement.anonymize.unmark') }}
+          {{ translations.unanonymize }}
         </a>
         <a
           v-else
           class="editor-menububble__button"
           @click="commands.anonymize">
-          {{ Translator.trans('statement.anonymize.mark') }}
+          {{ translations.anonymize }}
         </a>
       </div>
     </editor-menu-bubble>
@@ -34,6 +34,7 @@
 </template>
 
 <script>
+import { de } from '../shared/translations'
 import {
   Bold,
   BulletList,
@@ -69,6 +70,15 @@ export default {
   data () {
     return {
       editor: null
+    }
+  },
+
+  computed: {
+    translations () {
+      return {
+        anonymize: de.anonymization.mark,
+        unanonymize: de.anonymization.unmark
+      }
     }
   },
 

--- a/src/components/core/DpAnonymizeText.vue
+++ b/src/components/core/DpAnonymizeText.vue
@@ -69,13 +69,8 @@ export default {
 
   data () {
     return {
-      editor: null
-    }
-  },
-
-  computed: {
-    translations () {
-      return {
+      editor: null,
+      translations: {
         anonymize: de.anonymization.mark,
         unanonymize: de.anonymization.unmark
       }

--- a/src/components/core/DpEditor/DpEditor.vue
+++ b/src/components/core/DpEditor/DpEditor.vue
@@ -616,7 +616,12 @@ export default {
          */
         table: false,
         textDecoration: true
-      }, this.toolbarItems)
+      }, this.toolbarItems),
+      translations: {
+        ...de.editor,
+        insertImage: de.image.insert,
+        obscureTitle: de.obscure.title
+      }
     }
   },
 
@@ -632,14 +637,6 @@ export default {
 
     obscureEnabled () {
       return this.toolbar.obscure
-    },
-
-    translations () {
-      return {
-        ...de.editor,
-        insertImage: de.image.insert,
-        obscureTitle: de.obscure.title
-      }
     }
   },
 

--- a/src/components/core/DpEditor/DpEditor.vue
+++ b/src/components/core/DpEditor/DpEditor.vue
@@ -32,8 +32,8 @@
                 @click="cut"
                 :class="prefixClass('menubar__button')"
                 type="button"
-                :aria-label="Translator.trans('editor.cut')"
-                v-tooltip="Translator.trans('editor.cut')"
+                :aria-label="translations.cut"
+                v-tooltip="translations.cut"
                 :disabled="readonly">
                 <i
                   :class="prefixClass('fa fa-scissors')"
@@ -45,8 +45,8 @@
                 @click="commands.undo"
                 :class="prefixClass('menubar__button')"
                 type="button"
-                :aria-label="Translator.trans('editor.undo')"
-                v-tooltip="Translator.trans('editor.undo')"
+                :aria-label="translations.undo"
+                v-tooltip="translations.undo"
                 :disabled="readonly">
                 <i
                   :class="prefixClass('fa fa-reply')"
@@ -57,8 +57,8 @@
                 @click="commands.redo"
                 :class="prefixClass('menubar__button')"
                 type="button"
-                :aria-label="Translator.trans('editor.redo')"
-                v-tooltip="Translator.trans('editor.redo')"
+                :aria-label="translations.redo"
+                v-tooltip="translations.redo"
                 :disabled="readonly">
                 <i
                   :class="prefixClass('fa fa-share')"
@@ -72,8 +72,8 @@
                   @click="commands.bold"
                   :class="[isActive.bold() ? prefixClass('is-active'): '', prefixClass('menubar__button')]"
                   type="button"
-                  :aria-label="Translator.trans('editor.bold')"
-                  v-tooltip="Translator.trans('editor.bold')"
+                  :aria-label="translations.bold"
+                  v-tooltip="translations.bold"
                   :disabled="readonly">
                   <i
                     :class="prefixClass('fa fa-bold')"
@@ -85,8 +85,8 @@
                   @click="commands.italic"
                   :class="[isActive.italic() ? prefixClass('is-active') : '', prefixClass('menubar__button') ]"
                   type="button"
-                  :aria-label="Translator.trans('editor.italic')"
-                  v-tooltip="Translator.trans('editor.italic')"
+                  :aria-label="translations.italic"
+                  v-tooltip="translations.italic"
                   :disabled="readonly">
                   <i
                     :class="prefixClass('fa fa-italic')"
@@ -97,8 +97,8 @@
                   @click="commands.underline"
                   :class="[isActive.underline() ? prefixClass('is-active') : '', prefixClass('menubar__button')]"
                   type="button"
-                  :aria-label="Translator.trans('editor.underline')"
-                  v-tooltip="Translator.trans('editor.underline')"
+                  :aria-label="translations.underline"
+                  v-tooltip="translations.underline"
                   :disabled="readonly">
                   <i
                     :class="prefixClass('fa fa-underline')"
@@ -214,7 +214,7 @@
                 @click="commands.obscure"
                 :class="[isActive.obscure() ? prefixClass('is-active') : '', prefixClass('menubar__button')]"
                 type="button"
-                v-tooltip="Translator.trans('obscure.title')"
+                v-tooltip="translations.obscureTitle"
                 :disabled="readonly">
                 <i
                   :class="prefixClass('fa fa-pencil-square')"
@@ -236,7 +236,7 @@
                 @click.stop="openUploadModal(null)"
                 :class="prefixClass('menubar__button')"
                 type="button"
-                v-tooltip="Translator.trans('image.insert')"
+                v-tooltip="translations.insertImage"
                 :disabled="readonly">
                 <i
                   :class="prefixClass('fa fa-picture-o')" />
@@ -314,6 +314,7 @@
 </template>
 
 <script>
+import { de } from '../../shared/translations'
 import {
   Bold,
   BulletList,
@@ -631,6 +632,14 @@ export default {
 
     obscureEnabled () {
       return this.toolbar.obscure
+    },
+
+    translations () {
+      return {
+        ...de.editor,
+        insertImage: de.image.insert,
+        obscureTitle: de.obscure.title
+      }
     }
   },
 

--- a/src/components/core/DpEditor/DpLinkModal.vue
+++ b/src/components/core/DpEditor/DpLinkModal.vue
@@ -71,6 +71,13 @@ export default {
       isVisible: false,
       newTab: false,
       text: '',
+      translations: {
+        linkEdit: de.editor.link.edit,
+        linkHint: de.editor.link.hint,
+        linkInsert: de.editor.link.insert,
+        linkText: de.link.text,
+        newTab: de.tab.openNew
+      },
       url: ''
     }
   },
@@ -78,16 +85,6 @@ export default {
   computed: {
     hasLink () {
       return this.initUrl !== ''
-    },
-
-    translations () {
-      return {
-        linkEdit: de.editor.link.edit,
-        linkHint: de.editor.link.hint,
-        linkInsert: de.editor.link.insert,
-        linkText: de.link.text,
-        newTab: de.tab.openNew
-      }
     }
   },
 

--- a/src/components/core/DpEditor/DpLinkModal.vue
+++ b/src/components/core/DpEditor/DpLinkModal.vue
@@ -6,21 +6,21 @@
     @modal:toggled="setVisible">
     <template>
       <h3>
-        {{ Translator.trans(hasLink ? 'editor.link.edit' : 'editor.link.insert') }}
+        {{ hasLink ? translations.linkEdit : translations.linkInsert }}
       </h3>
       <div class="space-stack-m">
         <dp-input
           id="link_text"
           v-model="text"
           :label="{
-            text: Translator.trans('link.text')
+            text: translations.linkText
           }"
           :required="isVisible" />
         <dp-input
           id="link_url"
           v-model="url"
           :label="{
-            hint: Translator.trans('editor.link.url.formatHint'),
+            hint: translations.linkHint,
             text: Translator.trans('url')
           }"
           :pattern="isVisible === true ? '(^https?://.*|^//.*)' : null"
@@ -30,7 +30,7 @@
           id="newTab"
           v-model="newTab"
           :label="{
-            text: Translator.trans('open.in.new.tab')
+            text: translations.newTab
           }" />
         <dp-button-row
           class="u-mt"
@@ -50,6 +50,7 @@ import DpButtonRow from '../../DpButtonRow/DpButtonRow'
 import DpCheckbox from '../../DpCheckbox/DpCheckbox'
 import DpInput from '../../DpInput/DpInput'
 import DpModal from '../../DpModal/DpModal'
+import { de } from '../../shared/translations'
 import { dpValidateMixin } from '../../../mixins'
 
 export default {
@@ -77,6 +78,16 @@ export default {
   computed: {
     hasLink () {
       return this.initUrl !== ''
+    },
+
+    translations () {
+      return {
+        linkEdit: de.editor.link.edit,
+        linkHint: de.editor.link.hint,
+        linkInsert: de.editor.link.insert,
+        linkText: de.link.text,
+        newTab: de.tab.openNew
+      }
     }
   },
 

--- a/src/components/core/DpEditor/DpResizableImage.vue
+++ b/src/components/core/DpEditor/DpResizableImage.vue
@@ -16,6 +16,7 @@
 </template>
 
 <script>
+import { de } from '../../shared/translations'
 import { v4 as uuid } from 'uuid'
 
 export default {
@@ -62,7 +63,7 @@ export default {
   data () {
     return {
       id: uuid(),
-      imageTitle: Translator.trans('image.alt.edit.hint'),
+      imageTitle: de.image.alt.editHint,
       observer: null,
       ratioFactor: 1
     }

--- a/src/components/core/DpEditor/DpUploadModal.vue
+++ b/src/components/core/DpEditor/DpUploadModal.vue
@@ -6,12 +6,12 @@
       <h3
         v-if="editAltTextOnly"
         class="u-mb">
-        {{ Translator.trans('image.edit') }}
+        {{ translations.editImage }}
       </h3>
       <h3
         v-else
         class="u-mb">
-        {{ Translator.trans('image.insert') }}
+        {{ translations.insertImage }}
       </h3>
       <div v-show="editAltTextOnly === false">
         <dp-upload-files
@@ -21,7 +21,7 @@
           :max-file-size="20 * 1024 * 1024/* 20 MiB */"
           :max-number-of-files="1"
           ref="uploader"
-          :translations="{ dropHereOr: Translator.trans('form.button.upload.image', { browse: '{browse}', maxUploadSize: '20MB' }) }"
+          :translations="{ dropHereOr: translations.uploadImage('20MB')}"
           @upload-success="setFile" />
       </div>
       <dp-input
@@ -29,8 +29,8 @@
         v-model="altText"
         class="u-mb"
         :label="{
-          hint: Translator.trans('image.alt.explanation'),
-          text: Translator.trans('alternative.text')
+          hint: translations.altTextHint,
+          text: translations.altText,
         }" />
       <div class="u-mt text--right width-100p space-inline-s">
         <button
@@ -51,6 +51,7 @@
 </template>
 
 <script>
+import { de } from '../../shared/translations'
 import DpInput from '../../DpInput/DpInput'
 import DpModal from '../../DpModal/DpModal'
 import DpUploadFiles from '../DpUpload/DpUploadFiles'
@@ -76,6 +77,18 @@ export default {
       fileUrl: '',
       altText: '',
       editAltTextOnly: false
+    }
+  },
+
+  computed: {
+    translations() {
+      return {
+        altText: de.altText.default,
+        altTextHint: de.image.alt.explanation,
+        editImage: de.image.edit,
+        insertImage: de.image.insert,
+        uploadImage: de.upload.select.image
+      }
     }
   },
 

--- a/src/components/core/DpEditor/DpUploadModal.vue
+++ b/src/components/core/DpEditor/DpUploadModal.vue
@@ -76,13 +76,8 @@ export default {
     return {
       fileUrl: '',
       altText: '',
-      editAltTextOnly: false
-    }
-  },
-
-  computed: {
-    translations() {
-      return {
+      editAltTextOnly: false,
+      translations: {
         altText: de.altText.default,
         altTextHint: de.image.alt.explanation,
         editImage: de.image.edit,

--- a/src/components/core/DpEditor/libs/editorCustomDelete.js
+++ b/src/components/core/DpEditor/libs/editorCustomDelete.js
@@ -1,3 +1,4 @@
+import { de } from '../../../shared/translations'
 import { Mark } from 'tiptap'
 import { toggleMark } from 'tiptap-commands'
 
@@ -13,7 +14,7 @@ export default class EditorCustomDelete extends Mark {
           tag: 'del'
         }
       ],
-      toDOM: () => ['del', { title: Translator.trans('text.deleted') }, 0]
+      toDOM: () => ['del', { title: de.text.deleted }, 0]
     }
   }
 

--- a/src/components/core/DpEditor/libs/editorCustomInsert.js
+++ b/src/components/core/DpEditor/libs/editorCustomInsert.js
@@ -1,3 +1,4 @@
+import { de } from '../../../shared/translations'
 import { Mark } from 'tiptap'
 import { toggleMark } from 'tiptap-commands'
 
@@ -13,7 +14,7 @@ export default class EditorCustomInsert extends Mark {
           tag: 'ins'
         }
       ],
-      toDOM: () => ['ins', { title: Translator.trans('text.inserted') }, 0]
+      toDOM: () => ['ins', { title: de.text.inserted }, 0]
     }
   }
 

--- a/src/components/core/DpEditor/libs/editorCustomMark.js
+++ b/src/components/core/DpEditor/libs/editorCustomMark.js
@@ -1,3 +1,4 @@
+import { de } from '../../../shared/translations'
 import { Mark } from 'tiptap'
 import { toggleMark } from 'tiptap-commands'
 
@@ -13,7 +14,7 @@ export default class EditorCustomMark extends Mark {
           tag: 'mark'
         }
       ],
-      toDOM: () => ['mark', { title: Translator.trans('text.mark') }, 0]
+      toDOM: () => ['mark', { title: de.text.marked }, 0]
     }
   }
 

--- a/src/components/core/DpObscure.vue
+++ b/src/components/core/DpObscure.vue
@@ -12,9 +12,9 @@ import { de } from '../shared/translations'
 export default {
   name: 'DpObscure',
 
-  computed: {
-    title () {
-      return de.obscure.title
+  data () {
+    return {
+      title: de.obscure.title
     }
   }
 }

--- a/src/components/core/DpObscure.vue
+++ b/src/components/core/DpObscure.vue
@@ -1,13 +1,21 @@
 <template>
   <span
     class="u-obscure"
-    :title="Translator.trans('obscure.title')">
+    :title="title">
     <slot />
   </span>
 </template>
 
 <script>
+import { de } from '../shared/translations'
+
 export default {
-  name: 'DpObscure'
+  name: 'DpObscure',
+
+  computed: {
+    title () {
+      return de.obscure.title
+    }
+  }
 }
 </script>

--- a/src/components/core/DpUpload/DpUploadedFile.vue
+++ b/src/components/core/DpUpload/DpUploadedFile.vue
@@ -51,6 +51,14 @@ export default {
     }
   },
 
+  data () {
+    return {
+      translations: {
+        removeFile: de.file.remove
+      }
+    }
+  },
+
   computed: {
     fileIcon () {
       const icon = this.file.mimeType === 'txt' ? 'fa-file-text-o' : 'fa-folder-o'
@@ -64,12 +72,6 @@ export default {
     isImage () {
       const imageTypes = ['png', 'jpg', 'gif', 'bmp', 'ico', 'tiff', 'svg']
       return typeof imageTypes.find(type => type === this.file.mimeType) !== 'undefined'
-    },
-
-    translations () {
-      return {
-        removeFile: de.file.remove
-      }
     }
   },
 

--- a/src/components/core/DpUpload/DpUploadedFile.vue
+++ b/src/components/core/DpUpload/DpUploadedFile.vue
@@ -22,7 +22,7 @@
       <button
         type="button"
         :class="prefixClass('btn-icns u-m-0')"
-        :aria-label="Translator.trans('file.remove')"
+        :aria-label="translations.removeFile"
         @click="removeFile">
         <i
           :class="prefixClass('fa fa-trash')"
@@ -34,6 +34,7 @@
 
 <script>
 import { convertSize } from '../../../lib'
+import { de } from './utils/UppyTranslations'
 import { prefixClassMixin } from '../../../mixins'
 
 export default {
@@ -63,6 +64,12 @@ export default {
     isImage () {
       const imageTypes = ['png', 'jpg', 'gif', 'bmp', 'ico', 'tiff', 'svg']
       return typeof imageTypes.find(type => type === this.file.mimeType) !== 'undefined'
+    },
+
+    translations () {
+      return {
+        removeFile: de.file.remove
+      }
     }
   },
 

--- a/src/components/core/DpUpload/DpUploadedFile.vue
+++ b/src/components/core/DpUpload/DpUploadedFile.vue
@@ -34,7 +34,7 @@
 
 <script>
 import { convertSize } from '../../../lib'
-import { de } from './utils/UppyTranslations'
+import { de } from '../../shared/translations'
 import { prefixClassMixin } from '../../../mixins'
 
 export default {

--- a/src/components/core/DpUpload/utils/UppyTranslations.js
+++ b/src/components/core/DpUpload/utils/UppyTranslations.js
@@ -1,4 +1,6 @@
 import { convertSize } from '../../../../lib'
+import { de as german } from '../../../shared/translations'
+
 const de = () => {
   return {
     strings: {
@@ -10,11 +12,9 @@ const de = () => {
         browse: '{browse}',
         maxUploadSize: convertSize('GB', window.dplan.settings.maxUploadSize)
       }),
-      failedToUpload: Translator.trans('form.button.upload.failed', {
-        file: '{file}'
-      }),
+      failedToUpload: german.upload.failed,
       // This string is clickable and opens the system file selection dialog.
-      browse: Translator.trans('form.button.upload.search')
+      browse: german.computer
     }
   }
 }

--- a/src/components/shared/translations.js
+++ b/src/components/shared/translations.js
@@ -2,9 +2,13 @@ const de = {
   contextualHelp: 'Kontexthilfe',
   loadingData: 'Daten werden geladen...',
   selectPlaceholder: 'Bitte wählen Sie einen Eintrag aus.',
-  errorMandatoryFieldsIntro: 'Bitte korrigieren Sie Ihre Eingabe in folgenden Feldern: ',
-  errorMandatoryFieldsOutro: '. Erst dann können Sie Ihre Angaben speichern.',
-  errorMandatoryFieldsDefault: 'Bitte füllen Sie alle Pflichtfelder korrekt aus. Erst dann können Sie Ihre Angaben speichern.',
+  error: {
+    mandatoryFields: {
+      default: 'Bitte füllen Sie alle Pflichtfelder korrekt aus. Erst dann können Sie Ihre Angaben speichern.',
+      intro: 'Bitte korrigieren Sie Ihre Eingabe in folgenden Feldern: ',
+      outro: '. Erst dann können Sie Ihre Angaben speichern.'
+    }
+  }
 }
 
 export { de }

--- a/src/components/shared/translations.js
+++ b/src/components/shared/translations.js
@@ -1,13 +1,101 @@
 const de = {
+  anonymization: {
+    mark: 'Markierung anonymisieren',
+    unmark: 'Anonymisierung aufheben'
+  },
+  altText: {
+    default: 'Alternativer Text'
+  },
+  aria: {
+    deselect: {
+      all: 'Auswahl für alle Elemente aufheben',
+      element: 'Auswahl für Element aufheben'
+    },
+    select: {
+      element: 'Element auswählen'
+    }
+  },
+  computer: 'Computer',
   contextualHelp: 'Kontexthilfe',
-  loadingData: 'Daten werden geladen...',
-  selectPlaceholder: 'Bitte wählen Sie einen Eintrag aus.',
+  deselect: {
+    all: 'Alle abwählen'
+  },
+  editor: {
+    bold: 'Fett',
+    cut: 'Ausschneiden (Strg + X)',
+    italic: 'Kursiv',
+    link: {
+      edit: 'Link bearbeiten',
+      insert: 'Link einfügen',
+      hint: 'URLs sollten mit \'https://\' beginnen.'
+    },
+    redo: 'Wiederholen',
+    underline: 'Unterstrichen',
+    undo: 'Rückgängig'
+  },
   error: {
     mandatoryFields: {
       default: 'Bitte füllen Sie alle Pflichtfelder korrekt aus. Erst dann können Sie Ihre Angaben speichern.',
       intro: 'Bitte korrigieren Sie Ihre Eingabe in folgenden Feldern: ',
       outro: '. Erst dann können Sie Ihre Angaben speichern.'
     }
+  },
+  file: {
+    remove: 'Datei entfernen'
+  },
+  image: {
+    alt: {
+      editHint: 'Strg + Klick, um den alternativen Text zu bearbeiten',
+      explanation: 'Ein Screenreader liest diesen Text anstelle des Bildes vor.'
+    },
+    edit: 'Bild bearbeiten',
+    insert: 'Bild einfügen'
+  },
+  input: {
+    text: {
+      exactlength({ requiredlength, cssClass, count }) { return `Geben Sie exakt ${requiredlength} Zeichen ein. Aktuell sind <span class="${cssClass}"> ${count} </span> Zeichen eingegeben.` },
+      maxlength({ cssClass, count, max }) { return `Noch <span class="${cssClass}"> ${count} </span> von maximal ${max} Zeichen verfügbar.`},
+      minlength({ cssClass, count, min }) { return `Noch <span class="${cssClass}"> ${count} </span> um ${min} Zeichen zu erreichen.`}
+    }
+  },
+  link: {
+    text: 'Linktext'
+  },
+  loadingData: 'Daten werden geladen...',
+  obscure: {
+    title: 'Dieser Text wurde als geschwärzt markiert, um Datenschutzrichtlinien zu entsprechen.'
+  },
+  selectPlaceholder: 'Bitte wählen Sie einen Eintrag aus.',
+  select: {
+    all: 'Alle auswählen'
+  },
+  tab: {
+    openNew: 'in neuem Tab öffnen'
+  },
+  table: {
+    colsSelect: 'Spalten auswählen'
+  },
+  text: {
+    deleted: 'Dieser Text wurde entfernt',
+    inserted: 'Dieser Text wurde hinzugefügt',
+    marked: 'markierter Text'
+  },
+  upload: {
+    failed: 'Fehler beim Upload von Datei %{file}',
+    select: {
+      image(maxUploadSize) { return `Bild zum Upload hierher ziehen oder vom %{browse} auswählen (max. ${maxUploadSize})` }
+    }
+  },
+  validation: {
+    error: {
+      city: 'Bitte verwenden Sie ausschließlich Buchstaben und Leerzeichen.',
+      email: 'Bitte geben Sie eine gültige E-Mail-Adresse an.',
+      format: 'Bitte verwenden Sie das korrekte Format.',
+      zipCode: 'Bitte geben Sie genau 5 Zahlen ein (z.B. \'12345\').'
+    }
+  },
+  window: {
+    close: 'Fenster schließen'
   }
 }
 

--- a/src/lib/validation/utils/validateInputField.js
+++ b/src/lib/validation/utils/validateInputField.js
@@ -1,4 +1,5 @@
 import { shouldValidate, toggleErrorClass } from './helpers'
+import { de } from '../../../components/shared/translations'
 import { regexp } from './validateEmail'
 
 export default function validateInput (input) {
@@ -82,16 +83,16 @@ export default function validateInput (input) {
         // Error label based on pattern
         switch (inputPattern) {
           case '^[0-9]{5}$':
-            input.setCustomValidity(Translator.trans('validation.error.zipcode'))
+            input.setCustomValidity(de.validation.error.zipCode)
             break
           case '[A-Za-zÄäÜüÖöß ]+':
-            input.setCustomValidity(Translator.trans('validation.error.city'))
+            input.setCustomValidity(de.validation.error.city)
             break
           case 'email':
-            input.setCustomValidity(Translator.trans('validation.error.email'))
+            input.setCustomValidity(de.validation.error.email)
             break
           default:
-            input.setCustomValidity(Translator.trans('validation.error.default'))
+            input.setCustomValidity(de.validation.error.format)
         }
       } else {
         input.setCustomValidity(Translator.trans('validation.error.default')) // Theoretically this must not happen hence its not that helpful

--- a/src/mixins/dpValidateMixin.js
+++ b/src/mixins/dpValidateMixin.js
@@ -51,10 +51,10 @@ export default {
 
           if (nonEmptyFieldNames.length) {
             const fieldsString = nonEmptyFieldNames ? nonEmptyFieldNames.join(', ') : ' '
-            const errorMandatoryFields = de.errorMandatoryFieldsIntro + fieldsString + de.errorMandatoryFieldsOutro
+            const errorMandatoryFields = de.error.mandatoryFields.intro + fieldsString + de.error.mandatoryFields.outro
             dplan.notify.notify('error', errorMandatoryFields)
           } else {
-            dplan.notify.notify('error', de.errorMandatoryFieldsDefault)
+            dplan.notify.notify('error', de.error.mandatoryFields.default)
           }
         }
         const firstErrorElement = form.querySelector('.' + errorClass)

--- a/src/utils/lengthHint/lengthHint.js
+++ b/src/utils/lengthHint/lengthHint.js
@@ -1,3 +1,4 @@
+import { de } from '../../components/shared/translations'
 /**
  * Return a translated hint on exact matching characters.
  * @param {Number}    currentLength Currently used character count
@@ -8,10 +9,10 @@ const exactlengthHint = (currentLength, requiredLength) => {
   const reqLength = Number(requiredLength)
 
   return reqLength
-    ? Translator.trans('input.text.exactlength.short', {
+    ? de.input.text.exactlength({
       requiredlength: requiredLength,
+      cssClass: (currentLength === reqLength) ? 'color-status-progress-text' : 'color-status-failed-text',
       count: currentLength,
-      class: (currentLength === reqLength) ? 'color-status-progress-text' : 'color-status-failed-text'
     })
     : ''
 }
@@ -31,10 +32,10 @@ const maxlengthHint = (currentLength, maxlength) => {
   const max = Number(maxlength)
 
   return max
-    ? Translator.trans('input.text.maxlength.short', {
-      max,
+    ? de.input.text.maxlength({
+      cssClass: (max - currentLength > errorThreshold) ? 'color-status-progress-text' : 'color-status-failed-text',
       count: max - currentLength,
-      class: (max - currentLength > errorThreshold) ? 'color-status-progress-text' : 'color-status-failed-text'
+      max
     })
     : ''
 }
@@ -49,10 +50,10 @@ const minlengthHint = (currentLength, minlength) => {
   const min = Number(minlength)
 
   return min
-    ? Translator.trans('input.text.minlength.short', {
-      min: min,
+    ? de.input.text.minlength({
+      cssClass: (min <= currentLength) ? 'color-status-progress-text' : 'color-status-failed-text',
       count: min - currentLength,
-      class: (min <= currentLength) ? 'color-status-progress-text' : 'color-status-failed-text'
+      min: min,
     })
     : ''
 }

--- a/tests/DpTreeListCheckbox.spec.js
+++ b/tests/DpTreeListCheckbox.spec.js
@@ -6,7 +6,7 @@ window.Translator = {
   trans: jest.fn(key => key)
 }
 
-describe('should return result aria.deselect_all when props are: checked = true, checkAll = true', () => {
+describe('should return result \'Alle abwählen\' when props are: checked = true, checkAll = true', () => {
   const wrapper = shallowMount(DpTreeListCheckbox, {
     propsData: {
       checked: true,
@@ -15,8 +15,8 @@ describe('should return result aria.deselect_all when props are: checked = true,
     }
   })
 
-  it('returns aria.deselect_all', () => {
-    expect(wrapper.vm.label).toEqual('aria.deselect_all')
+  it('returns \'Alle abwählen\'', () => {
+    expect(wrapper.vm.label).toEqual('Alle abwählen')
   })
 })
 
@@ -34,7 +34,7 @@ describe('should return result aria.select.all when props are: checked = false, 
   })
 })
 
-describe('should return result aria.deselect when props are: checked = true, checkAll = false', () => {
+describe('should return result \'Auswahl für Element aufheben\' when props are: checked = true, checkAll = false', () => {
   const wrapper = shallowMount(DpTreeListCheckbox, {
     propsData: {
       checked: true,
@@ -43,12 +43,12 @@ describe('should return result aria.deselect when props are: checked = true, che
     }
   })
 
-  it('returns aria.deselect', () => {
-    expect(wrapper.vm.label).toEqual('aria.deselect')
+  it('returns \'Auswahl für Element aufheben\'', () => {
+    expect(wrapper.vm.label).toEqual('Auswahl für Element aufheben')
   })
 })
 
-describe('should return result aria.select when props are: checked = false, checkAll = false', () => {
+describe('should return result \'Element auswählen\' when props are: checked = false, checkAll = false', () => {
   const wrapper = shallowMount(DpTreeListCheckbox, {
     propsData: {
       checked: false,
@@ -57,8 +57,8 @@ describe('should return result aria.select when props are: checked = false, chec
     }
   })
 
-  it('returns aria.select', () => {
-    expect(wrapper.vm.label).toEqual('aria.select')
+  it('returns \'Element auswählen\'', () => {
+    expect(wrapper.vm.label).toEqual('Element auswählen')
   })
 })
 

--- a/tests/Obscure.spec.js
+++ b/tests/Obscure.spec.js
@@ -25,7 +25,7 @@ describe('Obscure', () => {
         default: '<div>Slot Content</div>'
       }
     })
-    expect(slotInstance.html()).toBe('<span title="obscure.title" class="u-obscure"><div>Slot Content</div></span>')
+    expect(slotInstance.html()).toBe('<span title="Dieser Text wurde als geschwärzt markiert, um Datenschutzrichtlinien zu entsprechen." class="u-obscure"><div>Slot Content</div></span>')
 
     window.hasPermission = () => false
     slotInstance = shallowMountWithGlobalMocks(DpObscure, {
@@ -33,6 +33,6 @@ describe('Obscure', () => {
         default: '<div>Slot Content</div>'
       }
     })
-    expect(slotInstance.html()).toBe('<span title="obscure.title" class="u-obscure"><div>Slot Content</div></span>')
+    expect(slotInstance.html()).toBe('<span title="Dieser Text wurde als geschwärzt markiert, um Datenschutzrichtlinien zu entsprechen." class="u-obscure"><div>Slot Content</div></span>')
   })
 })

--- a/tests/__snapshots__/DpContextualHelp.spec.js.snap
+++ b/tests/__snapshots__/DpContextualHelp.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DpContextualHelp should render the correct html 1`] = `"<i aria-label="contextual.help" class="fa fa-question-circle has-tooltip" data-original-title="null"></i>"`;
+exports[`DpContextualHelp should render the correct html 1`] = `"<i aria-label="Kontexthilfe" class="fa fa-question-circle has-tooltip" data-original-title="null"></i>"`;


### PR DESCRIPTION
Ticket: https://yaits.demos-deutschland.de/T31187

- move all keys used in demosplan-ui that were previously defined in demosplan-core to `translations.js`
- remove Translator usages