### PR TITLE
fix(refs T36875): add missing procedureId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 - ([#798](https://github.com/demos-europe/demosplan-ui/pull/798)) Add missing data attr for E-2-E Test ([@ahmad-demos](https://github.com/ahmad-demos))
 - ([#773](https://github.com/demos-europe/demosplan-ui/pull/773)) Add missing data attr for E-2-E Test ([@ahmad-demos](https://github.com/ahmad-demos))
 
+### Fixed
+
+- ([#804](https://github.com/demos-europe/demosplan-ui/pull/804)) DpEditor/DpUploadModal: Pass missing prop ([@hwiem](https://github.com/hwiem))
+
 ## v0.3.8 - 2024-03-15
 
 ### Added

--- a/src/components/DpEditor/DpEditor.vue
+++ b/src/components/DpEditor/DpEditor.vue
@@ -13,6 +13,7 @@
       :basic-auth="basicAuth"
       ref="uploadModal"
       :get-file-by-hash="routes.getFileByHash"
+      :procedure-id="procedureId"
       :tus-endpoint="tusEndpoint"
       @insert-image="insertImage"
       @add-alt="addAltTextToImage"
@@ -465,6 +466,11 @@ export default {
       type: Boolean,
       required: false,
       default: false
+    },
+
+    procedureId: {
+      type: String,
+      required: false
     },
 
     readonly: {

--- a/src/components/DpEditor/DpUploadModal.vue
+++ b/src/components/DpEditor/DpUploadModal.vue
@@ -82,6 +82,11 @@ export default {
       required: true
     },
 
+    procedureId: {
+      type: String,
+      required: false
+    },
+
     /**
      * Global path for file uploader endpoint.
      */
@@ -125,7 +130,11 @@ export default {
     },
 
     setFile ({ hash }) {
-      this.fileUrl = this.getFileByHash(hash)
+      if (this.procedureId) {
+        this.fileUrl = this.getFileByHash(hash, this.procedureId)
+      } else {
+        this.fileUrl = this.getFileByHash(hash)
+      }
       // Force-update the component so that DpModal updates and therefore check for new focusable elements
       this.$forceUpdate()
     },


### PR DESCRIPTION
Ticket: https://yaits.demos-deutschland.de/T36875

Since we are passing a second parameter to `getFileByHash` besides the `hash` (the `procedureId`), we need to provide it in the component that calls the function.

I don't think that this is a good solution because we don't want `procedureId` props in demosplan-ui (too demosplan-specific). However I couldn't find a better solution in the available time. If anyone does, please implement it. :pray: If not, we should consider this a hotfix and find a better solution soon.