### PR TITLE
fix(DPLAN-2231): fix 'data-dp-validate-if' within a fieldset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Fixed
 
-- ([#850](https://github.com/demos-europe/demosplan-ui/pull/850)) Fix the validation of the relation when the 'data-dp-validate-if' is provided ([@sakutademos](https://github.com/sakutademos))
+- ([#850](https://github.com/demos-europe/demosplan-ui/pull/850)) Input validation: use form as validation container ([@sakutademos](https://github.com/sakutademos))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+
+- ([#847](https://github.com/demos-europe/demosplan-ui/pull/847)) Tailwind: add "scrollbar-none" class ([@spiess-demos](https://github.com/spiess-demos))
+
 ## v0.3.12 - 2024-05-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+
+- ([#850](https://github.com/demos-europe/demosplan-ui/pull/850)) Fix the validation of the relation when the 'data-dp-validate-if' is provided ([@sakutademos](https://github.com/sakutademos))
+
 ### Added
 
 - ([#847](https://github.com/demos-europe/demosplan-ui/pull/847)) Tailwind: add "scrollbar-none" class ([@spiess-demos](https://github.com/spiess-demos))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Fixed
 
-- ([#858](https://github.com/demos-europe/demosplan-ui/pull/858)) DpCheckbox: fix vue warning related to type checking ([@sakutademos](https://github.com/sakutademos))
+- ([#858](https://github.com/demos-europe/demosplan-ui/pull/858)) DpCheckboxGroup: fix vue warning related to type checking ([@sakutademos](https://github.com/sakutademos))
 - ([#850](https://github.com/demos-europe/demosplan-ui/pull/850)) Input validation: use form as validation container ([@sakutademos](https://github.com/sakutademos))
 
 ## v0.3.13 - 2024-05-15

--- a/src/lib/validation/utils/assignHandlersForInputs.js
+++ b/src/lib/validation/utils/assignHandlersForInputs.js
@@ -21,7 +21,8 @@ function assignHandlersForSingleInput (input) {
       allConditions.forEach(condition => {
         const comparisonType = condition.indexOf('!==') > -1 ? 'isNotEqual' : 'isEqual'
         const matchers = condition.split(comparisonType === 'isNotEqual' ? '!==' : '===')
-        const form = input.closest('[data-dp-validate]')
+        const validationContainer = input.closest('[data-dp-validate]')
+        const form = (validationContainer.tagName === 'FIELDSET') ? validationContainer.form : validationContainer
 
         try {
           const inputToCheck = form.querySelector(matchers[0]) // It has to be a valid querySelector, which means that numerical ids will throw an error
@@ -59,7 +60,15 @@ function assignHandlersForSingleInput (input) {
     case 'fieldset':
       checkboxes = Array.from(input.querySelectorAll('input[type="checkbox"]'))
       radios = Array.from(input.querySelectorAll('input[type="radio"]'))
-      fieldsToCheck = checkboxes.length > 0 ? checkboxes : (radios.length > 0 ? radios : [])
+
+      if (checkboxes.length > 0) {
+        fieldsToCheck = checkboxes
+      } else if (radios.length > 0) {
+        fieldsToCheck = radios
+      } else {
+        fieldsToCheck = []
+      }
+
       fieldsToCheck.forEach(checkbox => checkbox.addEventListener('blur', () => validateFieldset(input)))
       fieldsToCheck.forEach(checkbox => checkbox.addEventListener('change', () => validateFieldset(input)))
       observeValidationRelations(input, () => validateFieldset(input))

--- a/src/lib/validation/utils/assignHandlersForInputs.js
+++ b/src/lib/validation/utils/assignHandlersForInputs.js
@@ -22,7 +22,7 @@ function assignHandlersForSingleInput (input) {
         const comparisonType = condition.indexOf('!==') > -1 ? 'isNotEqual' : 'isEqual'
         const matchers = condition.split(comparisonType === 'isNotEqual' ? '!==' : '===')
         const validationContainer = input.closest('[data-dp-validate]')
-        const form = (validationContainer.tagName === 'FIELDSET') ? validationContainer.form : validationContainer
+        const form = validationContainer.tagName === 'FIELDSET' && validationContainer.form ? validationContainer.form : validationContainer
 
         try {
           const inputToCheck = form.querySelector(matchers[0]) // It has to be a valid querySelector, which means that numerical ids will throw an error

--- a/src/lib/validation/utils/assignHandlersForInputs.js
+++ b/src/lib/validation/utils/assignHandlersForInputs.js
@@ -22,6 +22,11 @@ function assignHandlersForSingleInput (input) {
         const comparisonType = condition.indexOf('!==') > -1 ? 'isNotEqual' : 'isEqual'
         const matchers = condition.split(comparisonType === 'isNotEqual' ? '!==' : '===')
         const validationContainer = input.closest('[data-dp-validate]')
+        /**
+           Use the form as the validation container. This is necessary because in some cases, such as wizard,
+           the value of the 'data-dp-validate-if' attribute may refer to a different fieldset.
+           By using the form, this condition can be found throughout the entire form.
+        */
         const form = validationContainer.tagName === 'FIELDSET' && validationContainer.form ? validationContainer.form : validationContainer
 
         try {

--- a/src/lib/validation/utils/helpers.js
+++ b/src/lib/validation/utils/helpers.js
@@ -31,6 +31,11 @@ function validateConditionsFulfilled (input) {
     const comparisonType = condition.indexOf('!==') > -1 ? 'isNotEqual' : 'isEqual'
     const matchers = condition.split(comparisonType === 'isNotEqual' ? '!==' : '===')
     const validationContainer = input.closest('[data-dp-validate]')
+    /**
+     Use the form as the validation container. This is necessary because in some cases, such as wizard,
+     the value of the 'data-dp-validate-if' attribute may refer to a different fieldset.
+     By using the form, this condition can be found throughout the entire form.
+     */
     const form = validationContainer.tagName === 'FIELDSET' && validationContainer.form ? validationContainer.form : validationContainer
 
     try {

--- a/src/lib/validation/utils/helpers.js
+++ b/src/lib/validation/utils/helpers.js
@@ -30,7 +30,8 @@ function validateConditionsFulfilled (input) {
   return allConditions.some(condition => {
     const comparisonType = condition.indexOf('!==') > -1 ? 'isNotEqual' : 'isEqual'
     const matchers = condition.split(comparisonType === 'isNotEqual' ? '!==' : '===')
-    const form = input.closest('[data-dp-validate]')
+    const validationContainer = input.closest('[data-dp-validate]')
+    const form = (validationContainer.tagName === 'FIELDSET') ? validationContainer.form : validationContainer
 
     try {
       const inputToCheck = form.querySelector(matchers[0]) // It has to be a valid querySelector, which means that numerical ids will throw an error

--- a/src/lib/validation/utils/helpers.js
+++ b/src/lib/validation/utils/helpers.js
@@ -31,7 +31,7 @@ function validateConditionsFulfilled (input) {
     const comparisonType = condition.indexOf('!==') > -1 ? 'isNotEqual' : 'isEqual'
     const matchers = condition.split(comparisonType === 'isNotEqual' ? '!==' : '===')
     const validationContainer = input.closest('[data-dp-validate]')
-    const form = (validationContainer.tagName === 'FIELDSET') ? validationContainer.form : validationContainer
+    const form = validationContainer.tagName === 'FIELDSET' && validationContainer.form ? validationContainer.form : validationContainer
 
     try {
       const inputToCheck = form.querySelector(matchers[0]) // It has to be a valid querySelector, which means that numerical ids will throw an error

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -38,6 +38,16 @@ module.exports = {
           'word-break': 'break-word',
           'hyphens': 'auto'
         },
+        /**
+         * Hide scrollbar while keeping the element scrollable.
+         * See https://stackoverflow.com/a/63756377/6234391
+         */
+        '.scrollbar-none': {
+          'scrollbar-width': 'none',
+          '&::-webkit-scrollbar': {
+            'display': 'none'
+          }
+        }
       })
     })
   ],


### PR DESCRIPTION
**Ticket:** [DPLAN-2231](https://demoseurope.youtrack.cloud/issue/DPLAN-2231/Fehlermeldung-das-Verfahren-nicht-verortet-ist-in-jeden-Assistent-schritt-angezeigt)

**Description:** This PR fixes an issue with validation when a 'data-dp-validate-if' attribute is provided in an input within a fieldset instead of directly within a form, because the query selector (line 20) should search the entire form rather than just the fieldset; otherwise, it returns null.

- check if a `fieldset` is provided instead of a `form` when using `input.closest('[data-dp-validate]')`
- cognitive complexity has been reduced for the 'assignHandlersForSingleInput' method to address a SonarCloud issue