### PR TITLE
fix(refs DPLAN-1898): Destroy Tooltip instead of hiding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Fixed
 
+- ([#848](https://github.com/demos-europe/demosplan-ui/pull/848)) Don't show Tooltips after mouseout (prevent Tooltips from created twice) ([@salisdemos](https://github.com/salisdemos))
 - ([#844](https://github.com/demos-europe/demosplan-ui/pull/844)) Prevent changing Width on following DataTable Element, while resizing ([@salisdemos](https://github.com/salisdemos))
 
 ## v0.3.11 - 2024-05-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 - ([#847](https://github.com/demos-europe/demosplan-ui/pull/847)) Tailwind: add "scrollbar-none" class ([@spiess-demos](https://github.com/spiess-demos))
 
+### Fixed
+- 
+- ([#848](https://github.com/demos-europe/demosplan-ui/pull/848)) Don't show Tooltips after mouseout (prevent Tooltips from created twice) ([@salisdemos](https://github.com/salisdemos))
+
+
 ## v0.3.12 - 2024-05-06
 
 ### Fixed
 
-- ([#848](https://github.com/demos-europe/demosplan-ui/pull/848)) Don't show Tooltips after mouseout (prevent Tooltips from created twice) ([@salisdemos](https://github.com/salisdemos))
 - ([#844](https://github.com/demos-europe/demosplan-ui/pull/844)) Prevent changing Width on following DataTable Element, while resizing ([@salisdemos](https://github.com/salisdemos))
 
 ## v0.3.11 - 2024-05-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,13 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 ### Fixed
 
 - ([#858](https://github.com/demos-europe/demosplan-ui/pull/858)) DpCheckbox: fix vue warning related to type checking ([@sakutademos](https://github.com/sakutademos))
+- ([#848](https://github.com/demos-europe/demosplan-ui/pull/848)) Don't show Tooltips after mouseout (prevent Tooltips from created twice) ([@salisdemos](https://github.com/salisdemos))
 
 ## v0.3.13 - 2024-05-15
 
 ### Added
 
 - ([#847](https://github.com/demos-europe/demosplan-ui/pull/847)) Tailwind: add "scrollbar-none" class ([@spiess-demos](https://github.com/spiess-demos))
-
-### Fixed
-- 
-- ([#848](https://github.com/demos-europe/demosplan-ui/pull/848)) Don't show Tooltips after mouseout (prevent Tooltips from created twice) ([@salisdemos](https://github.com/salisdemos))
-
 
 ## v0.3.12 - 2024-05-06
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demos-europe/demosplan-ui",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "license": "MIT",
   "private": false,
   "description": "Vue components, Vue directives, Design Token and Scss files to build interfaces for demosPlan.",

--- a/src/components/DpTooltip/utils/tooltip.js
+++ b/src/components/DpTooltip/utils/tooltip.js
@@ -41,7 +41,7 @@ const initTooltip = (el, value, options) => {
 
   el.setAttribute('aria-describedby', id)
 
-  handleCreateTooltip = () => showTooltip(
+  handleCreateTooltip = () => createTooltip(
     id,
     el,
     options,
@@ -55,7 +55,7 @@ const initTooltip = (el, value, options) => {
   el.addEventListener('blur', handleRemoveTooltip)
 }
 
-const showTooltip = async (id, wrapperEl, { place = 'top', container = 'body', classes = '' }, zIndex)  => {
+const createTooltip = async (id, wrapperEl, { place = 'top', container = 'body', classes = '' }, zIndex)  => {
   if (!document.getElementById(wrapperEl.getAttribute('aria-describedby'))) {
     const value = tooltips[id]
     // this has to be in sync with the Template in DpTooltip
@@ -128,7 +128,7 @@ const updateTooltip = (wrapper, value, options) => {
 
   if (tooltipEl) {
     deleteTooltip(tooltipEl)
-    showTooltip(wrapperId, wrapper, options, zIndex)
+    createTooltip(wrapperId, wrapper, options, zIndex)
   }
 }
 

--- a/src/components/DpTooltip/utils/tooltip.js
+++ b/src/components/DpTooltip/utils/tooltip.js
@@ -2,8 +2,8 @@ import { arrow, computePosition, flip, offset, shift } from '@floating-ui/dom'
 import { v4 as uuid } from 'uuid'
 
 // We need empty Variables for our show/hide methods, so we can destroy them later on.
-let handleShowTooltip = null
-let handleHideTooltip = null
+let handleCreateTooltip = null
+let handleRemoveTooltip = null
 let handleTimeoutForDestroy = null
 let tooltips = {}
 
@@ -16,10 +16,10 @@ const deleteTooltip = (tooltipEl) => {
 const destroyTooltip = (wrapperEl) => {
   const tooltipEl = document.getElementById(wrapperEl.getAttribute('aria-describedby'))
 
-  wrapperEl.removeEventListener('mouseenter', handleShowTooltip)
-  wrapperEl.removeEventListener('focus', handleShowTooltip)
-  wrapperEl.removeEventListener('mouseleave', handleHideTooltip)
-  wrapperEl.removeEventListener('blur', handleHideTooltip)
+  wrapperEl.removeEventListener('mouseenter', handleCreateTooltip)
+  wrapperEl.removeEventListener('focus', handleCreateTooltip)
+  wrapperEl.removeEventListener('mouseleave', handleRemoveTooltip)
+  wrapperEl.removeEventListener('blur', handleRemoveTooltip)
 
   deleteTooltip(tooltipEl)
 }
@@ -32,22 +32,6 @@ const getZIndex = (element) => {
   return z
 }
 
-const createTooltip = (id, container, classes) => {
-  const value = tooltips[id]
-  // this has to be in sync with the Template in DpTooltip
-  const tooltipHtml =
-    `<div class="tooltip absolute ${classes} z-below-zero" role="tooltip" id="${id}">` +
-    `<div class="tooltip__arrow" data-tooltip-arrow></div>` +
-    `<div class="tooltip__inner">${value}</div>` +
-    `</div>`
-
-  const range = document.createRange()
-
-  const content = range.createContextualFragment(tooltipHtml)
-
-  document.querySelector(container).appendChild(content)
-}
-
 const initTooltip = (el, value, options) => {
   if (!value) return
 
@@ -57,23 +41,33 @@ const initTooltip = (el, value, options) => {
 
   el.setAttribute('aria-describedby', id)
 
-  handleShowTooltip = () => showTooltip(
+  handleCreateTooltip = () => showTooltip(
     id,
     el,
     options,
     zIndex
   )
-  handleHideTooltip = () => deleteTooltip(document.getElementById(el.getAttribute('aria-describedby')))
+  handleRemoveTooltip = () => deleteTooltip(document.getElementById(el.getAttribute('aria-describedby')))
 
-  el.addEventListener('mouseenter', handleShowTooltip)
-  el.addEventListener('focus', handleShowTooltip)
-  el.addEventListener('mouseleave', handleHideTooltip)
-  el.addEventListener('blur', handleHideTooltip)
+  el.addEventListener('mouseenter', handleCreateTooltip)
+  el.addEventListener('focus', handleCreateTooltip)
+  el.addEventListener('mouseleave', handleRemoveTooltip)
+  el.addEventListener('blur', handleRemoveTooltip)
 }
 
 const showTooltip = async (id, wrapperEl, { place = 'top', container = 'body', classes = '' }, zIndex)  => {
   if (!document.getElementById(wrapperEl.getAttribute('aria-describedby'))) {
-    createTooltip(id, container, classes)
+    const value = tooltips[id]
+    // this has to be in sync with the Template in DpTooltip
+    const tooltipHtml =
+      `<div class="tooltip absolute ${classes} z-below-zero" role="tooltip" id="${id}">` +
+      `<div class="tooltip__arrow" data-tooltip-arrow></div>` +
+      `<div class="tooltip__inner">${value}</div>` +
+      `</div>`
+    const range = document.createRange()
+    const content = range.createContextualFragment(tooltipHtml)
+
+    document.querySelector(container).appendChild(content)
   }
 
   const tooltipEl = document.getElementById(id)

--- a/src/components/DpTooltip/utils/tooltip.js
+++ b/src/components/DpTooltip/utils/tooltip.js
@@ -8,7 +8,6 @@ let handleTimeoutForDestroy = null
 let tooltips = {}
 
 const deleteTooltip = (tooltipEl) => {
-  console.log('deleteTooltip', tooltipEl)
   if (tooltipEl) {
     tooltipEl.remove()
   }
@@ -34,7 +33,6 @@ const getZIndex = (element) => {
 }
 
 const createTooltip = (id, container, classes) => {
-  console.log('create tooltip', document.getElementById(id))
   const value = tooltips[id]
   // this has to be in sync with the Template in DpTooltip
   const tooltipHtml =

--- a/src/components/DpTooltip/utils/tooltip.js
+++ b/src/components/DpTooltip/utils/tooltip.js
@@ -8,6 +8,7 @@ let handleTimeoutForDestroy = null
 let tooltips = {}
 
 const deleteTooltip = (tooltipEl) => {
+  console.log('deleteTooltip', tooltipEl)
   if (tooltipEl) {
     tooltipEl.remove()
   }
@@ -32,16 +33,8 @@ const getZIndex = (element) => {
   return z
 }
 
-const hideTooltip = (tooltipEl) => {
-  if (tooltipEl) {
-    tooltipEl.classList.add('z-below-zero')
-    tooltipEl.classList.add('opacity-0')
-  }
-
-  handleTimeoutForDestroy = setTimeout(() => deleteTooltip(tooltipEl), 300)
-}
-
 const createTooltip = (id, container, classes) => {
+  console.log('create tooltip', document.getElementById(id))
   const value = tooltips[id]
   // this has to be in sync with the Template in DpTooltip
   const tooltipHtml =
@@ -72,7 +65,7 @@ const initTooltip = (el, value, options) => {
     options,
     zIndex
   )
-  handleHideTooltip = () => hideTooltip(document.getElementById(el.getAttribute('aria-describedby')))
+  handleHideTooltip = () => deleteTooltip(document.getElementById(el.getAttribute('aria-describedby')))
 
   el.addEventListener('mouseenter', handleShowTooltip)
   el.addEventListener('focus', handleShowTooltip)
@@ -83,8 +76,6 @@ const initTooltip = (el, value, options) => {
 const showTooltip = async (id, wrapperEl, { place = 'top', container = 'body', classes = '' }, zIndex)  => {
   if (!document.getElementById(wrapperEl.getAttribute('aria-describedby'))) {
     createTooltip(id, container, classes)
-  } else {
-    clearTimeout(handleTimeoutForDestroy)
   }
 
   const tooltipEl = document.getElementById(id)
@@ -109,11 +100,11 @@ const showTooltip = async (id, wrapperEl, { place = 'top', container = 'body', c
     zIndex: Number(zIndex) + 1
   })
 
- /*
-   * Handles the position of the arrow -  e.g. if the Tooltip is on the top,
-   * we want to place the arrow at the bottom, and so on. `placement` can be
-   * 'bottom-start' etc as well, so we have to make sure to only take the first part.
-   */
+  /*
+    * Handles the position of the arrow -  e.g. if the Tooltip is on the top,
+    * we want to place the arrow at the bottom, and so on. `placement` can be
+    * 'bottom-start' etc as well, so we have to make sure to only take the first part.
+    */
   const { x: arrowX, y: arrowY } = middlewareData.arrow
   const opposedSide = {
     top: 'bottom',


### PR DESCRIPTION
It was the idea to hide the tooltip on mouseleave and only destroy it after 300ms to prevent recreating it again and again. But it turned out that it then sometimes got created twice. That had the effect, that the second tooltip didn't disappear.

**Ticket** DPLAN-1898