### PR TITLE
Cleanup dpApi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Changed
+
+- ([#803](https://github.com/demos-europe/demosplan-ui/pull/803)) dpApi: remove "option" argument ([@spiess-demos](https://github.com/spiess-demos))
+
 ### Added
 
 - ([#798](https://github.com/demos-europe/demosplan-ui/pull/798)) Add missing data attr for E-2-E Test ([@ahmad-demos](https://github.com/ahmad-demos))

--- a/src/components/DpUploadFiles/utils/GetFileIdsByHash.js
+++ b/src/components/DpUploadFiles/utils/GetFileIdsByHash.js
@@ -20,9 +20,6 @@ function getFileIdsByHash (hashes, route) {
           }
         }
       }
-    },
-    {
-      serialize: true
     }
   )
     .then(({ data }) => {

--- a/src/lib/DpApi.js
+++ b/src/lib/DpApi.js
@@ -49,9 +49,9 @@ const appendSerializedUrlParams = (url, params) => {
   return url.includes('?') ? `${url}&${params}` : `${url}?${params}`
 }
 
-const doRequest = (async ({ url, method = 'GET', data = {}, params, options = {} }) => {
+const doRequest = (async ({ method = 'GET', url, data = {}, headers, params }) => {
   const fetchOptions = {
-    headers: getHeaders({ ...params, url }),
+    headers: getHeaders({ headers, url }),
     method
   }
 
@@ -95,38 +95,35 @@ const doRequest = (async ({ url, method = 'GET', data = {}, params, options = {}
 
 const dpApi = doRequest
 
-dpApi.post = (url, params = {}, data = {}, options = {}) => doRequest({ method: 'POST', url, data, params, options })
-dpApi.get = (url, params = {}, options = {}) => doRequest({ method: 'GET', url, params, options })
-dpApi.put = (url, params = {}, data = {}, options = {}) => doRequest({ method: 'PUT', url, data, params, options })
-dpApi.patch = (url, params = {}, data = {}, options = {}) => doRequest({ method: 'PATCH', url, data, params, options })
-dpApi.delete = (url, params = {}, data = {}, options = {}) => doRequest({ method: 'DELETE', url, params, options })
+dpApi.post = (url, params = {}, data = {}) => doRequest({ method: 'POST', url, data, params })
+dpApi.get = (url, params = {}) => doRequest({ method: 'GET', url, params })
+dpApi.put = (url, params = {}, data = {}) => doRequest({ method: 'PUT', url, data, params })
+dpApi.patch = (url, params = {}, data = {}) => doRequest({ method: 'PATCH', url, data, params })
+dpApi.delete = (url, params = {}, data = {}) => doRequest({ method: 'DELETE', url, params })
 
 /**
- * Do a JsonRpc call.
+ * Submit a request to the rpc_generic_post API, which implements JSON-RPC 2.0.
  *
- * Id is optional and defaults to a UUID v4.
- *
- * @param {string} method
- * @param {object} parameters
- * @param {string} id
+ * @param {string} method     This is the RPC method (aka. action) to be invoked,
+ *                            not the Http request method (which is "POST" in any case).
+ * @param {object} params     Data to be used by the RPC method.
+ * @param {string|null} id    Request id. Optional, defaults to a UUID v4.
  * @return {Promise}
  */
-const dpRpc = function (method, parameters, id = null) {
+const dpRpc = function (method, params, id = null) {
   const data = {
     jsonrpc: '2.0',
-    method: method,
-    id: id === null ? uuid() : id,
-    params: parameters,
+    method,
+    params,
+    id: id === null ? uuid() : id
   }
 
   return doRequest({
-    url: Routing.generate('rpc_generic_post'),
     method: 'POST',
+    url: Routing.generate('rpc_generic_post'),
     data,
-    params: {
-      headers: {
-        'Content-Type': 'application/json'
-      }
+    headers: {
+      'Content-Type': 'application/json'
     }
   })
 }


### PR DESCRIPTION
This tackles some leftovers from the axios removal. While options were passed into axios by default before, we do not use it anymore - it was only used to indicate serialization of params which is done by default for get requests now.

- remove "serialize: true" from get route in getFileIdsByHash as params are now always serialized
- properties within the object passed to doRequest as param are reordered to match the most common way of ordering them when calling dpApi() directly in demosplan-core: method first, then url
- add 'headers' property in the object passed to doRequest as param directly instead of wrapping it in params. however this is only used when calling dpApi() directly, as the alias calls like dpApi.post() are used by API2.0 routes which are equipped with api2defaultHeaders anyway.

Linked PR https://github.com/demos-europe/demosplan-core/pull/2878