### PR TITLE
Fix(T33788): display only unique fields in the error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Changed
+- ([#634](https://github.com/demos-europe/demosplan-ui/pull/634)) Use filter() function to show unique fields in the error messages instead of using Javascript Set ([@sakutademos](https://github.com/sakutademos))
+
 ## v0.3 - 2023-11-08
 
 ### Removed

--- a/src/lib/validation/utils/assignHandlerForTrigger.js
+++ b/src/lib/validation/utils/assignHandlerForTrigger.js
@@ -47,11 +47,12 @@ export default function assignHandlerForTrigger (triggerButton, form) {
       })
 
       if (invalidCustomErrorFields.length === 0 || invalidCustomErrorFields.length < validatedForm.invalidFields) {
-        const nonEmptyFieldNames = validatedForm.invalidFields
-            .map(field => field.getAttribute('data-dp-validate-error-fieldname'))
-            .filter(Boolean)
-        const nonEmptyUniqueFieldNames = nonEmptyFieldNames.filter((field, idx) => nonEmptyFieldNames.indexOf(field) === idx)
-        const fieldsString = nonEmptyFieldNames ? nonEmptyFieldNames.join(', ') : ' '
+        const nonEmptyUniqueFieldNames = validatedForm.invalidFields
+          .map(field => field.getAttribute('data-dp-validate-error-fieldname'))
+          .filter(Boolean)
+          .filter((field, idx, arr) => arr.indexOf(field) === idx)
+
+        const fieldsString = nonEmptyUniqueFieldNames ? nonEmptyUniqueFieldNames.join(', ') : ' '
         const errorMandatoryFields = de.error.mandatoryFields.intro + fieldsString + de.error.mandatoryFields.outro
 
         nonEmptyUniqueFieldNames.length ? dplan.notify.notify('error', errorMandatoryFields) : dplan.notify.notify('error', de.error.mandatoryFields.default)

--- a/src/lib/validation/utils/assignHandlerForTrigger.js
+++ b/src/lib/validation/utils/assignHandlerForTrigger.js
@@ -45,17 +45,16 @@ export default function assignHandlerForTrigger (triggerButton, form) {
       invalidCustomErrorFields.forEach(field => {
         dplan.notify.notify('error', Translator.trans(field.validationMessage))
       })
-      const nonEmptyFieldNames = [...new Set(
-        validatedForm.invalidFields
-          .map(field => field.getAttribute('data-dp-validate-error-fieldname'))
-          .filter(Boolean)
-      )]
 
       if (invalidCustomErrorFields.length === 0 || invalidCustomErrorFields.length < validatedForm.invalidFields) {
+        const nonEmptyFieldNames = validatedForm.invalidFields
+            .map(field => field.getAttribute('data-dp-validate-error-fieldname'))
+            .filter(Boolean)
+        const nonEmptyUniqueFieldNames = nonEmptyFieldNames.filter((field, idx) => nonEmptyFieldNames.indexOf(field) === idx)
         const fieldsString = nonEmptyFieldNames ? nonEmptyFieldNames.join(', ') : ' '
         const errorMandatoryFields = de.error.mandatoryFields.intro + fieldsString + de.error.mandatoryFields.outro
 
-        nonEmptyFieldNames.length ? dplan.notify.notify('error', errorMandatoryFields) : dplan.notify.notify('error', de.error.mandatoryFields.default)
+        nonEmptyUniqueFieldNames.length ? dplan.notify.notify('error', errorMandatoryFields) : dplan.notify.notify('error', de.error.mandatoryFields.default)
       }
 
       scrollToVisibleElement(validatedForm.invalidFields[0])

--- a/src/mixins/dpValidateMixin.js
+++ b/src/mixins/dpValidateMixin.js
@@ -45,11 +45,10 @@ export default {
         customErrors.forEach(error => dplan.notify.notify('error', Translator.trans(error)))
 
         if (customErrors.length === 0) {
-          const nonEmptyFieldNames = invalidFields
+          const nonEmptyUniqueFieldNames = invalidFields
             .map(field => field.getAttribute('data-dp-validate-error-fieldname'))
             .filter(Boolean)
-
-          const nonEmptyUniqueFieldNames = nonEmptyFieldNames.filter((field, idx, arr) => arr.indexOf(field) === idx)
+            .filter((field, idx, arr) => arr.indexOf(field) === idx)
 
           if (nonEmptyUniqueFieldNames.length) {
             const fieldsString = nonEmptyUniqueFieldNames ? nonEmptyUniqueFieldNames.join(', ') : ' '

--- a/src/mixins/dpValidateMixin.js
+++ b/src/mixins/dpValidateMixin.js
@@ -45,14 +45,14 @@ export default {
         customErrors.forEach(error => dplan.notify.notify('error', Translator.trans(error)))
 
         if (customErrors.length === 0) {
-          const nonEmptyFieldNames = [...new Set(
-            invalidFields
-              .map(field => field.getAttribute('data-dp-validate-error-fieldname'))
-              .filter(Boolean)
-          )]
+          const nonEmptyFieldNames = invalidFields
+            .map(field => field.getAttribute('data-dp-validate-error-fieldname'))
+            .filter(Boolean)
 
-          if (nonEmptyFieldNames.length) {
-            const fieldsString = nonEmptyFieldNames ? nonEmptyFieldNames.join(', ') : ' '
+          const nonEmptyUniqueFieldNames = nonEmptyFieldNames.filter((field, idx) => nonEmptyFieldNames.indexOf(field) === idx)
+
+          if (nonEmptyUniqueFieldNames.length) {
+            const fieldsString = nonEmptyUniqueFieldNames ? nonEmptyUniqueFieldNames.join(', ') : ' '
             const errorMandatoryFields = de.error.mandatoryFields.intro + fieldsString + de.error.mandatoryFields.outro
             dplan.notify.notify('error', errorMandatoryFields)
           } else {

--- a/src/mixins/dpValidateMixin.js
+++ b/src/mixins/dpValidateMixin.js
@@ -49,7 +49,7 @@ export default {
             .map(field => field.getAttribute('data-dp-validate-error-fieldname'))
             .filter(Boolean)
 
-          const nonEmptyUniqueFieldNames = nonEmptyFieldNames.filter((field, idx) => nonEmptyFieldNames.indexOf(field) === idx)
+          const nonEmptyUniqueFieldNames = nonEmptyFieldNames.filter((field, idx, arr) => arr.indexOf(field) === idx)
 
           if (nonEmptyUniqueFieldNames.length) {
             const fieldsString = nonEmptyUniqueFieldNames ? nonEmptyUniqueFieldNames.join(', ') : ' '


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33137 --> 1.PLZ wird 2x angezeigt (nur beim Feld PLZ tritt der Fehler auf

**Description:** This PR fixes the issue with incorrect field names in the error message: [object Set] 
![image](https://github.com/demos-europe/demosplan-ui/assets/110987766/2245873f-c9f6-4abf-9559-2bd9d31e5372)

JavaScript `Set` was used for storing a collection of unique fields. However it does not work correctly after installing a new version of demosplan-ui in demosplan core.. 

- use filter() function to display only unique fields