### PR TITLE
fix(DPLAN-3297): DpLabel: adjust tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Changed
+
+- ([#851](https://github.com/demos-europe/demosplan-ui/pull/851)) DpLabel: replace the tooltip directive with the DpContextualHelp component ([@sakutademos](https://github.com/sakutademos))
+
 ### Added
 
 - ([#847](https://github.com/demos-europe/demosplan-ui/pull/847)) Tailwind: add "scrollbar-none" class ([@spiess-demos](https://github.com/spiess-demos))

--- a/src/components/DpLabel/DpLabel.vue
+++ b/src/components/DpLabel/DpLabel.vue
@@ -74,12 +74,6 @@ export default {
     }
   },
 
-  data () {
-    return {
-      ariaLabel: de.contextualHelp
-    }
-  },
-
   computed: {
     /**
      * List of Hints

--- a/src/components/DpLabel/DpLabel.vue
+++ b/src/components/DpLabel/DpLabel.vue
@@ -14,25 +14,26 @@
           v-cleanhtml="h" />
       </span>
     </span>
-    <i
+    <dp-contextual-help
       v-if="tooltip !== ''"
-      :class="prefixClass('fa fa-question-circle u-mt-0_125 ml-auto')"
+      :class="prefixClass('mt-px ml-0.5')"
       :aria-label="ariaLabel"
-      v-tooltip="tooltip" />
+      :text="tooltip" />
   </label>
 </template>
 
 <script>
-import { CleanHtml, Tooltip } from '~/directives'
+import { CleanHtml } from '~/directives'
 import { de } from '~/components/shared/translations'
 import { prefixClassMixin } from '~/mixins'
+import DpContextualHelp from '~/components/DpContextualHelp/DpContextualHelp.vue'
 
 export default {
   name: 'DpLabel',
+  components: { DpContextualHelp },
 
   directives: {
-    cleanhtml: CleanHtml,
-    tooltip: Tooltip
+    cleanhtml: CleanHtml
   },
 
   mixins: [prefixClassMixin],

--- a/src/components/DpLabel/DpLabel.vue
+++ b/src/components/DpLabel/DpLabel.vue
@@ -17,7 +17,6 @@
     <dp-contextual-help
       v-if="tooltip !== ''"
       :class="prefixClass('mt-px ml-0.5')"
-      :aria-label="ariaLabel"
       :text="tooltip" />
   </label>
 </template>
@@ -26,7 +25,7 @@
 import { CleanHtml } from '~/directives'
 import { de } from '~/components/shared/translations'
 import { prefixClassMixin } from '~/mixins'
-import DpContextualHelp from '~/components/DpContextualHelp/DpContextualHelp.vue'
+import DpContextualHelp from '~/components/DpContextualHelp'
 
 export default {
   name: 'DpLabel',


### PR DESCRIPTION
**Ticket:** [DPLAN-3297](https://demoseurope.youtrack.cloud/issue/DPLAN-3297/2-Als-Fachplanung-mochte-ich-Institutionen-per-E-Mail-zu-einem-Verfahren-einladen-konnen-obwohl-sie-noch-nicht-in-BLP)

**Description:** DpLabel: use the DpContextualHelp component instead of the tooltip directive and place it near the label.