### PR TITLE
Fix(T34173): flickering text when scrolling down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 - ([#443](https://github.com/demos-europe/demosplan-ui/pull/443)), ([#437](https://github.com/demos-europe/demosplan-ui/pull/437)) Add E2E Props ([@ahmad-demos](https://github.com/@ahmad-demos))
 
+### Changed
+
+- ([#438](https://github.com/demos-europe/demosplan-ui/pull/438)) Stickier.js: An extra check has been added wherever the function _bindBottom is called: when the value of the stickToDirection is 'top' the funciton _bindBottom will not be performed.([@sakutademos](https://github.com/sakutademos))
+
 ## v0.1.11 - 2023-08-11
 
 ### Fixed

--- a/src/components/DpTreeList/DpTreeList.vue
+++ b/src/components/DpTreeList/DpTreeList.vue
@@ -250,7 +250,7 @@ export default {
 
     // Header and Footer should be fixed to the top/bottom of the page when the TreeList exceeds the viewport height.
     initFixedControls () {
-      this.stickyHeader = new Stickier(this.$refs.header, this.$refs.treeList.$el, 0)
+      this.stickyHeader = new Stickier(this.$refs.header, this.$refs.treeList.$el, 0, 'top')
 
       if (this.$slots.footer) {
         this.stickyFooter = new Stickier(this.$refs.footer, this.$refs.treeList.$el, 0, 'bottom')

--- a/src/lib/Stickier.js
+++ b/src/lib/Stickier.js
@@ -172,11 +172,11 @@ class Stickier {
 
     // After page load, and before other conditions trigger, the element will be in its initial state
     if (this._isInitial()) {
-      if (scroll.top >= context.bottom) {
+      if (scroll.top >= context.bottom && this.stickToDirection !== 'top') {
         this._log('element context above viewport - initial position is bottom of context')
         this._bindBottom()
       } else if (scroll.top > element.top) {
-        if ((element.height + scroll.top - elementScroll) >= context.bottom) {
+        if ((element.height + scroll.top - elementScroll) >= context.bottom && this.stickToDirection !== 'top') {
           this._log('element ends below context - initial position is bottom of context')
           this._bindBottom()
         } else {
@@ -189,7 +189,7 @@ class Stickier {
         if (scroll.top <= element.top) {
           this._log('fixed element reached top of container')
           this._unsetPosition()
-        } else if ((element.height + scroll.top - elementScroll) >= context.bottom) {
+        } else if ((element.height + scroll.top - elementScroll) >= context.bottom && this.stickToDirection !== 'top') {
           this._log('fixed element reached bottom of container')
           this._bindBottom()
         } else if (doesNotFit) {
@@ -202,7 +202,7 @@ class Stickier {
         if ((scroll.bottom - element.height) <= element.top) {
           this._log('bottom fixed rail has reached top of container')
           this._unsetPosition()
-        } else if (scroll.bottom >= context.bottom) {
+        } else if (scroll.bottom >= context.bottom && this.stickToDirection !== 'top') {
           this._log('bottom fixed rail has reached bottom of container')
           this._bindBottom()
         } else if (doesNotFit) {


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34173

**Description:** This PR fixes the problem of text flickering when scrolling down. The problem arises when the element's container has limited space at the top and attempts to jump to the bottom. However, in this scenario, transitioning to the bottom is unnecessary, the element should be fixed at the top of the container. An extra check has been added wherever the function `_bindBottom` is called: when the value of the `stickToDirection` is 'top' the funciton `_bindBottom` will not be performed.

- when creating a new sticky object, set `'top'` as the value for `stickToDirection` in the DpTreeList component. 





