### PR TITLE
fix(refs DPLAN-11529): Don't change Width from Next El on Datatable resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+
+- ([#844](https://github.com/demos-europe/demosplan-ui/pull/844)) Prevent changing Width on following DataTable Element, while resizing ([@salisdemos](https://github.com/salisdemos))
+
 ## v0.3.11 - 2024-05-03
 
 ### Fixed

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -18,83 +18,83 @@
       </colgroup>
 
       <thead>
-        <dp-table-header
-          :data-cy="`${dataCy}:header`"
-          :checked="allSelected"
-          :has-flyout="hasFlyout"
-          :header-fields="headerFields"
-          :indeterminate="indeterminate"
-          :is-draggable="isDraggable"
-          :is-expandable="isExpandable"
-          :is-resizable="isResizable"
-          :is-selectable="isSelectable"
-          :is-sticky="hasStickyHeader"
-          :is-truncatable="isTruncatable"
-          :translations="headerTranslations"
-          @toggle-expand-all="toggleExpandAll"
-          @toggle-select-all="toggleSelectAll"
-          @toggle-wrap-all="toggleWrapAll">
-          <template v-slot:[`header-${field}`] v-for="field in fields">
-            <slot :name="`header-${field}`" />
-          </template>
-        </dp-table-header>
+      <dp-table-header
+        :data-cy="`${dataCy}:header`"
+        :checked="allSelected"
+        :has-flyout="hasFlyout"
+        :header-fields="headerFields"
+        :indeterminate="indeterminate"
+        :is-draggable="isDraggable"
+        :is-expandable="isExpandable"
+        :is-resizable="isResizable"
+        :is-selectable="isSelectable"
+        :is-sticky="hasStickyHeader"
+        :is-truncatable="isTruncatable"
+        :translations="headerTranslations"
+        @toggle-expand-all="toggleExpandAll"
+        @toggle-select-all="toggleSelectAll"
+        @toggle-wrap-all="toggleWrapAll">
+        <template v-slot:[`header-${field}`] v-for="field in fields">
+          <slot :name="`header-${field}`" />
+        </template>
+      </dp-table-header>
       </thead>
 
       <!-- not draggable -->
       <tbody v-if="!isDraggable && !isLoading">
-        <template v-for="(item, idx) in items">
-          <dp-table-row
-            ref="tableRows"
-            :data-cy="`${dataCy}:row:${idx}`"
-            :index="idx"
-            :checked="elementSelections[item[trackBy]] || false"
-            :fields="fields"
-            :has-flyout="hasFlyout"
-            :header-fields="headerFields"
-            :is-draggable="isDraggable"
-            :is-expandable="isExpandable"
-            :is-locked="lockCheckboxBy ? item[lockCheckboxBy] : false"
-            :is-locked-message="mergedTranslations.lockedForSelection"
-            :is-resizable="isResizable"
-            :is-selectable="isSelectable"
-            :is-selectable-name="isSelectableName"
-            :is-truncatable="isTruncatable"
-            :item="item"
-            :search-term="searchTerm"
-            :track-by="trackBy"
-            :wrapped="wrappedElements[item[trackBy]] || false"
-            @toggle-expand="toggleExpand"
-            @toggle-select="toggleSelect"
-            @toggle-wrap="toggleWrap">
-            <template
-              v-slot:[field]="item"
-              v-for="field in fields">
-              <slot
-                :name="field"
-                v-bind="item" />
-            </template>
-            <template v-slot:flyout="item">
-              <slot
-                name="flyout"
-                v-bind="item" />
-            </template>
-          </dp-table-row>
+      <template v-for="(item, idx) in items">
+        <dp-table-row
+          ref="tableRows"
+          :data-cy="`${dataCy}:row:${idx}`"
+          :index="idx"
+          :checked="elementSelections[item[trackBy]] || false"
+          :fields="fields"
+          :has-flyout="hasFlyout"
+          :header-fields="headerFields"
+          :is-draggable="isDraggable"
+          :is-expandable="isExpandable"
+          :is-locked="lockCheckboxBy ? item[lockCheckboxBy] : false"
+          :is-locked-message="mergedTranslations.lockedForSelection"
+          :is-resizable="isResizable"
+          :is-selectable="isSelectable"
+          :is-selectable-name="isSelectableName"
+          :is-truncatable="isTruncatable"
+          :item="item"
+          :search-term="searchTerm"
+          :track-by="trackBy"
+          :wrapped="wrappedElements[item[trackBy]] || false"
+          @toggle-expand="toggleExpand"
+          @toggle-select="toggleSelect"
+          @toggle-wrap="toggleWrap">
+          <template
+            v-slot:[field]="item"
+            v-for="field in fields">
+            <slot
+              :name="field"
+              v-bind="item" />
+          </template>
+          <template v-slot:flyout="item">
+            <slot
+              name="flyout"
+              v-bind="item" />
+          </template>
+        </dp-table-row>
 
-          <!-- DpTableRowExpanded -->
-          <tr
-            v-if="expandedElements[item[trackBy]] || false"
-            :class="{ 'is-expanded-content': expandedElements[item[trackBy]] }">
-            <td
-              :class="{ 'opacity-70': isLoading }"
-              :colspan="colCount"
-              @mouseenter="addHoveredClass(idx)"
-              @mouseleave="removeHoveredClass(idx)">
-              <slot
-                name="expandedContent"
-                v-bind="item" />
-            </td>
-          </tr>
-        </template>
+        <!-- DpTableRowExpanded -->
+        <tr
+          v-if="expandedElements[item[trackBy]] || false"
+          :class="{ 'is-expanded-content': expandedElements[item[trackBy]] }">
+          <td
+            :class="{ 'opacity-70': isLoading }"
+            :colspan="colCount"
+            @mouseenter="addHoveredClass(idx)"
+            @mouseleave="removeHoveredClass(idx)">
+            <slot
+              name="expandedContent"
+              v-bind="item" />
+          </td>
+        </tr>
+      </template>
       </tbody>
 
       <!-- draggable -->
@@ -558,9 +558,9 @@ export default {
           const headerFieldWidth = this.getColWidthFromHeaderField(headerField)
 
           const width = fixedWidth
-              || sessionColWidth
-              || headerFieldWidth
-              || `${tableHeaderEl.getBoundingClientRect().width}px`
+            || sessionColWidth
+            || headerFieldWidth
+            || `${tableHeaderEl.getBoundingClientRect().width}px`
 
           tableHeaderEl.style.width = width
           this.updateSessionStorage(storageName, width)
@@ -603,7 +603,9 @@ export default {
       this.elementSelections = this.setElementSelections(this.items, status)
       this.selectedElements = this.filterElementSelections()
       this.$emit('items-selected', this.selectedElements)
-      this.$emit('items-toggled', this.items.map(el => { return { id: el[this.trackBy] } }), status)
+      this.$emit('items-toggled', this.items.map(el => {
+        return { id: el[this.trackBy] }
+      }), status)
 
       // Used by multi-page selection in SegmentsList to determine whether to track selected or deselected items.
       this.$emit('select-all', status)
@@ -636,7 +638,7 @@ export default {
     this.mergedTranslations = { ...this.defaultTranslations, ...tmpTranslations }
   },
 
-  beforeUpdate() {
+  beforeUpdate () {
     this.headerCellCount = this.headerFields.length
   },
 

--- a/src/components/DpDataTable/DpResizableColumn.vue
+++ b/src/components/DpDataTable/DpResizableColumn.vue
@@ -81,41 +81,30 @@ export default {
       this.cursorStart = e.pageX
       const resizeBound = this.resize.getBoundingClientRect()
       this.resizeWidth = resizeBound.width
-
-      if (this.nextEl) {
-        const nextBound = this.nextEl.getBoundingClientRect()
-        this.nextWidth = nextBound.width
-      }
-
       this.namedFunc = (e) => this.resizeEl(e, idx)
       const bodyEl = document.getElementsByTagName('body')[0]
+
       bodyEl.classList.add('resizing')
       bodyEl.addEventListener('mousemove', this.namedFunc)
       bodyEl.addEventListener('mouseup', this.stopResize)
     },
 
-    resizeEl (e, idx) {
+    resizeEl (e) {
       if (this.dragStart) {
         const cursorPos = e.pageX
         const mouseMoved = cursorPos - this.cursorStart
         const newWidth = this.resizeWidth + mouseMoved
-        const newNextWidth = this.nextWidth - mouseMoved
 
-        if (newWidth <= 25 || newNextWidth <= 25) {
+        if (newWidth <= 25) {
           return
         }
 
         this.resize.style.width = newWidth + 'px'
         this.updateSessionStorage(`dpDataTable:data-col-field=${this.headerField.field}`, this.resize.style.width)
-
-        if (this.nextEl) {
-          this.nextEl.style.width = newNextWidth + 'px'
-          this.updateSessionStorage(`dpDataTable:data-col-field=${this.nextHeader.field}`, this.nextEl.style.width)
-        }
       }
     },
 
-    stopResize (e) {
+    stopResize () {
       this.currentHandle.classList.remove('is-active')
       this.dragStart = false
       document.querySelector('body').removeEventListener('mousemove', this.namedFunc)


### PR DESCRIPTION
I removed the behavior in DpDataTable, that on resize the followed Column gets resized too. Now all following cols get "pushed away".

I don't know what GitHub/my IDE did, but I only changed DpResizeableColumn. DpDataTable should only be autolinted.

**Ticket** https://demoseurope.youtrack.cloud/issue/DPLAN-11529/Abschnittstabelle-Nach-Breite-verkleinern-einer-Spalte-wird-die-Spalte-rechts-daneben-sehr-breit-gezogen
