### PR TITLE
Use tailwind utility classes for height and width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 - ([#690](https://github.com/demos-europe/demosplan-ui/pull/690)) DpApi method: handles cases where the response does not contain content and cannot be parsed as JSON ([@sakutademos](https://github.com/sakutademos))
 - ([#685](https://github.com/demos-europe/demosplan-ui/pull/685)) Adjust internal imports to resolve properly
 
+### Changed
+
+- ([#693](https://github.com/demos-europe/demosplan-ui/pull/693)) Use Tailwind utility classes for width and height
+
+
 ## v0.3.3 - 2023-12-11
 
 ### Changed

--- a/src/components/DpAccordion/DpAccordion.vue
+++ b/src/components/DpAccordion/DpAccordion.vue
@@ -9,7 +9,7 @@
       :class="fontWeight === 'bold' ? 'weight--bold' : 'weight--normal'"
       class="btn--blank o-link--default text-left">
       <i
-        class="width-s fa"
+        class="w-2 fa"
         :class="{'fa-caret-right': !isVisible, 'fa-caret-down': isVisible}"
         aria-hidden="true" />
       <span :class="compressed ? 'font-size-medium' : 'o-accordion--title'">{{ title }}</span>

--- a/src/components/DpDataTableExtended/DpSelectPageItemCount.vue
+++ b/src/components/DpDataTableExtended/DpSelectPageItemCount.vue
@@ -2,7 +2,7 @@
   <div>
     <select
       :id="selectId"
-      class="o-form__control-select width-auto u-mr-0_25"
+      class="o-form__control-select w-auto u-mr-0_25"
       @change="e => $emit('changed-count', parseInt(e.target.value))">
       <option
         v-for="option in pageCountOptions"

--- a/src/components/DpDatepicker/DpDatepicker.vue
+++ b/src/components/DpDatepicker/DpDatepicker.vue
@@ -99,7 +99,7 @@ export default {
         locale: 'DE-de',
         dateFormat: 'dd.mm.yyyy',
         id: this.id,
-        inputClass: 'o-form__control-input width-100p'
+        inputClass: 'o-form__control-input w-full'
       }
     }
   },

--- a/src/components/DpDetails/DpDetails.vue
+++ b/src/components/DpDetails/DpDetails.vue
@@ -8,7 +8,7 @@
       role="button"
       @click="isOpen = !isOpen">
       <i
-        class="fa width-s text--center"
+        class="fa w-2 text--center"
         :class="{'fa-caret-down': isOpen, 'fa-caret-right': !isOpen}"
         aria-hidden="true" />
       <strong v-cleanhtml="summary" />

--- a/src/components/DpEditor/DpUploadModal.vue
+++ b/src/components/DpEditor/DpUploadModal.vue
@@ -34,7 +34,7 @@
           hint: translations.altTextHint,
           text: translations.altText,
         }" />
-      <div class="u-mt text--right width-100p space-inline-s">
+      <div class="u-mt text--right w-full space-inline-s">
         <button
           class="btn btn--primary"
           type="button"

--- a/src/components/DpSearchField/DpSearchField.vue
+++ b/src/components/DpSearchField/DpSearchField.vue
@@ -1,5 +1,5 @@
 <template>
-  <span :class="{ 'inline-block width-100p': inputWidth !== ''}">
+  <span :class="{ 'inline-block w-full': inputWidth !== ''}">
     <dp-resettable-input
       id="searchField"
       data-cy="searchField"

--- a/src/components/DpTextArea/DpTextArea.vue
+++ b/src/components/DpTextArea/DpTextArea.vue
@@ -7,7 +7,7 @@
       :name="name"
       :id="id"
       class="o-form__control-textarea"
-      :class="{ 'grow': growToParent, 'height-60': reducedHeight }"
+      :class="{ 'grow': growToParent, 'h-7': reducedHeight }"
       :data-dp-validate-if="dataDpValidateIf"
       :data-dp-validate-error-fieldname="dataDpValidateErrorFieldname || label || null"
       :disabled="disabled"

--- a/src/components/DpTimePicker/DpTimePicker.vue
+++ b/src/components/DpTimePicker/DpTimePicker.vue
@@ -12,7 +12,7 @@
       v-if="!isMobileDevice"
       :id="`timeInput:${id}`"
       :ref="`timeInput:${id}`"
-      class="width-100"
+      class="w-9"
       button-variant="small"
       default-value="00:00"
       :input-attributes="{ disabled: disabled, autocomplete: 'off' }"
@@ -26,7 +26,7 @@
     <dp-input
       v-else
       :id="`timeInput:${id}`"
-      class="width-100"
+      class="w-9"
       type="time"
       pattern="([01]?[0-9]|2[0-3]):[0-5][0-9]"
       :value="currentTime"
@@ -38,7 +38,7 @@
       class="flex items-start justify-evenly c-timepicker__flyout font-size-small"
       :class="{ 'hidden': !showFlyout }"
       tabindex="0">
-      <ul class="u-m-0_25 u-mr-0 u-pr-0_25 overflow-y-scroll height-130">
+      <ul class="u-m-0_25 u-mr-0 u-pr-0_25 overflow-y-scroll h-9">
         <li
           v-for="hour in availableHours"
           :key="`${id}:hour:${hour}`"
@@ -55,7 +55,7 @@
         </li>
       </ul>
       <ul
-        class="u-m-0_25 height-130"
+        class="u-m-0_25 h-9"
         :class="minutes.length > 5 ? 'overflow-y-scroll' : ''">
         <li
           v-for="minute in availableMinutes"

--- a/src/components/DpTimePicker/DpTimePicker.vue
+++ b/src/components/DpTimePicker/DpTimePicker.vue
@@ -12,7 +12,7 @@
       v-if="!isMobileDevice"
       :id="`timeInput:${id}`"
       :ref="`timeInput:${id}`"
-      class="w-9"
+      class="w-8"
       button-variant="small"
       default-value="00:00"
       :input-attributes="{ disabled: disabled, autocomplete: 'off' }"
@@ -26,7 +26,7 @@
     <dp-input
       v-else
       :id="`timeInput:${id}`"
-      class="w-9"
+      class="w-8"
       type="time"
       pattern="([01]?[0-9]|2[0-3]):[0-5][0-9]"
       :value="currentTime"

--- a/src/components/DpTreeList/DpTreeListNode.vue
+++ b/src/components/DpTreeList/DpTreeListNode.vue
@@ -51,7 +51,7 @@
         v-model="isExpanded" />
       <div
         v-else
-        class="min-width-25" />
+        class="min-w-4" />
     </div>
     <component
       :is="draggable ? 'dp-draggable' : 'div'"


### PR DESCRIPTION
To be able to drop "height" and "width" custom utilities, we have to use the appropriate tailwind classes.