### PR TITLE
Make length prop validation work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+
+- () DpInput: fix "length" prop validation ([@spiess-demos](https://github.com/spiess-demos))
+
 ## v0.3.10 - 2024-04-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Fixed
 
-- () DpInput: fix "length" prop validation ([@spiess-demos](https://github.com/spiess-demos))
+- ([#843](https://github.com/demos-europe/demosplan-ui/pull/843)) DpInput: fix "length" prop validation ([@spiess-demos](https://github.com/spiess-demos))
 
 ## v0.3.10 - 2024-04-26
 

--- a/src/shared/props/props.js
+++ b/src/shared/props/props.js
@@ -26,21 +26,19 @@
  * to the actual textarea element without further transformation), or String (but containing an integer),
  * to not be forced to transform it to int in every template with `:maxlength="'<Number>'"`.
  */
-const length = () => {
-  return {
-    type: [Boolean, String],
-    required: false,
-    default: false,
-    validator: (string) => {
-      /*
-       * The `string !== true` check actually tests for the empty string being passed
-       * to the property, which internally is converted to the boolean "true". That way,
-       * using the `maxlength` attr without assigning a value to it throws an error.
-       * On the other hand it should not be possible to pass values that can't be
-       * converted into a whole number.
-       */
-      return string !== true && Number(string) % 1 === 0
-    }
+const length = {
+  type: [Boolean, String],
+  required: false,
+  default: false,
+  validator: (string) => {
+    /*
+     * The `string !== true` check actually tests for the empty string being passed
+     * to the property, which internally is converted to the boolean "true". That way,
+     * using the `maxlength` attr without assigning a value to it throws an error.
+     * On the other hand it should not be possible to pass values that can't be
+     * converted into a whole number.
+     */
+    return string !== true && Number(string) % 1 === 0
   }
 }
 


### PR DESCRIPTION
As the "length" variable is assigned to "maxlength" prop, without calling it, it does not need to be a function, rather an object.