### PR TITLE
bug: Align text for accordion button left

### DIFF
--- a/src/components/DpAccordion/DpAccordion.vue
+++ b/src/components/DpAccordion/DpAccordion.vue
@@ -7,7 +7,7 @@
       :aria-expanded="isVisible.toString()"
       :data-cy="dataCy"
       :class="fontWeight === 'bold' ? 'weight--bold' : 'weight--normal'"
-      class="btn--blank o-link--default">
+      class="btn--blank o-link--default text-left">
       <i
         class="width-s fa"
         :class="{'fa-caret-right': !isVisible, 'fa-caret-down': isVisible}"


### PR DESCRIPTION
If the text doesn't fit in one line, the text is aligned center and it does not match the other buttons.

![accordion-button](https://github.com/demos-europe/demosplan-ui/assets/101879352/4135f10c-8c86-4de6-b263-add41aa22482)

