### PR TITLE
chore (refs T34290): remove exporting checkResponse.

### DIFF
--- a/src/lib/DpApi.js
+++ b/src/lib/DpApi.js
@@ -213,4 +213,4 @@ function makeFormPost (payload, url) {
   })
 }
 
-export { dpApi, handleResponseMessages, checkResponse, dpRpc, makeFormPost, externalApi }
+export { dpApi, handleResponseMessages, dpRpc, makeFormPost, externalApi }

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,4 +1,4 @@
-import { checkResponse, dpApi, dpRpc, externalApi, handleResponseMessages, makeFormPost } from './DpApi'
+import { dpApi, dpRpc, externalApi, handleResponseMessages, makeFormPost } from './DpApi'
 import { convertSize, getFileInfo, getFileTypes, mimeTypes } from './FileInfo'
 import { highlightActiveLinks } from './HighlightHashLink'
 import ActionMenu from './ActionMenu'
@@ -13,7 +13,6 @@ import TableWrapper from './TableWrapper'
 
 export {
   ActionMenu,
-  checkResponse,
   Confirm,
   convertSize,
   Detabinator,


### PR DESCRIPTION
https://yaits.demos-deutschland.de/T34290

- remove checkResponse from (dpApi/dpRpc).