### PR TITLE
feat: group tiptap and storybook dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,11 @@ updates:
         time: "09:00"
         timezone: Europe/Berlin
     open-pull-requests-limit: 10
+    groups:
+      storybook:
+        patterns:
+          - "@storybook*"
+          - "storybook"
+      tiptap:
+        patterns:
+          - "@tiptap*"


### PR DESCRIPTION
All tiptap (and storybook) dependencies will have to be updated at once, otherwise things will break. So here we go.