### PR TITLE
fix(refs T34571): Shorten Delay for destroytooltip

### DIFF
--- a/src/components/DpTooltip/utils/tooltip.js
+++ b/src/components/DpTooltip/utils/tooltip.js
@@ -30,10 +30,10 @@ const hideTooltip = (tooltipEl) => {
   handleTimeoutForDestroy = setTimeout(() => deleteTooltip(tooltipEl), 3000)
 }
 
-const createTooltip = (id, el, value, container) => {
+const createTooltip = (id, el, value, container, classes) => {
   // this has to be in sync with the Template in DpTooltip
   const tooltipHtml =
-    `<div class="tooltip absolute z-below-zero " role="tooltip" id="${id}">` +
+    `<div class="tooltip absolute ${classes} z-below-zero" role="tooltip" id="${id}">` +
     `<div class="tooltip__arrow" data-tooltip-arrow></div>` +
     `<div class="tooltip__inner">${value}</div>` +
     `</div>`
@@ -65,9 +65,9 @@ const initTooltip = (el, value, options) => {
   el.addEventListener('blur', handleHideTooltip)
 }
 
-const showTooltip = async (id, wrapperEl, value, { place = 'top', container = 'body' })  => {
+const showTooltip = async (id, wrapperEl, value, { place = 'top', container = 'body', classes = '' })  => {
   if (!document.getElementById(wrapperEl.getAttribute('aria-describedby'))) {
-    createTooltip(id, wrapperEl, value, container)
+    createTooltip(id, wrapperEl, value, container, classes)
   } else {
     clearTimeout(handleTimeoutForDestroy)
   }

--- a/src/components/DpTooltip/utils/tooltip.js
+++ b/src/components/DpTooltip/utils/tooltip.js
@@ -27,7 +27,7 @@ const hideTooltip = (tooltipEl) => {
   tooltipEl.classList.add('z-below-zero')
   tooltipEl.classList.add('opacity-0')
 
-  handleTimeoutForDestroy = setTimeout(() => deleteTooltip(tooltipEl), 3000)
+  handleTimeoutForDestroy = setTimeout(() => deleteTooltip(tooltipEl), 300)
 }
 
 const createTooltip = (id, el, value, container, classes) => {

--- a/src/directives/Tooltip/Tooltip.js
+++ b/src/directives/Tooltip/Tooltip.js
@@ -43,7 +43,18 @@ VPopover.options = { ...VPopover.options, ...tooltipConfig }
  */
 const Tooltip = {
   inserted: function (element, binding) {
-    initTooltip(element, binding.value, { placement: 'top' })
+    let content = binding.value
+    let container = element
+
+    if (typeof binding.value === 'object') {
+      content = binding.value.content
+
+      if (binding.value.container) {
+        container = binding.value.container
+      }
+    }
+
+    initTooltip(container, content, { placement: 'top' })
   },
   unbind: function (element) {
     destroyTooltip(element)

--- a/src/directives/Tooltip/Tooltip.js
+++ b/src/directives/Tooltip/Tooltip.js
@@ -44,17 +44,21 @@ VPopover.options = { ...VPopover.options, ...tooltipConfig }
 const Tooltip = {
   inserted: function (element, binding) {
     let content = binding.value
-    let container = element
+    let options = { place: 'top' }
 
-    if (typeof binding.value === 'object') {
+    if (binding.value && typeof binding.value === 'object') {
       content = binding.value.content
 
       if (binding.value.container) {
-        container = binding.value.container
+        options = { ...options, container: binding.value.container }
+      }
+
+      if (binding.value.classes) {
+        options = { ...options, classes: binding.value.classes }
       }
     }
 
-    initTooltip(container, content, { placement: 'top' })
+    initTooltip(element, content, options)
   },
   unbind: function (element) {
     destroyTooltip(element)


### PR DESCRIPTION
**Ticket** https://yaits.demos-deutschland.de/T34571

to allow clicking on Buttons where the `tooltip` has been after hovering off.
300 ms should be enough for a rebounce and for normal user interaction to
not click before the tooltip has been removed.

Actually we need this tweak only in cases, where the z-index get increased from outside
with a class that defines the z-index after `z-below-zero` in the css-file