### PR TITLE
bug (refs DPLAN-11586): Remove header from form posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 - ([#848](https://github.com/demos-europe/demosplan-ui/pull/848)) Don't show Tooltips after mouseout (prevent Tooltips from created twice) ([@salisdemos](https://github.com/salisdemos))
 - ([#850](https://github.com/demos-europe/demosplan-ui/pull/850)) Input validation: use form as validation container ([@sakutademos](https://github.com/sakutademos))
 - ([#860](https://github.com/demos-europe/demosplan-ui/pull/860)) DpDatePicker: set attribute only if datePickerInput is defined ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
+- ([#865](https://github.com/demos-europe/demosplan-ui/pull/865)) DpApi: Don't set Content-Type header for FormData ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
 
 ## v0.3.14 - 2024-05-16
 

--- a/src/lib/DpApi.js
+++ b/src/lib/DpApi.js
@@ -214,8 +214,7 @@ function makeFormPost (payload, url) {
   return dpApi({
     method: 'POST',
     url: url,
-    data: postData,
-    headers: { 'Content-Type': 'multipart/form-data' }
+    data: postData
   })
 }
 


### PR DESCRIPTION
Ticket: [DPLAN-11586](https://demoseurope.youtrack.cloud/issue/DPLAN-11586/Stellungnahme-als-Entwurf-speichern-spater-nicht-sichtbar-unter-Meine-Entwurfe)

If you're sending form data using FormData, you should not manually set the Content-Type header. The browser will automatically set it to multipart/form-data and append the necessary boundary parameter.