### PR TITLE
chore: use Tailwind class instead of demosplan-core class

### DIFF
--- a/src/components/DpBadge/DpBadge.vue
+++ b/src/components/DpBadge/DpBadge.vue
@@ -1,6 +1,6 @@
 <template>
   <span
-    :class="`rounded-sm ${colorClasses} ${sizeClasses} badge`"
+    :class="`rounded ${colorClasses} ${sizeClasses} badge`"
     v-text="text" />
 </template>
 

--- a/src/components/DpBadge/DpBadge.vue
+++ b/src/components/DpBadge/DpBadge.vue
@@ -1,6 +1,6 @@
 <template>
   <span
-    :class="`border-radius-small ${colorClasses} ${sizeClasses} badge`"
+    :class="`rounded-sm ${colorClasses} ${sizeClasses} badge`"
     v-text="text" />
 </template>
 


### PR DESCRIPTION
As we're already using the `rounded...` classes (and in preparation of removing legacy utility css), let's use Tailwind class instead of demosplan-core class here.