### PR TITLE
Fix(T36635): improve error validation for DpMultiselect and DpSelect components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+
+- ([#783](https://github.com/demos-europe/demosplan-ui/pull/783)) Improve error validation for DpMultiselect and DpSelect components ([@sakutademos](https://github.com/sakutademos))
+
 ### Changed 
+
 - ([#774](https://github.com/demos-europe/demosplan-ui/pull/774)) Improve render performance of the DpTreeList component ([@sakutademos](https://github.com/sakutademos))
 
 ### Removed

--- a/src/components/DpMultiselect/DpMultiselect.vue
+++ b/src/components/DpMultiselect/DpMultiselect.vue
@@ -30,6 +30,7 @@
         value
       }"
       :data-cy="dataCy"
+      :data-dp-validate-error-fieldname="dataDpValidateErrorFieldname || label || null"
       v-dp-validate-multiselect="required"
       @close="newVal => $emit('close', newVal)"
       @input="newVal => $emit('input', newVal)"
@@ -134,6 +135,12 @@ export default {
       type: String,
       required: false,
       default: 'multiselect'
+    },
+
+    dataDpValidateErrorFieldname: {
+      type: String,
+      required: false,
+      default: ''
     },
 
     deselectLabel: {

--- a/src/components/DpMultiselect/DpMultiselect.vue
+++ b/src/components/DpMultiselect/DpMultiselect.vue
@@ -30,7 +30,7 @@
         value
       }"
       :data-cy="dataCy"
-      :data-dp-validate-error-fieldname="dataDpValidateErrorFieldname || label || null"
+      :data-dp-validate-error-fieldname="dataDpValidateErrorFieldname"
       v-dp-validate-multiselect="required"
       @close="newVal => $emit('close', newVal)"
       @input="newVal => $emit('input', newVal)"

--- a/src/components/DpSelect/DpSelect.vue
+++ b/src/components/DpSelect/DpSelect.vue
@@ -10,6 +10,7 @@
  --><select
       :id="nameOrId"
       :data-cy="dataCy"
+      :data-dp-validate-error-fieldname="dataDpValidateErrorFieldname || label.text || null"
       :required="required"
       :name="name !== '' ? name : false"
       class="o-form__control-select"
@@ -72,6 +73,12 @@ export default {
       type: String,
       required: false,
       default: 'selectElement'
+    },
+
+    dataDpValidateErrorFieldname: {
+      type: String,
+      required: false,
+      default: ''
     },
 
     disabled: {


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36635

**Description:** To improve the UX and provide information about invalid fields, add the prop called `dataDpValidateErrorFieldname`. This prop is needed for the `dpValidate` mixin to display the correct error message with the invalid fields.

[PR in Core](https://github.com/demos-europe/demosplan-core/pull/2853)