### PR TITLE
bug (refs DPLAN-11472): Only setAttribute if datePickerInput is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+
+- ([#860](https://github.com/demos-europe/demosplan-ui/pull/860)) DpDatePicker: set attribute only if datePickerInput is defined ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
+
 ### Changed
 
 - ([#851](https://github.com/demos-europe/demosplan-ui/pull/851)) DpLabel: replace the tooltip directive with the DpContextualHelp component ([@sakutademos](https://github.com/sakutademos))

--- a/src/components/DpDatepicker/DpDatepicker.vue
+++ b/src/components/DpDatepicker/DpDatepicker.vue
@@ -154,7 +154,7 @@ export default {
        * This attribute is needed for validation to display the field name in case of an error
        * and must be set every time the Datepicker is mounted or updated.
        */
-      datePickerInput.setAttribute('data-dp-validate-error-fieldname', this.dataDpValidateErrorFieldname)
+      datePickerInput?.setAttribute('data-dp-validate-error-fieldname', this.dataDpValidateErrorFieldname)
     },
 
     emitUpdate (e) {


### PR DESCRIPTION
Ticket: [DPLAN-11472](https://demoseurope.youtrack.cloud/issue/DPLAN-11472)

Only set attribute if datePickerInput is defined