### PR TITLE
Fix(T34571): place tooltip in the foreground 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+- ([#523](https://github.com/demos-europe/demosplan-ui/pull/523)) Added a method that checks the z-index of the parent element and appends zIndex + 1 to the style of the tooltip ([@sakutademos](https://github.com/sakutademos))
+
 ## v0.1.14 - 2023-09-07
 
 Several minor bugfixes.

--- a/src/components/DpTooltip/utils/tooltip.js
+++ b/src/components/DpTooltip/utils/tooltip.js
@@ -23,6 +23,14 @@ const destroyTooltip = (wrapperEl) => {
   deleteTooltip(tooltipEl)
 }
 
+const getZIndex = (element) => {
+  const z = window.getComputedStyle(element).getPropertyValue('z-index')
+  if (isNaN(z)) {
+    return (element.nodeName === 'HTML') ? 1 : getZIndex(element.parentNode)
+  }
+  return z
+}
+
 const hideTooltip = (tooltipEl) => {
   tooltipEl.classList.add('z-below-zero')
   tooltipEl.classList.add('opacity-0')
@@ -50,12 +58,14 @@ const initTooltip = (el, value, options) => {
   if (!value) return
 
   const id = `tooltip-${uuid()}`
+  const zIndex = getZIndex(el)
 
   handleShowTooltip = () => showTooltip(
     id,
     el,
     value,
-    options
+    options,
+    zIndex
   )
   handleHideTooltip = () => hideTooltip(document.getElementById(el.getAttribute('aria-describedby')))
 
@@ -65,7 +75,7 @@ const initTooltip = (el, value, options) => {
   el.addEventListener('blur', handleHideTooltip)
 }
 
-const showTooltip = async (id, wrapperEl, value, { place = 'top', container = 'body', classes = '' })  => {
+const showTooltip = async (id, wrapperEl, value, { place = 'top', container = 'body', classes = '' }, zIndex)  => {
   if (!document.getElementById(wrapperEl.getAttribute('aria-describedby'))) {
     createTooltip(id, wrapperEl, value, container, classes)
   } else {
@@ -90,7 +100,8 @@ const showTooltip = async (id, wrapperEl, value, { place = 'top', container = 'b
 
   Object.assign(tooltipEl.style, {
     left: `${x}px`,
-    top: `${y}px`
+    top: `${y}px`,
+    zIndex: Number(zIndex) + 1
   })
 
  /*


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34571

**Description:** There are cases when tooltips are in the modal windows and have a smaller z-index than the modal.

- added a method that checks the z-index of the parent element and appends zIndex + 1 to the style of the tooltip