### PR TITLE
bug(refs T34956): Fix stickier position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 - ([#624](https://github.com/demos-europe/demosplan-ui/pull/624)) Use proper import for buildSuggestion ([@salis-demos](https://github.com/salis-demos))
 - ([#621](https://github.com/demos-europe/demosplan-ui/pull/621)) Bump Vue Peer dependency to 2.5.17 ([@spiess-demos](https://github.com/spiess-demos))
 - ([#615](https://github.com/demos-europe/demosplan-ui/pull/615)) **Breaking:** Change DpBulkEditHeader Props ([@ahmad-demos](https://github.com/@ahmad-demos))
-- ([#630](https://github.com/demos-europe/demosplan-ui/pull/630)) Stickier.js: Remove extra check for stickToDirection that has been added wherever the function _bindBottom is called, because otherwise the element has not enough space and the bottom of the element is not reachable([@gruenbergerdemos](https://github.com/gruenbergerdemos))
+- ([#630](https://github.com/demos-europe/demosplan-ui/pull/630)) Stickier.js: Remove extra check for stickToDirection that has been added wherever the function _bindBottom is called, because otherwise the element has not enough space and the bottom of the element is not reachable ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
 
 ### Added
 - ([#629](https://github.com/demos-europe/demosplan-ui/pull/629)) Allow to use all available slots from vue-multiselect in DpMultiselect ([@salis-demos](https://github.com/salis-demos))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 - ([#624](https://github.com/demos-europe/demosplan-ui/pull/624)) Use proper import for buildSuggestion ([@salis-demos](https://github.com/salis-demos))
 - ([#621](https://github.com/demos-europe/demosplan-ui/pull/621)) Bump Vue Peer dependency to 2.5.17 ([@spiess-demos](https://github.com/spiess-demos))
 - ([#615](https://github.com/demos-europe/demosplan-ui/pull/615)) **Breaking:** Change DpBulkEditHeader Props ([@ahmad-demos](https://github.com/@ahmad-demos))
+- ([#630](https://github.com/demos-europe/demosplan-ui/pull/630)) Stickier.js: Remove extra check for stickToDirection that has been added wherever the function _bindBottom is called, because otherwise the element has not enough space and the bottom of the element is not reachable([@gruenbergerdemos](https://github.com/gruenbergerdemos))
 
 ### Added
 - ([#629](https://github.com/demos-europe/demosplan-ui/pull/629)) Allow to use all available slots from vue-multiselect in DpMultiselect ([@salis-demos](https://github.com/salis-demos))

--- a/src/lib/Stickier.js
+++ b/src/lib/Stickier.js
@@ -176,7 +176,7 @@ class Stickier {
         this._log('element context above viewport - initial position is bottom of context')
         this._bindBottom()
       } else if (scroll.top > element.top) {
-        if ((element.height + scroll.top - elementScroll) >= context.bottom && this.stickToDirection !== 'top') {
+        if ((element.height + scroll.top - elementScroll) >= context.bottom) {
           this._log('element ends below context - initial position is bottom of context')
           this._bindBottom()
         } else {
@@ -189,7 +189,7 @@ class Stickier {
         if (scroll.top <= element.top) {
           this._log('fixed element reached top of container')
           this._unsetPosition()
-        } else if ((element.height + scroll.top - elementScroll) >= context.bottom && this.stickToDirection !== 'top') {
+        } else if ((element.height + scroll.top - elementScroll) >= context.bottom) {
           this._log('fixed element reached bottom of container')
           this._bindBottom()
         } else if (doesNotFit) {

--- a/src/lib/Stickier.js
+++ b/src/lib/Stickier.js
@@ -172,7 +172,7 @@ class Stickier {
 
     // After page load, and before other conditions trigger, the element will be in its initial state
     if (this._isInitial()) {
-      if (scroll.top >= context.bottom && this.stickToDirection !== 'top') {
+      if (scroll.top >= context.bottom) {
         this._log('element context above viewport - initial position is bottom of context')
         this._bindBottom()
       } else if (scroll.top > element.top) {
@@ -202,7 +202,7 @@ class Stickier {
         if ((scroll.bottom - element.height) <= element.top) {
           this._log('bottom fixed rail has reached top of container')
           this._unsetPosition()
-        } else if (scroll.bottom >= context.bottom && this.stickToDirection !== 'top') {
+        } else if (scroll.bottom >= context.bottom) {
           this._log('bottom fixed rail has reached bottom of container')
           this._bindBottom()
         } else if (doesNotFit) {


### PR DESCRIPTION
Ticket: https://yaits.demos-deutschland.de/T34956

If the element ends below context the position should be the bottom of context. Otherwise the element has not enough space and is not reachable. Don't stick to direction in this case. 

It seems like the bug was introduced with this fix https://github.com/demos-europe/demosplan-ui/pull/438
Since this doesn't fix the bug completely (see https://yaits.demos-deutschland.de/T34173) I suggest to revert it and to try to fix it another way. 