### PR TITLE
fix(refs T34566): Pass propper Values to init Tooltips

### DIFF
--- a/src/components/DpTooltip/utils/tooltip.js
+++ b/src/components/DpTooltip/utils/tooltip.js
@@ -30,10 +30,10 @@ const hideTooltip = (tooltipEl) => {
   handleTimeoutForDestroy = setTimeout(() => deleteTooltip(tooltipEl), 3000)
 }
 
-const createTooltip = (id, el, value, container) => {
+const createTooltip = (id, el, value, container, classes) => {
   // this has to be in sync with the Template in DpTooltip
   const tooltipHtml =
-    `<div class="tooltip absolute z-below-zero " role="tooltip" id="${id}">` +
+    `<div class="tooltip absolute ${classes} z-below-zero" role="tooltip" id="${id}">` +
     `<div class="tooltip__arrow" data-tooltip-arrow></div>` +
     `<div class="tooltip__inner">${value}</div>` +
     `</div>`
@@ -65,9 +65,9 @@ const initTooltip = (el, value, options) => {
   el.addEventListener('blur', handleHideTooltip)
 }
 
-const showTooltip = async (id, wrapperEl, value, { place = 'top', container = 'body' })  => {
+const showTooltip = async (id, wrapperEl, value, { place = 'top', container = 'body', classes = '' })  => {
   if (!document.getElementById(wrapperEl.getAttribute('aria-describedby'))) {
-    createTooltip(id, wrapperEl, value, container)
+    createTooltip(id, wrapperEl, value, container, classes)
   } else {
     clearTimeout(handleTimeoutForDestroy)
   }

--- a/src/directives/Tooltip/Tooltip.js
+++ b/src/directives/Tooltip/Tooltip.js
@@ -43,7 +43,18 @@ VPopover.options = { ...VPopover.options, ...tooltipConfig }
  */
 const Tooltip = {
   inserted: function (element, binding) {
-    initTooltip(element, binding.value, { placement: 'top' })
+    let content = binding.value
+    let container = element
+
+    if (typeof binding.value === 'object') {
+      content = binding.value.content
+
+      if (binding.value.container) {
+        container = binding.value.container
+      }
+    }
+
+    initTooltip(container, content, { placement: 'top' })
   },
   unbind: function (element) {
     destroyTooltip(element)

--- a/src/directives/Tooltip/Tooltip.js
+++ b/src/directives/Tooltip/Tooltip.js
@@ -44,17 +44,21 @@ VPopover.options = { ...VPopover.options, ...tooltipConfig }
 const Tooltip = {
   inserted: function (element, binding) {
     let content = binding.value
-    let container = element
+    let options = { place: 'top' }
 
-    if (typeof binding.value === 'object') {
+    if (binding.value && typeof binding.value === 'object') {
       content = binding.value.content
 
       if (binding.value.container) {
-        container = binding.value.container
+        options = { ...options, container: binding.value.container }
+      }
+
+      if (binding.value.classes) {
+        options = { ...options, classes: binding.value.classes }
       }
     }
 
-    initTooltip(container, content, { placement: 'top' })
+    initTooltip(element, content, options)
   },
   unbind: function (element) {
     destroyTooltip(element)


### PR DESCRIPTION
**Ticket** https://yaits.demos-deutschland.de/T34566

When using the tooltip-directive It was only supportet to pass the content. 
But we also have situations, where we pass Objects with container, content or classes. 
That was forgotten when rewriting the tooltip directive. 
So we have to reimplement it now 