### PR TITLE
Repair jest build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+## v0.3.3 - 2023-12-11
+
+### Changed
+
+- ([#674](https://github.com/demos-europe/demosplan-ui/pull/674)) use Tailwind class instead of demosplan-core class
+
+### Fixed
+
+- ([#673](https://github.com/demos-europe/demosplan-ui/pull/673)) lock style-dictionary at 3.8.0
+
 ## v0.3.2 - 2023-12-08
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "react-dom": "^18.2.0",
     "storybook": "7.6.4",
     "storybook-addon-vue-slots": "^0.9.21",
+    "string-width": "4.2.1",
     "style-dictionary": "3.8.0",
     "style-loader": "^3.3.1",
     "tailwindcss": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7098,7 +7098,7 @@ glob@7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^10.0.0, glob@^10.2.2, glob@^10.3.1, glob@^10.3.10, glob@^10.3.3:
+glob@^10.0.0, glob@^10.2.2, glob@^10.3.1, glob@^10.3.3:
   version "10.3.10"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.3.10.tgz#0351ebb809fd187fe421ab96af83d3a70715df4b"
   integrity sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==
@@ -7109,7 +7109,7 @@ glob@^10.0.0, glob@^10.2.2, glob@^10.3.1, glob@^10.3.10, glob@^10.3.3:
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
     path-scurry "^1.10.1"
 
-glob@^7.0.0, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@^7.0.0, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -11883,6 +11883,15 @@ string-length@^4.0.1:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
+string-width@4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.1.tgz#1933ce1f470973d224368009bd1316cad81d5f4f"
+  integrity sha512-LL0OLyN6AnfV9xqGQpDBwedT2Rt63737LxvsRxbcwpa2aIeynBApG2Sm//F3TaLHIR1aJBN52DWklc06b94o5Q==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.0"
+
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
@@ -11989,7 +11998,7 @@ style-dictionary@3.8.0:
     change-case "^4.1.2"
     commander "^8.3.0"
     fs-extra "^10.0.0"
-    glob "^10.3.10"
+    glob "^7.2.0"
     json5 "^2.2.2"
     jsonc-parser "^3.0.0"
     lodash "^4.17.15"


### PR DESCRIPTION
There are too many dependencies and transitive uses of string-width and
strip-ansi in differing versions. This resolves the tree so that our
current jest and webpack setups are able to run

The ChatGPT-aided fix was to manually upgrade string-width after
adding the version requested by jest to our devDependencies.