### PR TITLE
feat(refs T27593): use correct webpack config for tw

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -8,12 +8,32 @@ module.exports = {
     "@storybook/addon-links",
     "@storybook/addon-essentials",
     "@storybook/addon-mdx-gfm",
-    {
+    ({
       name: "@storybook/addon-styling-webpack",
       options: {
-        postCss: true,
-      },
-    },
+        rules: [
+          {
+            test: /\.css$/,
+            sideEffects: true,
+            use: [
+              require.resolve("style-loader"),
+              {
+                loader: require.resolve("css-loader"),
+                options: {
+                  importLoaders: 1,
+                },
+              },
+              {
+                loader: require.resolve("postcss-loader"),
+                options: {
+                  implementation: require.resolve("postcss"),
+                },
+              },
+            ],
+          },
+        ],
+      }
+    }),
   ],
   webpackFinal: async config => {
     /**

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import { Translator } from './translatorMock'
-import '../style/style.css'
+import '../style/index.css'
 
 Vue.prototype.Translator = Translator
 


### PR DESCRIPTION
the new api of addon-styling-webpack is different from the old one, so postcss must be configured more explicitly. See https://github.com/storybookjs/addon-styling-webpack/issues/1