### PR TITLE
Consolidate tooltip components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 - ([#383](https://github.com/demos-europe/demosplan-ui/pull/383)) Rework Tooltip Directive and Component ([@salisdemos](https://github.com/salisdemos))
   - Introduced DpTooltip. Please replace VPopover (now deprecated) with DpTooltip
-- () Deprecate DpTooltipIcon in favor of DpContextualHelp ([@spiess-demos](https://github.com/spiess-demos))
+- ([#462](https://github.com/demos-europe/demosplan-ui/pull/462) Deprecate DpTooltipIcon in favor of DpContextualHelp ([@spiess-demos](https://github.com/spiess-demos))
 
 ## v0.1.12 - 2023-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 - ([#383](https://github.com/demos-europe/demosplan-ui/pull/383)) Rework Tooltip Directive and Component ([@salisdemos](https://github.com/salisdemos))
   - Introduced DpTooltip. Please replace VPopover (now deprecated) with DpTooltip
+- () Deprecate DpTooltipIcon in favor of DpContextualHelp ([@spiess-demos](https://github.com/spiess-demos))
 
 ## v0.1.12 - 2023-08-18
 

--- a/src/components/DpContextualHelp/DpContextualHelp.vue
+++ b/src/components/DpContextualHelp/DpContextualHelp.vue
@@ -1,21 +1,45 @@
 <template>
-  <i
-    class="fa fa-question-circle"
+  <dp-icon
+    :icon="icon"
     :aria-label="ariaLabel"
     v-tooltip="text" />
 </template>
 
 <script>
 import { de } from '../shared/translations'
+import DpIcon from '../DpIcon/DpIcon'
+import { SIZES } from '../DpIcon/util/iconVariables'
 import { Tooltip } from '../../directives'
 
 export default {
   name: 'DpContextualHelp',
 
+  components: {
+    DpIcon
+  },
+
   props: {
     /**
-     * A translation key representing the actual tooltip content.
-     * May actually be any string including html.
+     * The icon displayed as trigger for the tooltip.
+     */
+    icon: {
+      type: String,
+      required: false,
+      default: 'question'
+    },
+
+    /**
+     * The icon size. May be small, medium, or large.
+     */
+    size: {
+      type: String,
+      required: false,
+      default: 'medium',
+      validator: (prop) => Object.keys(SIZES).includes(prop)
+    },
+
+    /**
+     * A string representing the actual tooltip content. May include html.
      */
     text: {
       type: String,

--- a/src/components/DpContextualHelp/DpContextualHelp.vue
+++ b/src/components/DpContextualHelp/DpContextualHelp.vue
@@ -1,7 +1,8 @@
 <template>
   <dp-icon
-    :icon="icon"
     :aria-label="ariaLabel"
+    :icon="icon"
+    :size="size"
     v-tooltip="text" />
 </template>
 

--- a/src/components/DpTooltipIcon/DpTooltipIcon.vue
+++ b/src/components/DpTooltipIcon/DpTooltipIcon.vue
@@ -6,6 +6,10 @@
 </template>
 
 <script>
+/**
+ * A component rendering a tooltip with an icon trigger.
+ * @deprecated Use DpContextualHelp instead.
+ */
 import { Tooltip } from '../../directives'
 
 export default {


### PR DESCRIPTION
Both DpContextualHelp and DpTooltipIcon do the same.
However, as the team agreed to go with DpContextualHelp,
it is now prepared to cater for all cases DpTooltipIcon
is used in:

- defaults to the question mark icon, but supports other icons
- defaults to medium size, but supports other icon sizes
- uses DpIcon instead of fontawesome