### PR TITLE
bug (refs T35953): Don't stringify form data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+
+- ([#703](https://github.com/demos-europe/demosplan-ui/pull/703)) Don't stringify form data for post requests ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
+
 ## v0.3.4 - 2024-01-05
 
 ### Fixed

--- a/src/lib/DpApi.js
+++ b/src/lib/DpApi.js
@@ -45,7 +45,11 @@ const doRequest = (async ({ url, method = 'GET', data = {}, params, options = {}
   }
 
   if (method.toUpperCase() !== 'GET') {
-    payload.body = JSON.stringify(data)
+    if (data instanceof FormData) {
+      payload.body = data
+    } else {
+      payload.body = JSON.stringify(data)
+    }
   } else if (options.serialize === true) {
     delete payload.options.serialize
 
@@ -202,7 +206,7 @@ function makeFormPost (payload, url) {
   }
 
   return dpApi({
-    method: 'post',
+    method: 'POST',
     url: url,
     data: postData,
     headers: { 'Content-Type': 'multipart/form-data' }


### PR DESCRIPTION
Ticket: https://yaits.demos-deutschland.de/T35953

If you stringify a form data object you get an empty object. For form post we need to send the form data as it is.