### PR TITLE
fix(T36253): performance issue - ElementsList

### DIFF
--- a/src/components/DpTreeList/DpTreeList.vue
+++ b/src/components/DpTreeList/DpTreeList.vue
@@ -292,7 +292,7 @@ export default {
       this.selectedNodesObject = {}
       this.allElementsSelected = false
 
-      this.$emit('node-selection-change', this. this.selectedNodes)
+      this.$emit('node-selection-change', this.selectedNodes)
     }
   },
 

--- a/src/components/DpTreeList/DpTreeList.vue
+++ b/src/components/DpTreeList/DpTreeList.vue
@@ -168,6 +168,10 @@ export default {
       return `margin-left: ${margin}px;`
     },
 
+    selectedNodes () {
+      return Object.keys(this.selectedNodesObject).map(id => this.selectedNodesObject[id])
+    },
+
     /**
      * The `tree` getter is called whenever this.treeData is changed from outside DpTreeList.
      * The setter is called whenever the tree structure is changed from within the draggable instance.
@@ -279,7 +283,7 @@ export default {
     },
 
     unselectAll () {
-      Object.values(this.selectedNodesObject).forEach(node => {
+      this.selectedNodes.forEach(node => {
         if (this.$refs['node_' + node.id]) {
           this.$refs['node_' + node.id][0].setSelectionState(false)
         }
@@ -288,7 +292,7 @@ export default {
       this.selectedNodesObject = {}
       this.allElementsSelected = false
 
-      this.$emit('node-selection-change', this.selectedNodesObject)
+      this.$emit('node-selection-change', this. this.selectedNodes)
     }
   },
 

--- a/src/components/DpTreeList/DpTreeList.vue
+++ b/src/components/DpTreeList/DpTreeList.vue
@@ -253,7 +253,7 @@ export default {
 
       filteredSelections.forEach(selection => this.setSelectionState(selection))
 
-      this.$emit('node-selection-change', this.selectedNodesObject)
+      this.$emit('node-selection-change', this.selectedNodes)
     },
 
     // Header and Footer should be fixed to the top/bottom of the page when the TreeList exceeds the viewport height.

--- a/src/components/DpTreeList/DpTreeList.vue
+++ b/src/components/DpTreeList/DpTreeList.vue
@@ -47,6 +47,7 @@
         :draggable="draggable"
         :handle-change="handleChange"
         :handle-drag="handleDrag"
+        :leaf-only="isLeafOnly"
         :level="0"
         :node="node"
         :node-id="node.id"
@@ -112,6 +113,12 @@ export default {
       default: true
     },
 
+    leafOnly: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+
     /*
      * Callback to be executed on move event of draggable.
      * It can be used to cancel drag by returning false.
@@ -138,6 +145,7 @@ export default {
     return {
       allElementsExpanded: false,
       allElementsSelected: false,
+      isLeafOnly: this.leafOnly,
 
       /*
        * To be able to control the appearance of nodes when hovered vs. when dragged,
@@ -158,10 +166,6 @@ export default {
     checkboxIndentationStyle () {
       const margin = this.opts.dragBranches || this.opts.dragLeaves ? dragHandleWidth : 0
       return `margin-left: ${margin}px;`
-    },
-
-    selectedNodes () {
-      return Object.keys(this.selectedNodesObject).map(id => this.selectedNodesObject[id])
     },
 
     /**
@@ -245,7 +249,7 @@ export default {
 
       filteredSelections.forEach(selection => this.setSelectionState(selection))
 
-      this.$emit('node-selection-change', this.selectedNodes)
+      this.$emit('node-selection-change', this.selectedNodesObject)
     },
 
     // Header and Footer should be fixed to the top/bottom of the page when the TreeList exceeds the viewport height.
@@ -275,7 +279,7 @@ export default {
     },
 
     unselectAll () {
-      this.selectedNodes.forEach(node => {
+      Object.values(this.selectedNodesObject).forEach(node => {
         if (this.$refs['node_' + node.id]) {
           this.$refs['node_' + node.id][0].setSelectionState(false)
         }
@@ -284,7 +288,7 @@ export default {
       this.selectedNodesObject = {}
       this.allElementsSelected = false
 
-      this.$emit('node-selection-change', this.selectedNodes)
+      this.$emit('node-selection-change', this.selectedNodesObject)
     }
   },
 

--- a/src/components/DpTreeList/DpTreeListNode.vue
+++ b/src/components/DpTreeList/DpTreeListNode.vue
@@ -75,6 +75,7 @@
         :children="child.children || []"
         :handle-change="handleChange"
         :handle-drag="handleDrag"
+        :leaf-only="isLeafOnly"
         :level="level + 1"
         :node="child"
         :node-id="child.id"
@@ -157,6 +158,12 @@ export default {
       required: true
     },
 
+    leafOnly: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+
     level: {
       type: Number,
       required: true
@@ -199,7 +206,8 @@ export default {
   data () {
     return {
       isExpanded: false,
-      isSelected: false
+      isSelected: false,
+      isLeafOnly: this.leafOnly
     }
   },
 
@@ -325,12 +333,19 @@ export default {
     },
 
     setSelectionState ({ selectionState, selections = [], fromParent = false }) {
+      this.isSelected = selectionState
+      const type = this.isBranch === true ? 'branch' : 'leaf'
+
+      if (this.leafOnly && type === 'branch') {
+        return
+      }
+
       const selectionsCpy = [...selections]
 
-      this.isSelected = selectionState
       selectionsCpy.push({
         nodeId: this.nodeId,
-        nodeType: this.isBranch === true ? 'branch' : 'leaf',
+        node: this.node,
+        nodeType: type,
         selectionState: selectionState
       })
 


### PR DESCRIPTION
- add `leafOnly` prop: to reduce the number of array functions like `filter()`, use the `leafOnly` prop instead, for cases where only leafs nodes are needed. This helps to remove an extra `filter()` function in the` ElementsList.vue` component >  `nodeSelectionChange` (line: 157)

[demosplan-core](https://github.com/demos-europe/demosplan-core/pull/2776)