### PR TITLE
Always serialize request params for GET request in dpApi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Changed 
 - ([#774](https://github.com/demos-europe/demosplan-ui/pull/774)) Improve render performance of the DpTreeList component ([@sakutademos](https://github.com/sakutademos))
-- ([#](https://github.com/demos-europe/demosplan-ui/pull/)) dpApi.get: Always serialize request params ([@spiess-demos](https://github.com/spiess-demos))
+- ([#784](https://github.com/demos-europe/demosplan-ui/pull/784)) dpApi.get: Always serialize request params ([@spiess-demos](https://github.com/spiess-demos))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Changed 
 - ([#774](https://github.com/demos-europe/demosplan-ui/pull/774)) Improve render performance of the DpTreeList component ([@sakutademos](https://github.com/sakutademos))
+- ([#](https://github.com/demos-europe/demosplan-ui/pull/)) dpApi.get: Always serialize request params ([@spiess-demos](https://github.com/spiess-demos))
 
 ### Removed
 


### PR DESCRIPTION
When moving from axios to fetch, it was overlooked that axios serializes params by default, and we only do that occasionally. This leads to the params being dropped in the fetch request whenever "serialize: true" is set via the options arg.

To overcome this, and as we always need to serialize params within get requests, the request params are always appended as stringified value to the url. As the "url" argument may already have params appended, this needs to be handled as well.

The "payload" variable has been renamed into "fetchOptions" to level up readability while distinguishing it from the "options" variable still being used in dpApi.

Also, "options" and "params" has been removed from the request payload as the fetch method does not use these values.

See https://developer.mozilla.org/en-US/docs/Web/API/fetch