### PR TITLE
fix(T36253): TreeList performance issue

### DIFF
--- a/src/components/DpTreeList/DpTreeList.vue
+++ b/src/components/DpTreeList/DpTreeList.vue
@@ -53,6 +53,7 @@
         :on-move="onMove"
         :options="opts"
         :parent-selected="allElementsSelected"
+        :selection-by-prop="isSelectionByProp"
         @draggable:change="bubbleDraggableChange"
         @end="handleDrag('end')"
         @node-selected="handleSelectEvent"
@@ -131,6 +132,12 @@ export default {
     treeData: {
       type: Array,
       required: true
+    },
+
+    selectionByProp: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   },
 
@@ -138,6 +145,7 @@ export default {
     return {
       allElementsExpanded: false,
       allElementsSelected: false,
+      isSelectionByProp: this.selectionByProp,
 
       /*
        * To be able to control the appearance of nodes when hovered vs. when dragged,
@@ -176,6 +184,20 @@ export default {
 
       set (payload) {
         this.$emit('tree:change', payload)
+      }
+    }
+  },
+
+  watch: {
+    allElementsSelected (val) {
+      if (!this.selectionByProp) {
+        if (this.options.selectOn.parentSelect && val === true && this.isSelected === false) {
+          this.setSelectionState({ selectionState: val, fromParent: true })
+        }
+
+        if (this.options.deselectOn.parentDeselect && val === false && this.isSelected === true) {
+          this.setSelectionState({ selectionState: val, fromParent: true })
+        }
       }
     }
   },


### PR DESCRIPTION
**Issue:** 

When selecting a folder with many subfolders and approximately 800 files, each element in the list starts the process (points 1, 2, 3, 4) one after the other, and the page freezes because it takes about 1 minute to perform the calculations:

1. `DpTreeListNode.vue`: **An object is created** with the `nodeId` and **sent to parent** via emit.
2. `DpTreeList.vue`: The object is added to the list `selectedNodesObject`. Then this list is **transformed into an array** and forwarded to the parent via emit.
3. `ElementsList.vue`: The **array is filtered** by _leaf_ and a **new array** with IDs is **created**. Then **allFiles are filtered** by these IDs, and **a new array** with selected files is **created**.
4. ` ElementsList.vue`: Reactive Button Label responds to changes in the list, and the size of the selected files is calculated and displayed.

**The main issues with the current logic:**

- the list elements are in the DOM even when they are not visually visible. This was implemented so that the parent component (Folder) could have access to the child component in the DOM and clicked `nodeIds` could be collected.
- the data transmission from the child to the parent component with various data transformations are also time consuming, especially when there are many elements.

**Changes in these PRs:**

My suggestion would be to change a logic a bit and to add an `isSelected` property to each node object: if a checkbox is selected, the value changes. If the node has children, the value will also be recursively changed for the children. Using this, we could remove points 1, 2, and 3, which **improves the performance from 1 minute to milliseconds** for the list of 800 elements.

[PR in core](https://github.com/demos-europe/demosplan-core/pull/2805)

**Advantages:**

- list elements can exist in the DOM only when they should be visible, as this depends on the value of `isSelected`.
- events (child to parent) can be reduced

**The TreeList component is used in multiple places, so I have currently added a prop called `selectionByProp` that can enable this functionality. Currently, I cannot change the` v-show` directive to `v-if` because either `v-if` or `v-show` should be used in the template. But maybe we can implement this functionality as a standard?**