### PR TITLE
feat(DPLAN-11460): adjust padding according to different icon sizes

### DIFF
--- a/src/components/DpButton/DpButton.vue
+++ b/src/components/DpButton/DpButton.vue
@@ -158,7 +158,7 @@ export default {
       return [
         'btn inline-flex items-center space-inline-xs',
         this.busy && 'is-busy pointer-events-none',
-        this.iconOnly && 'icon-only',
+        this.iconOnly && `icon-only ${this.iconSize}`,
         this.rounded && 'rounded-full',
         ['primary', 'secondary', 'warning'].includes(this.color) && classes.color[this.color],
         ['solid', 'outline', 'subtle'].includes(this.variant) && classes.variant[this.variant]


### PR DESCRIPTION
`Ticket:` [DPLAN-11460](https://demoseurope.youtrack.cloud/issue/DPLAN-11460/Fullscreen-mode-fur-die-Abschnittsliste-und-die-STN-Liste-implementieren)

`Description:` This PR allows adjusting padding for different icon sizes.

[PR in core](https://github.com/demos-europe/demosplan-core/pull/2979)