### PR TITLE
refactor(refs DPLAN-24): provide id for dragging to another list

### DIFF
--- a/src/components/DpDraggable/DpDraggable.vue
+++ b/src/components/DpDraggable/DpDraggable.vue
@@ -30,6 +30,16 @@ const props = defineProps({
     required: true
   },
 
+
+  /*
+   * Set to true if items should be draggable between different lists
+   */
+  dragAcrossBranches: {
+    type: Boolean,
+    required: false,
+    default: true
+  },
+
   /*
    * Set to true if the content should be draggable and false if not.
    */
@@ -110,6 +120,7 @@ useSortable(
   list,
   {
     disabled: !props.isDraggable,
+    group: props.dragAcrossBranches ? 'treelistgroup' : props.groupId,
     onChange: (e: Event) => props.handleChange(e, props.nodeId, wrapper),
     onAdd: () => emit('add'),
     onEnd: (e) => {

--- a/src/components/DpDraggable/DpDraggable.vue
+++ b/src/components/DpDraggable/DpDraggable.vue
@@ -1,6 +1,7 @@
 <template>
   <component
     :is="draggableTag"
+    :id="groupId"
     ref="wrapper">
     <slot />
   </component>
@@ -22,20 +23,11 @@ const emit = defineEmits(
 
 const props = defineProps({
   /*
-     * Content you want to display in the draggable.
-     */
+  * Content you want to display in the draggable.
+  */
   contentData: {
     type: Array,
     required: true
-  },
-
-  /*
-   * Set to true if items should be draggable between different lists
-   */
-  dragAcrossBranches: {
-    type: Boolean,
-    required: false,
-    default: true
   },
 
   /*
@@ -118,7 +110,6 @@ useSortable(
   list,
   {
     disabled: !props.isDraggable,
-    group: props.dragAcrossBranches ? 'treelistgroup' : props.groupId,
     onChange: (e: Event) => props.handleChange(e, props.nodeId, wrapper),
     onAdd: () => emit('add'),
     onEnd: (e) => {

--- a/src/components/DpTreeList/DpTreeList.vue
+++ b/src/components/DpTreeList/DpTreeList.vue
@@ -59,7 +59,7 @@
         @start="handleDrag('start')"
         @tree:change="bubbleChangeEvent">
         <template
-          v-for="slot in Object.keys($scopedSlots)"
+          v-for="slot in Object.keys($slots)"
           v-slot:[slot]="scope">
           <slot
             :name="slot"

--- a/src/components/DpTreeList/DpTreeListNode.vue
+++ b/src/components/DpTreeList/DpTreeListNode.vue
@@ -56,6 +56,7 @@
     </div>
     <component
       :is="draggable ? 'dp-draggable' : 'div'"
+      :drag-across-branches="options.dragAcrossBranches"
       class="list-style-none u-mb-0 u-1-of-1"
       :content-data="draggable ? children : null"
       draggable-tag="ul"

--- a/src/components/DpTreeList/DpTreeListNode.vue
+++ b/src/components/DpTreeList/DpTreeListNode.vue
@@ -56,7 +56,6 @@
     </div>
     <component
       :is="draggable ? 'dp-draggable' : 'div'"
-      :drag-across-branches="options.dragAcrossBranches"
       class="list-style-none u-mb-0 u-1-of-1"
       :content-data="draggable ? children : null"
       draggable-tag="ul"


### PR DESCRIPTION
https://demoseurope.youtrack.cloud/issue/DPLAN-24/VueDraggable-durch-vue3-kompatible-Alternative-ersetzen

By providing the `id` as an attribute of the html element, we allow accessing it via the properties `to` and `from` of the emitted event `onEnd`.