### PR TITLE
Send uppercase request headers in DpApi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 - ([#703](https://github.com/demos-europe/demosplan-ui/pull/703)) Don't stringify form data for post requests ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
 
+### Changed
+
+- ([#](https://github.com/demos-europe/demosplan-ui/pull/)) Send DpApi request headers in uppercase format ([@spiess-demos](https://github.com/spiess-demos))
+
 ## v0.3.4 - 2024-01-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Changed
 
-- ([#](https://github.com/demos-europe/demosplan-ui/pull/)) Send DpApi request headers in uppercase format ([@spiess-demos](https://github.com/spiess-demos))
+- ([#706](https://github.com/demos-europe/demosplan-ui/pull/706)) Send DpApi request headers in uppercase format ([@spiess-demos](https://github.com/spiess-demos))
 
 ## v0.3.4 - 2024-01-05
 

--- a/src/lib/DpApi.js
+++ b/src/lib/DpApi.js
@@ -19,21 +19,21 @@ const apiDefaultHeaders = {
 }
 
 const api2defaultHeaders = {
-  Accept: 'application/vnd.api+json',
+  'Accept': 'application/vnd.api+json',
   'Content-Type': 'application/vnd.api+json',
   'X-JWT-Authorization': 'Bearer ' + jwtToken
 }
 
-const getHeaders = function (params) {
-  const headers = params.url.includes('api/2.0/')
-    ? new Headers({ ...api2defaultHeaders, ...params.headers })
-    : new Headers({ ...apiDefaultHeaders, ...params.headers })
+const demosplanProcedureHeaders = {
+  'X-Demosplan-Procedure-Id': currentProcedureId
+}
 
-  // Add current procedure id only if set
-  if (currentProcedureId !== null) {
-    headers.append('X-Demosplan-Procedure-Id', currentProcedureId)
+const getHeaders = function ({ headers, url }) {
+  return {
+    ...(url.includes('api/2.0/') ? api2defaultHeaders : apiDefaultHeaders),
+    ...(currentProcedureId !== null ? demosplanProcedureHeaders : {}),
+    ...headers
   }
-  return headers
 }
 
 const doRequest = (async ({ url, method = 'GET', data = {}, params, options = {} }) => {
@@ -116,7 +116,7 @@ const dpRpc = function (method, parameters, id = null) {
     data,
     params: {
       headers: {
-        'Content-type': 'application/json'
+        'Content-Type': 'application/json'
       }
     }
   })


### PR DESCRIPTION
Whether it is required by spec is debated, especially when it comes to http2, but as the vuex-json-api plugin also sends headers in the format of "First-Char-Uppercase", this is done here, too, for the time being.