### PR TITLE
fix(refs T35888): Adjust broken imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+
+- ([#685](https://github.com/demos-europe/demosplan-ui/pull/685)) Adjust internal imports to resolve properly
+
 ## v0.3.3 - 2023-12-11
 
 ### Changed

--- a/src/components/DpEditor/DpLinkModal.vue
+++ b/src/components/DpEditor/DpLinkModal.vue
@@ -47,7 +47,10 @@
 
 <script>
 import { de } from '../shared/translations'
-import { DpButtonRow, DpCheckbox, DpInput, DpModal } from '~/components'
+import DpButtonRow from '~/components/DpButtonRow'
+import DpCheckbox from '~/components/DpCheckbox'
+import DpInput from '~/components/DpInput'
+import DpModal from '~/components/DpModal'
 import { dpValidateMixin } from '../../mixins'
 
 export default {

--- a/src/components/DpEditor/DpUploadModal.vue
+++ b/src/components/DpEditor/DpUploadModal.vue
@@ -54,7 +54,9 @@
 
 <script>
 import { de } from '../shared/translations'
-import { DpInput, DpModal, DpUploadFiles } from '~/components'
+import DpInput from '~/components/DpInput'
+import DpModal from '~/components/DpModal'
+import DpUploadFiles from '~/components/DpUploadFiles'
 
 export default {
   name: 'DpUploadModal',


### PR DESCRIPTION
Since the imports can't be resolved directly from `~/components` atm. The Modals are broken.
Simple fix is to change the imports, like i did here. In a second step, we have to fix the setup, that we can use the imports the way we want to.