### PR TITLE
chore: remove unneeded tooltip.js lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "tiptap": "^1.32.2",
     "tiptap-commands": "^1.17.0",
     "tiptap-extensions": "^1.35.2",
-    "tooltip.js": "^1.3.3",
     "uuid": "^9.0.0",
     "v-tooltip": "2.1.3",
     "vue-click-outside": "^1.1.0",

--- a/src/directives/Tooltip/Tooltip.js
+++ b/src/directives/Tooltip/Tooltip.js
@@ -10,7 +10,6 @@ const VPopover = Popover
 
 /*
  * Merge custom config into default options for tooltip config.
- * The non-vue tooltip lib also uses tooltip.js, both have to be in sync.
  */
 const tooltipConfig = {
   defaultHtml: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11541,7 +11541,7 @@ polished@^4.2.2:
   dependencies:
     "@babel/runtime" "^7.17.8"
 
-popper.js@^1.0.2, popper.js@^1.16.1:
+popper.js@^1.16.1:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
   integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
@@ -14041,13 +14041,6 @@ token-stream@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/token-stream/-/token-stream-1.0.0.tgz#cc200eab2613f4166d27ff9afc7ca56d49df6eb4"
   integrity sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==
-
-tooltip.js@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/tooltip.js/-/tooltip.js-1.3.3.tgz#2ad0d77bb6776a76e117eac0afcd3c7d3a237121"
-  integrity sha512-XWWuy/dBdF/F/YpRE955yqBZ4VdLfiTAUdOqoU+wJm6phJlMpEzl/iYHZ+qJswbeT9VG822bNfsETF9wzmoy5A==
-  dependencies:
-    popper.js "^1.0.2"
 
 totalist@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
The tooltip.js lib was already deprecated when moving to v-tooltip. Time to remove it.