### PR TITLE
chore: Migrate DpTooltipIcon stories to v7.

### DIFF
--- a/src/components/DpTooltipIcon/DpTooltipIcon.stories.mdx
+++ b/src/components/DpTooltipIcon/DpTooltipIcon.stories.mdx
@@ -1,3 +1,11 @@
+import { Meta } from '@storybook/addon-docs'
+import DpTooltipIcon from './DpTooltipIcon'
+
+<Meta
+    title="Components/TooltipIcon"
+    component={DpTooltipIcon}
+/>
+
 # Tooltip Icon
 
 Renders a fontawesome Icon with a tooltip.

--- a/src/components/DpTooltipIcon/DpTooltipIcon.stories.mdx
+++ b/src/components/DpTooltipIcon/DpTooltipIcon.stories.mdx
@@ -10,6 +10,8 @@ import DpTooltipIcon from './DpTooltipIcon'
 
 Renders a fontawesome Icon with a tooltip.
 
+This component is deprecated in favor of DpContextualHelp
+
 ## Default usage
 
 ```html

--- a/src/components/DpTooltipIcon/DpTooltipIcon.stories.tsx
+++ b/src/components/DpTooltipIcon/DpTooltipIcon.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/vue'
+import DpTooltipIcon from './DpTooltipIcon.vue'
+
+const meta: Meta<typeof DpTooltipIcon> = {
+    component: DpTooltipIcon,
+    title: "Components/TooltipIcon",
+    argTypes: {}
+}
+
+export default meta
+type Story = StoryObj<typeof DpTooltipIcon>
+
+export const Default: Story = {
+    args: {
+        icon: 'fa-question-circle',
+        text: 'Content of the tooltip'
+    }
+}


### PR DESCRIPTION
https://github.com/demos-europe/demosplan-ui/pull/379

- Migrate DpTooltipIcon stories to v7.