### PR TITLE
fix(DPLAN-11483): vue warning on type check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 - ([#851](https://github.com/demos-europe/demosplan-ui/pull/851)) DpLabel: replace the tooltip directive with the DpContextualHelp component ([@sakutademos](https://github.com/sakutademos))
 
+### Fixed
+
+- ([#858](https://github.com/demos-europe/demosplan-ui/pull/858)) DpCheckbox: fix vue warning related to type checking ([@sakutademos](https://github.com/sakutademos))
+
 ## v0.3.13 - 2024-05-15
 
 ### Added

--- a/src/components/DpCheckboxGroup/DpCheckboxGroup.vue
+++ b/src/components/DpCheckboxGroup/DpCheckboxGroup.vue
@@ -15,7 +15,7 @@
         text: option.label
       }"
       :name="option.name || ''"
-      :data-cy="dataCy !== '' ? `${dataCy}:${option.id}` : false"
+      :data-cy="dataCy !== '' ? `${dataCy}:${option.id}` : null"
       @change="$emit('update', selected)" />
   </fieldset>
 </template>


### PR DESCRIPTION
**Ticket:** [DPLAN-11483](https://demoseurope.youtrack.cloud/issue/DPLAN-11483/8-2-Als-Planungsburo-brauche-ich-eine-Admin-Rolle-um-Verfahren-selbst-anlegen-und-durchfuhren-zu-konnen) 

**Description:** Fix the warning: _Type check failed for the prop 'dataCy'_, bacause it expected a string but received a boolean. Change it to `null`, as this attribute does not appear in the element if it is null.