### PR TITLE
chore: send csrf token when submitting a rpc2.0 call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+
+- ([#714](https://github.com/demos-europe/demosplan-ui/pull/714/files)) add csrf token to dpRpc to prevent missing csrf errors ([@muellerdemos](https://github.com/muellerdemos)) 
+
 ## v0.3.5 - 2024-01-09
 
 ### Fixed

--- a/src/lib/DpApi.js
+++ b/src/lib/DpApi.js
@@ -4,6 +4,7 @@ import { v4 as uuid } from 'uuid'
 
 let currentProcedureId = null
 let jwtToken = null
+let csrfToken = null
 
 if (typeof dplan !== 'undefined') {
   if (hasOwnProp(dplan, 'procedureId')) {
@@ -11,6 +12,7 @@ if (typeof dplan !== 'undefined') {
   }
   if (hasOwnProp(dplan, 'jwtToken')) {
     jwtToken = dplan.jwtToken
+    csrfToken = dplan.csrfToken
   }
 }
 
@@ -21,16 +23,18 @@ const apiDefaultHeaders = {
 const api2defaultHeaders = {
   'Accept': 'application/vnd.api+json',
   'Content-Type': 'application/vnd.api+json',
-  'X-JWT-Authorization': 'Bearer ' + jwtToken
+  'X-JWT-Authorization': 'Bearer ' + jwtToken,
+  'X-Csrf-Token': csrfToken
 }
 
 const demosplanProcedureHeaders = {
   'X-Demosplan-Procedure-Id': currentProcedureId
 }
 
+
 const getHeaders = function ({ headers, url }) {
   return {
-    ...(url.includes('api/2.0/') ? api2defaultHeaders : apiDefaultHeaders),
+    ...(url.includes('api/2.0/') || url.includes('rpc/2.0') ? api2defaultHeaders : apiDefaultHeaders),
     ...(currentProcedureId !== null ? demosplanProcedureHeaders : {}),
     ...headers
   }
@@ -61,10 +65,10 @@ const doRequest = (async ({ url, method = 'GET', data = {}, params, options = {}
     const contentTypeHeader = response.headers.get('Content-Type')
     const contentType = contentTypeHeader ? contentTypeHeader.toLowerCase() : ''
     const content = contentType.includes('json')
-      ? await response.json()
-      : contentType.includes('text')
-      ? await response.text()
-      : null
+        ? await response.json()
+        : contentType.includes('text')
+            ? await response.text()
+            : null
 
     return {
       data: content,

--- a/src/lib/DpApi.js
+++ b/src/lib/DpApi.js
@@ -65,10 +65,10 @@ const doRequest = (async ({ url, method = 'GET', data = {}, params, options = {}
     const contentTypeHeader = response.headers.get('Content-Type')
     const contentType = contentTypeHeader ? contentTypeHeader.toLowerCase() : ''
     const content = contentType.includes('json')
-        ? await response.json()
-        : contentType.includes('text')
-        ? await response.text()
-        : null
+      ? await response.json()
+      : contentType.includes('text')
+      ? await response.text()
+      : null
 
     return {
       data: content,

--- a/src/lib/DpApi.js
+++ b/src/lib/DpApi.js
@@ -18,7 +18,7 @@ if (typeof dplan !== 'undefined') {
 
 const apiDefaultHeaders = {
   'X-JWT-Authorization': 'Bearer ' + jwtToken,
-  'X-Csrf-Token': csrfToken
+  'x-csrf-token': csrfToken
 }
 
 const api2defaultHeaders = {

--- a/src/lib/DpApi.js
+++ b/src/lib/DpApi.js
@@ -17,14 +17,14 @@ if (typeof dplan !== 'undefined') {
 }
 
 const apiDefaultHeaders = {
-  'X-JWT-Authorization': 'Bearer ' + jwtToken
+  'X-JWT-Authorization': 'Bearer ' + jwtToken,
+  'X-Csrf-Token': csrfToken
 }
 
 const api2defaultHeaders = {
   'Accept': 'application/vnd.api+json',
   'Content-Type': 'application/vnd.api+json',
-  'X-JWT-Authorization': 'Bearer ' + jwtToken,
-  'X-Csrf-Token': csrfToken
+  'X-JWT-Authorization': 'Bearer ' + jwtToken
 }
 
 const demosplanProcedureHeaders = {
@@ -34,7 +34,7 @@ const demosplanProcedureHeaders = {
 
 const getHeaders = function ({ headers, url }) {
   return {
-    ...(url.includes('api/2.0/') || url.includes('rpc/2.0') ? api2defaultHeaders : apiDefaultHeaders),
+    ...(url.includes('api/2.0/') ? api2defaultHeaders : apiDefaultHeaders),
     ...(currentProcedureId !== null ? demosplanProcedureHeaders : {}),
     ...headers
   }

--- a/src/lib/DpApi.js
+++ b/src/lib/DpApi.js
@@ -67,8 +67,8 @@ const doRequest = (async ({ url, method = 'GET', data = {}, params, options = {}
     const content = contentType.includes('json')
         ? await response.json()
         : contentType.includes('text')
-            ? await response.text()
-            : null
+        ? await response.text()
+        : null
 
     return {
       data: content,

--- a/src/lib/DpApi.js
+++ b/src/lib/DpApi.js
@@ -31,7 +31,6 @@ const demosplanProcedureHeaders = {
   'X-Demosplan-Procedure-Id': currentProcedureId
 }
 
-
 const getHeaders = function ({ headers, url }) {
   return {
     ...(url.includes('api/2.0/') ? api2defaultHeaders : apiDefaultHeaders),


### PR DESCRIPTION
### Description

- This PR is the front-end part of enabling x-csrf-token as header which was mainly introduced to prevent the purple error messages about missing csrf tokens when loading addons on various areas of dplan

### Linked PRs:
https://github.com/demos-europe/demosplan-core/pull/2586

### Important:
Before removing the hidden input field throughout dplan this PR needs to be merged first and a new release is needed