### PR TITLE
Fix(T34716) tooltip update method

### DIFF
--- a/src/components/DpTooltip/utils/tooltip.js
+++ b/src/components/DpTooltip/utils/tooltip.js
@@ -78,17 +78,14 @@ const initTooltip = (el, value, options) => {
 }
 
 const showTooltip = async (id, wrapperEl, value, { place = 'top', container = 'body', classes = '' }, zIndex)  => {
-  let elementToRemove = document.getElementById(id)
-  if (elementToRemove) {
+  const existingTooltip = document.getElementById(id)
+
+  if (existingTooltip) {
+    document.querySelector(container).removeChild(existingTooltip)
     clearTimeout(handleTimeoutForDestroy)
-    document.querySelector(container).removeChild(elementToRemove)
   }
 
-  if (!document.getElementById(wrapperEl.getAttribute('aria-describedby'))) {
-    createTooltip(id, wrapperEl, value, container, classes)
-  } else {
-    clearTimeout(handleTimeoutForDestroy)
-  }
+  createTooltip(id, wrapperEl, value, container, classes)
 
   const tooltipEl = document.getElementById(id)
   const arrowEl = tooltipEl.querySelector('[data-tooltip-arrow]')
@@ -140,13 +137,16 @@ const showTooltip = async (id, wrapperEl, value, { place = 'top', container = 'b
 const updateTooltip = (elWrapper, value, options, id) => {
   if (!value) return
 
+  const zIndex = getZIndex(elWrapper)
+
   destroyTooltip(elWrapper)
 
   handleShowTooltip = () => showTooltip(
     id,
     elWrapper,
     value,
-    options
+    options,
+    zIndex
   )
   handleHideTooltip = () => hideTooltip(document.getElementById(elWrapper.getAttribute('aria-describedby')))
 

--- a/src/components/DpTooltip/utils/tooltip.js
+++ b/src/components/DpTooltip/utils/tooltip.js
@@ -32,8 +32,10 @@ const getZIndex = (element) => {
 }
 
 const hideTooltip = (tooltipEl) => {
-  tooltipEl.classList.add('z-below-zero')
-  tooltipEl.classList.add('opacity-0')
+  if (tooltipEl) {
+    tooltipEl.classList.add('z-below-zero')
+    tooltipEl.classList.add('opacity-0')
+  }
 
   handleTimeoutForDestroy = setTimeout(() => deleteTooltip(tooltipEl), 300)
 }
@@ -76,6 +78,12 @@ const initTooltip = (el, value, options) => {
 }
 
 const showTooltip = async (id, wrapperEl, value, { place = 'top', container = 'body', classes = '' }, zIndex)  => {
+  let elementToRemove = document.getElementById(id)
+  if (elementToRemove) {
+    clearTimeout(handleTimeoutForDestroy)
+    document.querySelector(container).removeChild(elementToRemove)
+  }
+
   if (!document.getElementById(wrapperEl.getAttribute('aria-describedby'))) {
     createTooltip(id, wrapperEl, value, container, classes)
   } else {
@@ -129,4 +137,23 @@ const showTooltip = async (id, wrapperEl, value, { place = 'top', container = 'b
   tooltipEl.classList.remove('opacity-0')
 }
 
-export { destroyTooltip, initTooltip }
+const updateTooltip = (elWrapper, value, options, id) => {
+  if (!value) return
+
+  destroyTooltip(elWrapper)
+
+  handleShowTooltip = () => showTooltip(
+    id,
+    elWrapper,
+    value,
+    options
+  )
+  handleHideTooltip = () => hideTooltip(document.getElementById(elWrapper.getAttribute('aria-describedby')))
+
+  elWrapper.addEventListener('mouseenter', handleShowTooltip)
+  elWrapper.addEventListener('focus', handleShowTooltip)
+  elWrapper.addEventListener('mouseleave', handleHideTooltip)
+  elWrapper.addEventListener('blur', handleHideTooltip)
+}
+
+export { destroyTooltip, initTooltip, updateTooltip }

--- a/src/directives/Tooltip/Tooltip.js
+++ b/src/directives/Tooltip/Tooltip.js
@@ -62,9 +62,7 @@ const Tooltip = {
   },
 
   update: function (element, binding) {
-    console.log('update')
     const tooltipEl = document.getElementById(element.getAttribute('aria-describedby'))
-
     let content = binding.value
     let options = { place: 'top' }
 

--- a/src/directives/Tooltip/Tooltip.js
+++ b/src/directives/Tooltip/Tooltip.js
@@ -1,5 +1,5 @@
 import { VPopover as Popover } from 'v-tooltip'
-import { destroyTooltip, initTooltip } from '../../components/DpTooltip/utils/tooltip'
+import { destroyTooltip, initTooltip, updateTooltip } from '../../components/DpTooltip/utils/tooltip'
 
 /**
  * @deprecated Use DpTooltip instead
@@ -60,6 +60,31 @@ const Tooltip = {
 
     initTooltip(element, content, options)
   },
+
+  update: function (element, binding) {
+    console.log('update')
+    const tooltipEl = document.getElementById(element.getAttribute('aria-describedby'))
+
+    let content = binding.value
+    let options = { place: 'top' }
+
+    if (binding.value && typeof binding.value === 'object') {
+      content = binding.value.content
+
+      if (binding.value.container) {
+        options = { ...options, container: binding.value.container }
+      }
+
+      if (binding.value.classes) {
+        options = { ...options, classes: binding.value.classes }
+      }
+    }
+
+    if (tooltipEl) {
+      updateTooltip(element, content, options, tooltipEl.id)
+    }
+  },
+
   unbind: function (element) {
     destroyTooltip(element)
   }


### PR DESCRIPTION
**Description:** This PR adds a method that updates the tooltip value.

- it removes the previous events from the wrapper element
- adds the showTooltip function with a new value to the wrapper
- checks if the tooltip element already exists in the HTML (if yes: removes it from the HTML and destroys the tooltip)
- creates a new tooltip with a new value
- adds new events to the wrapper element

However, it does not fix the current bug because the tooltip can only be updated if it appears in the HTML and can be found using `getElementById`.
