### PR TITLE
chore: remove "build:css" script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 dist/
-style/style.css

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Removed
+
+- ([#779](https://github.com/demos-europe/demosplan-ui/pull/779)) Remove `build:css` script ([@spiess-demos](https://github.com/spiess-demos))
+
 ### Fixed
 
 - ([#748](https://github.com/demos-europe/demosplan-ui/pull/748)) Fix required for multiselect ([@gruenbergerdemos](https://github.com/gruenbergerdemos))

--- a/package.json
+++ b/package.json
@@ -152,10 +152,9 @@
     }
   },
   "scripts": {
-    "build:css": "tailwindcss -i ./style/index.css -o ./style/style.css",
     "build:storybook": "storybook build",
     "build:tokens": "node buildTokens.js",
-    "prepack": "yarn build && yarn build:tokens && yarn build:css",
+    "prepack": "yarn build && yarn build:tokens",
     "storybook": "storybook dev -p 6006",
     "build": "yarn test && yarn build:prod",
     "build:dev": "webpack --mode=development",


### PR DESCRIPTION
As we do not need it here (Storybook consumes the index.css directly), and also do not need it in projects using demosplan-ui (as they import the tailwind.config and tokens, rather than a compiled file), we can remove the compile step here.