### PR TITLE
Feat(dplan-11462): DataTable: save width to the session storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Changed
+- ([#835](https://github.com/demos-europe/demosplan-ui/pull/835)) DpDataTable: enhance column resizing functionality; save the width to sessionStorage ([@sakutademos](https://github.com/sakutademos))
+
 ### Added
 - ([#834](https://github.com/demos-europe/demosplan-ui/pull/834)) DpButton: add icon size class ([@sakutademos](https://github.com/sakutademos))
 

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -471,9 +471,9 @@ export default {
       if (this.isResizable) {
         this.$nextTick(() => {
           const firstRow = this.tableEl.getElementsByTagName('tr')[0]
-          const tableHeaders = firstRow ? firstRow.children : null
+          const tableHeaderElements = firstRow ? firstRow.children : null
 
-          this.setColsWidth(tableHeaders)
+          this.setColsWidth(tableHeaderElements)
         })
       }
     },
@@ -537,14 +537,14 @@ export default {
     },
 
     setColsWidth (headers) {
-      headers.forEach(tableHeader => {
+      Array.from(headers).forEach(tableHeaderEl => {
         /**
          * Some of childNodes of the first table row are not Element nodes but comments or text.
          * This originates in the Vue template compiler leaving empty html comments when rendering
          * falsy `v-if` blocks. We allow only nodeType "Element" to access its `getBoundingClientRect` api.
          */
-        if(tableHeader.nodeType === 1) {
-          const headerField = tableHeader.getAttribute('data-col-field')
+        if (tableHeaderEl.nodeType === 1) {
+          const headerField = tableHeaderEl.getAttribute('data-col-field')
           const savedColWidth = sessionStorage.getItem(`data-col-field=${headerField}`)
           const fixedWidth = this.getFixedColWidth(headerField)  // some columns, such as 'flyout' and 'wrap', should not be resizable; their width is fixed; the getBoundingClientRect() function should not be applied to them
           const headerFieldWidth = this.getColWidthFromHeaderField(headerField)
@@ -552,9 +552,9 @@ export default {
           const width = fixedWidth
               || savedColWidth
               || headerFieldWidth
-              || `${tableHeader.getBoundingClientRect().width}px`
+              || `${tableHeaderEl.getBoundingClientRect().width}px`
 
-          tableHeader.style.width = width
+          tableHeaderEl.style.width = width
           this.updateSessionStorage(headerField, width)
         }
       })
@@ -650,23 +650,21 @@ export default {
      */
     if (this.isResizable || this.isTruncatable) {
       const firstRow = this.tableEl.getElementsByTagName('tr')[0]
-      const tableHeaders = firstRow ? firstRow.children : null
+      const tableHeaderElements = firstRow ? firstRow.children : null
 
-      this.setColsWidth(tableHeaders)
+      this.setColsWidth(tableHeaderElements)
 
       this.tableEl.style.tableLayout = 'fixed'
       this.tableEl.classList.add('is-fixed')
 
       // Remove styles set by initialMaxWidth and initialWidth after copying rendered width into th styles
       if (this.isResizable) {
-        Array.from(tableHeaders).forEach(tableRow => {
-          Array.from(tableRow).forEach(cell => {
-            if (cell.firstChild) {
-              cell.firstChild.style.width = null
-              cell.firstChild.style.maxWidth = null
-              cell.firstChild.style.minWidth = null
-            }
-          })
+        Array.from(tableHeaderElements).forEach(th => {
+          if (th.firstChild) {
+            th.firstChild.style.width = null
+            th.firstChild.style.maxWidth = null
+            th.firstChild.style.minWidth = null
+          }
         })
       }
     }

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -534,7 +534,7 @@ export default {
          */
         if(tableHeader.nodeType === 1) {
           const headerField = tableHeader.getAttribute('data-col-field')
-          const savedColWidth = sessionStorage.getItem(`data-col-field=${field}`)
+          const savedColWidth = sessionStorage.getItem(`data-col-field=${headerField}`)
           const width = savedColWidth || `${tableHeader.getBoundingClientRect().width}px`
           tableHeader.style.width = width
 

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -515,6 +515,17 @@ export default {
       this.selectedElements = this.filterElementSelections()
     },
 
+    getColWidthFromHeaderField (field) {
+      const headerField = this.headerFields.find(headerField => headerField.field === field)
+
+      return headerField && headerField.colWidth ? headerField.colWidth : null
+    },
+
+
+    getFixedColWidth (field) {
+      return ['flyout', 'wrap', 'select', 'dragHandle'].includes(field) ? '30px' : null
+    },
+
     removeHoveredClass(idx) {
       const tableRow = this.$refs.tableRows[idx]
 
@@ -535,9 +546,15 @@ export default {
         if(tableHeader.nodeType === 1) {
           const headerField = tableHeader.getAttribute('data-col-field')
           const savedColWidth = sessionStorage.getItem(`data-col-field=${headerField}`)
-          const width = savedColWidth || `${tableHeader.getBoundingClientRect().width}px`
-          tableHeader.style.width = width
+          const fixedWidth = this.getFixedColWidth(headerField)  // some columns, such as 'flyout' and 'wrap', should not be resizable; their width is fixed; the getBoundingClientRect() function should not be applied to them
+          const headerFieldWidth = this.getColWidthFromHeaderField(headerField)
 
+          const width = fixedWidth
+              || savedColWidth
+              || headerFieldWidth
+              || `${tableHeader.getBoundingClientRect().width}px`
+
+          tableHeader.style.width = width
           this.updateSessionStorage(headerField, width)
         }
       })

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -175,6 +175,7 @@
 <script>
 import { CleanHtml } from '~/directives'
 import { de } from '~/components/shared/translations'
+import { sessionStorageMixin } from '~/mixins'
 import DomPurify from 'dompurify'
 import DpDraggable from '~/components/DpDraggable'
 import DpLoading from '~/components/DpLoading'
@@ -194,6 +195,8 @@ export default {
   directives: {
     cleanhtml: CleanHtml
   },
+
+  mixins: [sessionStorageMixin],
 
   props: {
     dataCy: {
@@ -545,17 +548,22 @@ export default {
          */
         if (tableHeaderEl.nodeType === 1) {
           const headerField = tableHeaderEl.getAttribute('data-col-field')
-          const savedColWidth = sessionStorage.getItem(`data-col-field=${headerField}`)
-          const fixedWidth = this.getFixedColWidth(headerField)  // some columns, such as 'flyout' and 'wrap', should not be resizable; their width is fixed; the getBoundingClientRect() function should not be applied to them
+          const storageName = `dpDataTable:data-col-field=${headerField}`
+          const sessionColWidth = this.getItemFromSessionStorage(storageName)
+          /**
+           * Some columns, such as 'flyout' and 'wrap', should not be resizable;
+           * their width is fixed; the getBoundingClientRect() function should not be applied to them
+           */
+          const fixedWidth = this.getFixedColWidth(headerField)
           const headerFieldWidth = this.getColWidthFromHeaderField(headerField)
 
           const width = fixedWidth
-              || savedColWidth
+              || sessionColWidth
               || headerFieldWidth
               || `${tableHeaderEl.getBoundingClientRect().width}px`
 
           tableHeaderEl.style.width = width
-          this.updateSessionStorage(headerField, width)
+          this.updateSessionStorage(storageName, width)
         }
       })
     },
@@ -614,12 +622,6 @@ export default {
       }, {})
 
       this.allWrapped = status
-    },
-
-    updateSessionStorage (storageName, value) {
-      if (storageName) {
-        sessionStorage.setItem(`data-col-field=${storageName}`, value)
-      }
     }
   },
 

--- a/src/components/DpDataTable/DpResizableColumn.vue
+++ b/src/components/DpDataTable/DpResizableColumn.vue
@@ -15,8 +15,9 @@
 </template>
 
 <script>
-import DpResizeHandle from './DpResizeHandle'
 import { hasOwnProp } from '../../utils'
+import { sessionStorageMixin } from '~/mixins'
+import DpResizeHandle from './DpResizeHandle'
 
 export default {
   name: 'DpResizableColumn',
@@ -24,6 +25,8 @@ export default {
   components: {
     DpResizeHandle
   },
+
+  mixins: [sessionStorageMixin],
 
   props: {
     idx: {
@@ -103,11 +106,11 @@ export default {
         }
 
         this.resize.style.width = newWidth + 'px'
-        this.updateSessionStorage(this.headerField.field, this.resize.style.width)
+        this.updateSessionStorage(`dpDataTable:data-col-field=${this.headerField.field}`, this.resize.style.width)
 
         if (this.nextEl) {
           this.nextEl.style.width = newNextWidth + 'px'
-          this.updateSessionStorage(this.nextHeader.field, this.nextEl.style.width)
+          this.updateSessionStorage(`dpDataTable:data-col-field=${this.nextHeader.field}`, this.nextEl.style.width)
         }
       }
     },
@@ -118,10 +121,6 @@ export default {
       document.querySelector('body').removeEventListener('mousemove', this.namedFunc)
       document.querySelector('body').removeEventListener('mouseup', this.stopResize)
       document.querySelector('body').classList.remove('resizing')
-    },
-
-    updateSessionStorage (field, width) {
-      sessionStorage.setItem(`data-col-field=${field}`, width)
     }
   }
 }

--- a/src/components/DpDataTable/DpResizableColumn.vue
+++ b/src/components/DpDataTable/DpResizableColumn.vue
@@ -73,7 +73,7 @@ export default {
       this.resize = this.$refs.resizableColumn
       this.currentHandle = this.resize.getElementsByClassName('c-data-table__resize-handle')[0]
       this.currentHandle.classList.add('is-active')
-      this.nextEl = document.querySelector(`th[data-col-idx='${idx + 1}']`) // could be replaced with data-field
+      this.nextEl = document.querySelector(`th[data-col-idx='${idx + 1}']`)
       this.dragStart = true
       this.cursorStart = e.pageX
       const resizeBound = this.resize.getBoundingClientRect()

--- a/src/components/DpDataTable/DpResizableColumn.vue
+++ b/src/components/DpDataTable/DpResizableColumn.vue
@@ -79,7 +79,7 @@ export default {
       const resizeBound = this.resize.getBoundingClientRect()
       this.resizeWidth = resizeBound.width
 
-      if (this.nextEl) { // check the table width
+      if (this.nextEl) {
         const nextBound = this.nextEl.getBoundingClientRect()
         this.nextWidth = nextBound.width
       }
@@ -98,11 +98,16 @@ export default {
         const newWidth = this.resizeWidth + mouseMoved
         const newNextWidth = this.nextWidth - mouseMoved
 
-        if (newWidth > 25 && newNextWidth > 25) {
-          this.resize.style.width = newWidth + 'px'
-          sessionStorage.setItem(`data-col-field=${this.headerField.field}`, this.resize.style.width)
+        if (newWidth <= 25 || newNextWidth <= 25) {
+          return
+        }
+
+        this.resize.style.width = newWidth + 'px'
+        this.updateSessionStorage(this.headerField.field, this.resize.style.width)
+
+        if (this.nextEl) {
           this.nextEl.style.width = newNextWidth + 'px'
-          sessionStorage.setItem(`data-col-field=${this.nextHeader.field}`, this.nextEl.style.width)
+          this.updateSessionStorage(this.nextHeader.field, this.nextEl.style.width)
         }
       }
     },
@@ -113,6 +118,10 @@ export default {
       document.querySelector('body').removeEventListener('mousemove', this.namedFunc)
       document.querySelector('body').removeEventListener('mouseup', this.stopResize)
       document.querySelector('body').classList.remove('resizing')
+    },
+
+    updateSessionStorage (field, width) {
+      sessionStorage.setItem(`data-col-field=${field}`, width)
     }
   }
 }

--- a/src/components/DpDataTable/DpResizableColumn.vue
+++ b/src/components/DpDataTable/DpResizableColumn.vue
@@ -4,6 +4,7 @@
     ref="resizableColumn"
     class="c-data-table__resizable"
     :class="{ 'u-pr-0' : isLast }"
+    :data-col-field="headerField.field"
     :data-col-idx="idx">
     <slot/>
     <dp-resize-handle
@@ -39,7 +40,13 @@ export default {
       type: Boolean,
       required: false,
       default: false
-    }
+    },
+
+    nextHeader: {
+      type: Object,
+      required: false,
+      default: null
+    },
   },
 
   data () {
@@ -66,13 +73,17 @@ export default {
       this.resize = this.$refs.resizableColumn
       this.currentHandle = this.resize.getElementsByClassName('c-data-table__resize-handle')[0]
       this.currentHandle.classList.add('is-active')
-      this.nextEl = document.querySelector(`th[data-col-idx='${idx + 1}']`)
+      this.nextEl = document.querySelector(`th[data-col-idx='${idx + 1}']`) // could be replaced with data-field
       this.dragStart = true
       this.cursorStart = e.pageX
       const resizeBound = this.resize.getBoundingClientRect()
       this.resizeWidth = resizeBound.width
-      const nextBound = this.nextEl.getBoundingClientRect()
-      this.nextWidth = nextBound.width
+
+      if (this.nextEl) { // check the table width
+        const nextBound = this.nextEl.getBoundingClientRect()
+        this.nextWidth = nextBound.width
+      }
+
       this.namedFunc = (e) => this.resizeEl(e, idx)
       const bodyEl = document.getElementsByTagName('body')[0]
       bodyEl.classList.add('resizing')
@@ -89,7 +100,9 @@ export default {
 
         if (newWidth > 25 && newNextWidth > 25) {
           this.resize.style.width = newWidth + 'px'
+          sessionStorage.setItem(`data-col-field=${this.headerField.field}`, this.resize.style.width)
           this.nextEl.style.width = newNextWidth + 'px'
+          sessionStorage.setItem(`data-col-field=${this.nextHeader.field}`, this.nextEl.style.width)
         }
       }
     },

--- a/src/components/DpDataTable/DpTableHeader.vue
+++ b/src/components/DpDataTable/DpTableHeader.vue
@@ -5,6 +5,7 @@
     :class="{ 'c-data-table__sticky-header': isSticky }">
     <th
       v-if="isDraggable"
+      :data-col-field="isResizable ? 'dragHandle' : null"
       scope="col"
       class="c-data-table__cell--narrow">
       <dp-icon
@@ -13,6 +14,7 @@
     </th>
     <th
       v-if="isSelectable"
+      :data-col-field="isResizable ? 'select' : null"
       scope="col"
       class="c-data-table__cell--narrow">
       <input
@@ -45,6 +47,7 @@
     </template>
     <th
       v-if="hasFlyout"
+      :data-col-field="isResizable ? 'flyout' : null"
       scope="col" />
     <th
       v-if="isExpandable"
@@ -57,6 +60,7 @@
     </th>
     <th
       v-if="isTruncatable"
+      :data-col-field="isResizable ? 'truncatable' : null"
       scope="col"
       class="c-data-table__cell--narrow"
       @click="toggleWrapAll()">

--- a/src/components/DpDataTable/DpTableHeader.vue
+++ b/src/components/DpDataTable/DpTableHeader.vue
@@ -60,7 +60,7 @@
     </th>
     <th
       v-if="isTruncatable"
-      :data-col-field="isResizable ? 'truncatable' : null"
+      :data-col-field="isResizable ? 'wrap' : null"
       scope="col"
       class="c-data-table__cell--narrow"
       @click="toggleWrapAll()">

--- a/src/components/DpDataTable/DpTableHeader.vue
+++ b/src/components/DpDataTable/DpTableHeader.vue
@@ -29,6 +29,7 @@
         v-if="isResizable"
         :is-last="headerFields.length === idx"
         :header-field="hf"
+        :next-header="headerFields[idx + 1]"
         :idx="idx">
         <slot :name="`header-${hf.field}`">
           <span v-if="hf.label" v-text="hf.label" />

--- a/src/components/DpUploadFiles/DpUploadFiles.vue
+++ b/src/components/DpUploadFiles/DpUploadFiles.vue
@@ -44,10 +44,10 @@
 </template>
 
 <script>
+import { prefixClassMixin, sessionStorageMixin } from '~/mixins'
 import DpLabel from '../DpLabel/DpLabel'
 import DpUpload from './DpUpload'
 import DpUploadedFileList from './DpUploadedFileList'
-import { prefixClassMixin } from '~/mixins'
 
 export default {
   name: 'DpUploadFiles',
@@ -58,7 +58,7 @@ export default {
     DpUploadedFileList
   },
 
-  mixins: [prefixClassMixin],
+  mixins: [prefixClassMixin, sessionStorageMixin],
 
   provide () {
     return {
@@ -233,9 +233,7 @@ export default {
 
   watch: {
     storageName () {
-      if (this.storageName) {
-        this.updateSessionStorage()
-      }
+      this.updateSessionStorage(this.storageName, this.uploadedFiles)
     }
   },
 
@@ -251,9 +249,7 @@ export default {
       }
 
       this.uploadedFiles.push(file)
-      if (this.storageName) {
-        this.updateSessionStorage()
-      }
+      this.updateSessionStorage(this.storageName, this.uploadedFiles)
     },
 
     clearFilesList () {
@@ -281,20 +277,12 @@ export default {
       }
 
       this.uploadedFiles = this.uploadedFiles.filter(el => el.hash !== file.hash)
-      if (this.storageName) {
-        this.updateSessionStorage()
-      }
-    },
-
-    updateSessionStorage () {
-      sessionStorage.setItem(this.storageName, JSON.stringify(this.uploadedFiles))
+      this.updateSessionStorage(this.storageName, this.uploadedFiles)
     }
   },
 
   mounted () {
-    if (this.storageName) {
-      this.uploadedFiles = JSON.parse(sessionStorage.getItem(this.storageName)) || []
-    }
+    this.uploadedFiles = this.getItemFromSessionStorage(this.storageName) || []
   }
 }
 </script>

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -1,11 +1,13 @@
 import prefixClassMixin from './prefixClassMixin/prefixClassMixin'
 import dpSelectAllMixin from './dpSelectAllMixin'
 import dpValidateMixin from './dpValidateMixin'
+import sessionStorageMixin from'./sessionStorageMixin'
 import tableSelectAllItems from './tableSelectAllItems'
 
 export {
   dpSelectAllMixin,
   dpValidateMixin,
   prefixClassMixin,
+  sessionStorageMixin,
   tableSelectAllItems
 }

--- a/src/mixins/sessionStorageMixin.js
+++ b/src/mixins/sessionStorageMixin.js
@@ -1,0 +1,25 @@
+export default {
+  methods: {
+    updateSessionStorage (storageName, value) {
+      if (storageName) {
+        sessionStorage.setItem(storageName, JSON.stringify(value))
+      }
+    },
+
+    getItemFromSessionStorage (storageName) {
+      if (storageName) {
+        return JSON.parse(sessionStorage.getItem(storageName))
+      }
+    },
+
+    removeFromSessionStorage (storageName) {
+      if (storageName) {
+        sessionStorage.removeItem(storageName)
+      }
+    },
+
+    clearSessionStorage () {
+      sessionStorage.clear()
+    }
+  }
+}

--- a/src/mixins/sessionStorageMixin.js
+++ b/src/mixins/sessionStorageMixin.js
@@ -8,7 +8,7 @@ export default {
 
     getItemFromSessionStorage (storageName) {
       if (storageName) {
-        return JSON.parse(sessionStorage.getItem(storageName))
+        return JSON.parse(sessionStorage.getItem(storageName)) || null
       }
     },
 


### PR DESCRIPTION
**Ticket:** [DPLAN-11462](https://demoseurope.youtrack.cloud/issue/DPLAN-11462/macht-spalten-in-der-Abschnittsliste-resizable)

**Description:** This PR adds functionality to save the width of the columns to session storage, eliminating the need to adjust the width every time the user reopens the page. Additionally, it fixes some problems with the `is-resizable` feature.

It saves in the sessionStorage with the key `dpDataTable:data-col-field=${field}`

[PR in Core](https://github.com/demos-europe/demosplan-core/pull/3003)