### PR TITLE
Fix(T33788): disabled scrolling after closing the modal window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 - ([#603](https://github.com/demos-europe/demosplan-ui/pull/603)) Remove DpHeightLimit, DpSwitcher, and DpTextWrapper components. ([@ahmad-demos](https://github.com/@ahmad-demos))
 
 ### Changed
-- ([#633](https://github.com/demos-europe/demosplan-ui/pull/633)) Call the preventScroll function in the toggle method for cases where the @after-leave transition does not work correctly (AssignEntityModal) ([@sakutademos](https://github.com/sakutademos))
+- ([#633](https://github.com/demos-europe/demosplan-ui/pull/633)) DpModal: Call the preventScroll function within the toggle method in cases where the @after-leave transition does not work correctly (AssignEntityModal) ([@sakutademos](https://github.com/sakutademos))
 - ([#624](https://github.com/demos-europe/demosplan-ui/pull/624)) Use proper import for buildSuggestion ([@salis-demos](https://github.com/salis-demos))
 - ([#622](https://github.com/demos-europe/demosplan-ui/pull/622)) Improve validation notifications in the DpValidation action by incorporating invalid fields and displaying unique fields only ([@sakutademos](https://github.com/sakutademos))
 - ([#621](https://github.com/demos-europe/demosplan-ui/pull/621)) Bump Vue Peer dependency to 2.5.17 ([@spiess-demos](https://github.com/spiess-demos))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 - ([#603](https://github.com/demos-europe/demosplan-ui/pull/603)) Remove DpHeightLimit, DpSwitcher, and DpTextWrapper components. ([@ahmad-demos](https://github.com/@ahmad-demos))
 
 ### Changed
+- ([#633](https://github.com/demos-europe/demosplan-ui/pull/633)) Call the preventScroll function in the toggle method for cases where the @after-leave transition does not work correctly (AssignEntityModal) ([@sakutademos](https://github.com/sakutademos))
 - ([#624](https://github.com/demos-europe/demosplan-ui/pull/624)) Use proper import for buildSuggestion ([@salis-demos](https://github.com/salis-demos))
 - ([#622](https://github.com/demos-europe/demosplan-ui/pull/622)) Improve validation notifications in the DpValidation action by incorporating invalid fields and displaying unique fields only ([@sakutademos](https://github.com/sakutademos))
 - ([#621](https://github.com/demos-europe/demosplan-ui/pull/621)) Bump Vue Peer dependency to 2.5.17 ([@spiess-demos](https://github.com/spiess-demos))

--- a/src/components/DpModal/DpModal.vue
+++ b/src/components/DpModal/DpModal.vue
@@ -140,7 +140,6 @@ export default {
       this.$emit('modal:toggled', this.isOpenModal)
 
       if (this.isOpenModal === true) {
-        this.preventScroll(true)
         this.lastFocusedElement = document.activeElement
         // On toggle get all focusable elements and focus the first one (after everything is rendered)
         this.$nextTick(() => {

--- a/src/components/DpModal/DpModal.vue
+++ b/src/components/DpModal/DpModal.vue
@@ -140,6 +140,7 @@ export default {
       this.$emit('modal:toggled', this.isOpenModal)
 
       if (this.isOpenModal === true) {
+        this.preventScroll(true)
         this.lastFocusedElement = document.activeElement
         // On toggle get all focusable elements and focus the first one (after everything is rendered)
         this.$nextTick(() => {
@@ -150,6 +151,7 @@ export default {
           }
         })
       } else {
+        this.preventScroll(false)
         this.lastFocusedElement.focus()
       }
     },

--- a/src/components/DpModal/DpModal.vue
+++ b/src/components/DpModal/DpModal.vue
@@ -150,7 +150,7 @@ export default {
           }
         })
       } else {
-        this.preventScroll(false)
+        this.preventScroll(false) // it could be removed after dropping the assessment table
         this.lastFocusedElement.focus()
       }
     },


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33788

**Description:** This PR addresses the issue where scrolling becomes impossible after closing the modal window:

- call the `preventScroll` function in the `toggle() `method for cases where the `@after-leave` transition does not work correctly, especially when there is a parent component (such as a specialized modal like AssignEntityModal, ConsolidateModal or CopyStatementModal)

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly