### PR TITLE
Fix(dplan 1965): improve error validation of the Datepicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 ### Fixed
 
 - ([#843](https://github.com/demos-europe/demosplan-ui/pull/843)) DpInput: fix "length" prop validation ([@spiess-demos](https://github.com/spiess-demos))
+- ([#841](https://github.com/demos-europe/demosplan-ui/pull/841)) Fix the DpDatepicker error validation ([@sakutademos](https://github.com/sakutademos))
 
 ## v0.3.10 - 2024-04-26
 

--- a/src/components/DpDateRangePicker/DpDateRangePicker.vue
+++ b/src/components/DpDateRangePicker/DpDateRangePicker.vue
@@ -8,6 +8,7 @@
       :calendars-after="calendarsAfter"
       :calendars-before="calendarsBefore"
       :disabled="startDisabled"
+      :data-dp-validate-error-fieldname="dataDpValidateErrorFieldname || null"
       :value="startValue"
       :required="required || (endDate !== '' && endDate < currentDate)"
       :data-cy="`${dataCy}:startDate`"
@@ -21,6 +22,7 @@
       :calendars-after="calendarsAfter"
       :calendars-before="calendarsBefore"
       :disabled="endDisabled"
+      :data-dp-validate-error-fieldname="dataDpValidateErrorFieldname || null"
       :value="endValue"
       :required="required"
       :data-cy="`${dataCy}:endDate`"
@@ -56,6 +58,12 @@ export default {
       type: String,
       required: false,
       default: 'dateRangePicker'
+    },
+
+    dataDpValidateErrorFieldname: {
+      type: String,
+      required: false,
+      default: ''
     },
 
     endDisabled: {

--- a/src/components/DpDatepicker/DpDatepicker.vue
+++ b/src/components/DpDatepicker/DpDatepicker.vue
@@ -151,8 +151,8 @@ export default {
     addErrorFieldnameAttribute () {
       const datePickerInput = document.getElementsByName(this.name)[0]
       /**
-       * To ensure proper error handling, this attribute needs to be added every time the Datepicker is mounted and updated.
-       * This attribute is needed by the validation to display the field name in case of an error
+       * This attribute is needed for validation to display the field name in case of an error
+       * and must be set every time the Datepicker is mounted or updated.
        */
       datePickerInput.setAttribute('data-dp-validate-error-fieldname', this.dataDpValidateErrorFieldname)
     },

--- a/src/components/DpDatepicker/DpDatepicker.vue
+++ b/src/components/DpDatepicker/DpDatepicker.vue
@@ -164,6 +164,7 @@ export default {
   },
 
   mounted () {
+    // https://github.com/mathislucka/a11y-datepicker
     const config = {
       ...this.calendarsAfter > 0 ? { monthsAfterCurrent: this.calendarsAfter } : {},
       ...this.calendarsBefore > 0 ? { monthsBeforeCurrent: this.calendarsBefore } : {},

--- a/src/components/DpDatepicker/DpDatepicker.vue
+++ b/src/components/DpDatepicker/DpDatepicker.vue
@@ -142,8 +142,20 @@ export default {
   },
 
   methods: {
+    isValidDate (dateString) {
+      // Attempt to create a Date object from the given string
+      const date = new Date(dateString);
+
+      // Check if the created date is valid
+      // Also, check if the input string is not 'Invalid Date'
+      return !isNaN(date.getTime()) && date.toString() !== 'Invalid Date';
+    },
+
     emitUpdate (e) {
       const currentVal = e.target.value
+      const isValid = this.isValidDate(currentVal)
+      console.log('isValid', isValid)
+      console.log('currectVal', currentVal)
       const date = this.datepicker.getDateAsString()
       const valueToEmit = date === currentVal ? date : currentVal
       this.$emit('input', valueToEmit)

--- a/src/components/DpDatepicker/DpDatepicker.vue
+++ b/src/components/DpDatepicker/DpDatepicker.vue
@@ -150,7 +150,11 @@ export default {
   methods: {
     addErrorFieldnameAttribute () {
       const datePickerInput = document.getElementsByName(this.name)[0]
-      datePickerInput.setAttribute('data-dp-validate-error-fieldname', this.dataDpValidateErrorFieldname) // this attribute is required by the validation to showcase the field name in case of an error
+      /**
+       * To ensure proper error handling, this attribute needs to be added every time the Datepicker is mounted and updated.
+       * This attribute is needed by the validation to display the field name in case of an error
+       */
+      datePickerInput.setAttribute('data-dp-validate-error-fieldname', this.dataDpValidateErrorFieldname)
     },
 
     emitUpdate (e) {

--- a/src/components/DpDatepicker/DpDatepicker.vue
+++ b/src/components/DpDatepicker/DpDatepicker.vue
@@ -31,6 +31,12 @@ export default {
       default: 'datepicker'
     },
 
+    dataDpValidateErrorFieldname: {
+      type: String,
+      required: false,
+      default: ''
+    },
+
     disabled: {
       type: Boolean,
       required: false,
@@ -142,29 +148,22 @@ export default {
   },
 
   methods: {
-    isValidDate (dateString) {
-      // Attempt to create a Date object from the given string
-      const date = new Date(dateString);
-
-      // Check if the created date is valid
-      // Also, check if the input string is not 'Invalid Date'
-      return !isNaN(date.getTime()) && date.toString() !== 'Invalid Date';
+    addErrorFieldnameAttribute () {
+      const datePickerInput = document.getElementsByName(this.name)[0]
+      datePickerInput.setAttribute('data-dp-validate-error-fieldname', this.dataDpValidateErrorFieldname) // this attribute is required by the validation to showcase the field name in case of an error
     },
 
     emitUpdate (e) {
       const currentVal = e.target.value
-      const isValid = this.isValidDate(currentVal)
-      console.log('isValid', isValid)
-      console.log('currectVal', currentVal)
       const date = this.datepicker.getDateAsString()
       const valueToEmit = date === currentVal ? date : currentVal
       this.$emit('input', valueToEmit)
       this.$root.$emit('dp-datepicker', { id: this.id, value: valueToEmit })
+      this.addErrorFieldnameAttribute()
     }
   },
 
   mounted () {
-    // https://github.com/mathislucka/a11y-datepicker
     const config = {
       ...this.calendarsAfter > 0 ? { monthsAfterCurrent: this.calendarsAfter } : {},
       ...this.calendarsBefore > 0 ? { monthsBeforeCurrent: this.calendarsBefore } : {},
@@ -177,6 +176,7 @@ export default {
     }
     this.datepicker = Datepicker(config)
     this.value !== '' && this.datepicker.setDate(this.value)
+    this.addErrorFieldnameAttribute()
   }
 }
 </script>

--- a/src/lib/validation/utils/helpers.js
+++ b/src/lib/validation/utils/helpers.js
@@ -2,7 +2,7 @@ import getScrollTop from '../../../utils/getScrollTop'
 import prefixClass from '../../../utils/prefixClass'
 
 function getAllInputsArray (form) {
-  return Array.from(form.querySelectorAll('[pattern], [required], input[type="email"], input[name="r_startdate"], input[name="r_enddate"], .tiptap__input--hidden.is-required, .multiselect.is-required, fieldset.is-required, [minlength], [maxlength], [data-dp-validate-maxlength], [data-dp-validate-should-equal]'))
+  return Array.from(form.querySelectorAll('[pattern], [required], [data-ad-id], input[name="r_enddate"], .tiptap__input--hidden.is-required, .multiselect.is-required, fieldset.is-required, [minlength], [maxlength], [data-dp-validate-maxlength], [data-dp-validate-should-equal]'))
 }
 
 function shouldValidate (input) {
@@ -16,8 +16,7 @@ function shouldValidate (input) {
     isRequired ||
     input.hasAttribute('pattern') ||
     input.getAttribute('type') === 'email' ||
-    input.getAttribute('name') === 'r_startdate' ||
-    input.getAttribute('name') === 'r_enddate' ||
+    input.hasAttribute('data-ad-id') ||
     input.hasAttribute('minlength') ||
     input.hasAttribute('maxlength') ||
     input.hasAttribute('data-dp-validate-maxlength') ||

--- a/src/lib/validation/utils/helpers.js
+++ b/src/lib/validation/utils/helpers.js
@@ -2,7 +2,7 @@ import getScrollTop from '../../../utils/getScrollTop'
 import prefixClass from '../../../utils/prefixClass'
 
 function getAllInputsArray (form) {
-  return Array.from(form.querySelectorAll('[pattern], [required], [data-ad-id], .tiptap__input--hidden.is-required, .multiselect.is-required, fieldset.is-required, [minlength], [maxlength], [data-dp-validate-maxlength], [data-dp-validate-should-equal]'))
+  return Array.from(form.querySelectorAll('[pattern], [required], input[type="email"], [data-ad-id], .tiptap__input--hidden.is-required, .multiselect.is-required, fieldset.is-required, [minlength], [maxlength], [data-dp-validate-maxlength], [data-dp-validate-should-equal]'))
 }
 
 function shouldValidate (input) {

--- a/src/lib/validation/utils/helpers.js
+++ b/src/lib/validation/utils/helpers.js
@@ -2,7 +2,7 @@ import getScrollTop from '../../../utils/getScrollTop'
 import prefixClass from '../../../utils/prefixClass'
 
 function getAllInputsArray (form) {
-  return Array.from(form.querySelectorAll('[pattern], [required], [data-ad-id], input[name="r_enddate"], .tiptap__input--hidden.is-required, .multiselect.is-required, fieldset.is-required, [minlength], [maxlength], [data-dp-validate-maxlength], [data-dp-validate-should-equal]'))
+  return Array.from(form.querySelectorAll('[pattern], [required], [data-ad-id], .tiptap__input--hidden.is-required, .multiselect.is-required, fieldset.is-required, [minlength], [maxlength], [data-dp-validate-maxlength], [data-dp-validate-should-equal]'))
 }
 
 function shouldValidate (input) {

--- a/src/lib/validation/utils/helpers.js
+++ b/src/lib/validation/utils/helpers.js
@@ -16,7 +16,7 @@ function shouldValidate (input) {
     isRequired ||
     input.hasAttribute('pattern') ||
     input.getAttribute('type') === 'email' ||
-    input.hasAttribute('data-ad-id') ||
+    input.hasAttribute('data-ad-id') || /* this attribute is used to get the input of the Datepicker */
     input.hasAttribute('minlength') ||
     input.hasAttribute('maxlength') ||
     input.hasAttribute('data-dp-validate-maxlength') ||

--- a/src/lib/validation/utils/helpers.js
+++ b/src/lib/validation/utils/helpers.js
@@ -2,7 +2,7 @@ import getScrollTop from '../../../utils/getScrollTop'
 import prefixClass from '../../../utils/prefixClass'
 
 function getAllInputsArray (form) {
-  return Array.from(form.querySelectorAll('[pattern], [required], input[type="email"], .tiptap__input--hidden.is-required, .multiselect.is-required, fieldset.is-required, [minlength], [maxlength], [data-dp-validate-maxlength], [data-dp-validate-should-equal]'))
+  return Array.from(form.querySelectorAll('[pattern], [required], input[type="email"], input[name="r_startdate"], input[name="r_enddate"], .tiptap__input--hidden.is-required, .multiselect.is-required, fieldset.is-required, [minlength], [maxlength], [data-dp-validate-maxlength], [data-dp-validate-should-equal]'))
 }
 
 function shouldValidate (input) {
@@ -16,6 +16,8 @@ function shouldValidate (input) {
     isRequired ||
     input.hasAttribute('pattern') ||
     input.getAttribute('type') === 'email' ||
+    input.getAttribute('name') === 'r_startdate' ||
+    input.getAttribute('name') === 'r_enddate' ||
     input.hasAttribute('minlength') ||
     input.hasAttribute('maxlength') ||
     input.hasAttribute('data-dp-validate-maxlength') ||

--- a/src/lib/validation/utils/validateDatepicker.js
+++ b/src/lib/validation/utils/validateDatepicker.js
@@ -2,11 +2,19 @@ import { toggleErrorClass } from './helpers'
 
 export default function validateDatepicker (input) {
   let isValid = true
+
   if (input.value === '') {
-    isValid = false
+    isValid = !input.hasAttribute('required')
   } else {
-    // Regex to check date from https://stackoverflow.com/a/15504877
-    const regex = /^(?:(?:31(.)(?:0?[13578]|1[02]))\1|(?:(?:29|30)(.)(?:0?[13-9]|1[0-2])\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:29(.)0?2\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:0?[1-9]|1\d|2[0-8])(.)(?:(?:0?[1-9])|(?:1[0-2]))\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$/
+    /**
+     * DpDatePicker accepts the dateFormat: 'dd.mm.yyyy'
+     * Regex to check date from https://www.regextester.com/97612
+     * Allows dates following these rules:
+     * - days may have leading zeros. 1-31. max 2 digits
+     * - months may have leading zeros. 1-12. max 2 digits
+     * - years 1900-2099. 4 digits
+     */
+    const regex = /^\s*(3[01]|[12][0-9]|0?[1-9])\.(1[012]|0?[1-9])\.((?:19|20)\d{2})\s*$/
     if (regex.test(input.value) === false) {
       isValid = false
     }


### PR DESCRIPTION
**Ticket:** [DPLAN-1965](https://demoseurope.youtrack.cloud/issue/DPLAN-1965/Invalid-Inputs-beim-Verfahrenerstellen-werfen-nicht-die-richtigen-Fehlernachrichten) 

**Description:**  This PR adjusts the validation of the Datepicker.

- add the `data-dp-validate-error-fieldname` attribute to the Datepicker via `setAttribute() `to facilitate the display of the field name in case of an error.
- include `name` attributes `r_startdate` and `r_enddate` in the validation form, as the date field need to be validated every time the value changes and not only if the field has an `required` attribute
- an empty string is accepted if the `required` attribute is not present.

[PR in Core](https://github.com/demos-europe/demosplan-core/pull/3038)