### PR TITLE
feat(refs T27593): add tailwind to storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -7,7 +7,13 @@ module.exports = {
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",
-    "@storybook/addon-mdx-gfm"
+    "@storybook/addon-mdx-gfm",
+    {
+      name: "@storybook/addon-styling-webpack",
+      options: {
+        postCss: true,
+      },
+    },
   ],
   webpackFinal: async config => {
     /**

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import { Translator } from './translatorMock'
+import '../style/style.css'
 
 Vue.prototype.Translator = Translator
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 ### Added
 
 - ([#472](https://github.com/demos-europe/demosplan-ui/pull/472)) Add DpCard documentation to Storybook7 ([@ahmad-demos](https://github.com/@ahmad-demos))
+- ([#475](https://github.com/demos-europe/demosplan-ui/pull/475)) Add Tailwind Styles to Storybook7 ([@spiess-demos](https://github.com/spiess-demos))
 
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@storybook/addon-essentials": "7.0.27",
     "@storybook/addon-links": "7.0.27",
     "@storybook/addon-mdx-gfm": "7.0.27",
+    "@storybook/addon-styling-webpack": "^0.0.2",
     "@storybook/vue": "7.0.27",
     "@storybook/vue-webpack5": "7.0.27",
     "@types/jest": "^29.5.1",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,6 @@
 module.exports = {
-  // Add you postcss configuration here
-  // Learn more about it at https://github.com/webpack-contrib/postcss-loader#config-files
-  plugins: [["autoprefixer"]],
-};
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -39,11 +39,6 @@ module.exports = {
       })
     })
   ],
-  safelist: [
-    {
-      pattern: /./// Disable purging https://github.com/tailwindlabs/tailwindcss/discussions/6557#discussioncomment-1838214
-    }
-  ],
   theme: {
     borderRadius,
     boxShadow,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2939,6 +2939,13 @@
     "@storybook/types" "7.0.27"
     ts-dedent "^2.0.0"
 
+"@storybook/addon-styling-webpack@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-styling-webpack/-/addon-styling-webpack-0.0.2.tgz#75c2e77094c4955149f55f8dac0dde0dde2828df"
+  integrity sha512-ffbfzXITu09GJjgzrS2cxkipX+xejc1+C7fhcs6o84ci63zczEfbjjyuhenGCTwBVs/e971xpcQ8NY28d2Uu4w==
+  dependencies:
+    "@storybook/node-logger" "^7.0.12"
+
 "@storybook/addon-toolbars@7.0.27":
   version "7.0.27"
   resolved "https://registry.yarnpkg.com/@storybook/addon-toolbars/-/addon-toolbars-7.0.27.tgz#377d4ee8214561f6e174e2d68207d589f8e9f0bc"
@@ -3391,6 +3398,11 @@
     chalk "^4.1.0"
     npmlog "^5.0.1"
     pretty-hrtime "^1.0.3"
+
+"@storybook/node-logger@^7.0.12":
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-7.3.2.tgz#c8fea7b87d63c7b50757646af990d7cf13f7c71e"
+  integrity sha512-XCCYiLa5mQ7KeDQcZ4awlyWDmtxJHLIJeedvXx29JUNztUjgwyon9rlNvxtxtGj6171zgn9MERFh920WyJOOOQ==
 
 "@storybook/postinstall@7.0.27":
   version "7.0.27"


### PR DESCRIPTION
to further enable component development within storybook, tailwind styles are made available in storybook.

Most tutorials on this topic refer to the deprecated @storybook/addon-styling, however @storybook/addon-styling-webpack installs way less dependencies and seems to do the same job.

As we are now able to build tailwind in demosplan-core, we can remove the safelist hack that forced tw to render all css classes by default.