### PR TITLE
feat: allow mailto links in editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 - ([#721](https://github.com/demos-europe/demosplan-ui/pull/721)) Pass the allowEmpty prop to vue-multiselect, which prevents the deselection of values ([@sakutademos](https://github.com/sakutademos))
 - ([#718](https://github.com/demos-europe/demosplan-ui/pull/718)) Add missing data attr for E-2-E Test ([@ahmad-demos](https://github.com/ahmad-demos)) 
 - ([#714](https://github.com/demos-europe/demosplan-ui/pull/714/files)) add csrf token to dpRpc to prevent missing csrf errors ([@muellerdemos](https://github.com/muellerdemos)) 
+- ([#](https://github.com/demos-europe/demosplan-ui/pull/)) Allow mailto links in DpEditor link modal ([@spiess-demos](https://github.com/spiess-demos))
 
 ## v0.3.5 - 2024-01-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 - ([#721](https://github.com/demos-europe/demosplan-ui/pull/721)) Pass the allowEmpty prop to vue-multiselect, which prevents the deselection of values ([@sakutademos](https://github.com/sakutademos))
 - ([#718](https://github.com/demos-europe/demosplan-ui/pull/718)) Add missing data attr for E-2-E Test ([@ahmad-demos](https://github.com/ahmad-demos)) 
 - ([#714](https://github.com/demos-europe/demosplan-ui/pull/714/files)) add csrf token to dpRpc to prevent missing csrf errors ([@muellerdemos](https://github.com/muellerdemos)) 
-- ([#](https://github.com/demos-europe/demosplan-ui/pull/)) Allow mailto links in DpEditor link modal ([@spiess-demos](https://github.com/spiess-demos))
+- ([#734](https://github.com/demos-europe/demosplan-ui/pull/734)) Allow mailto links in DpEditor link modal ([@spiess-demos](https://github.com/spiess-demos))
 
 ## v0.3.5 - 2024-01-09
 

--- a/src/components/DpEditor/DpLinkModal.vue
+++ b/src/components/DpEditor/DpLinkModal.vue
@@ -23,7 +23,7 @@
             hint: translations.linkHint,
             text: Translator.trans('url')
           }"
-          :pattern="isVisible === true ? '(^https?://.*|^//.*)' : null"
+          :pattern="isVisible === true ? '(^https?://.*|^//.*|^mailto:.*)' : null"
           :required="isVisible"
           type="url" />
         <dp-checkbox


### PR DESCRIPTION
Adds the possibility to add `mailto` links via the link modal of DpEditor.