### PR TITLE
feat: add resistFingerprintingDuckTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 Since v0.0.10, this Changelog is formatted according to the [Common Changelog][common-changelog] recommendations.
 
 ## UNRELEASED
+
+### Added
+
+- ([#856](https://github.com/demos-europe/demosplan-ui/pull/856)) Utils: add resistFingerprintingDuckTest ([@spiess-demos](https://github.com/spiess-demos))
+
 ## v0.3.16 - 2024-05-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Added
 
-- ([#856](https://github.com/demos-europe/demosplan-ui/pull/856)) Utils: add resistFingerprintingDuckTest ([@spiess-demos](https://github.com/spiess-demos))
+- ([#875](https://github.com/demos-europe/demosplan-ui/pull/875)) Utils: add resistFingerprintingDuckTest ([@spiess-demos](https://github.com/spiess-demos))
 
 ## v0.3.16 - 2024-05-24
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -9,6 +9,7 @@ import getAnimationEventName from './getAnimationEventName'
 import getScrollTop from './getScrollTop'
 import hasOwnProp from './hasOwnProp'
 import prefixClass from './prefixClass'
+import resistFingerprintingDuckTest from './resistFingerprintingDuckTest'
 import sortAlphabetically from './sortAlphabetically'
 import throttle from './throttle'
 import uniqueArrayByObjectKey from './uniqueArrayByObjectKey'
@@ -33,6 +34,7 @@ export {
   hasOwnProp,
   maxlengthHint,
   minlengthHint,
+  resistFingerprintingDuckTest,
   sortAlphabetically,
   throttle,
   prefixClass,

--- a/src/utils/resistFingerprintingDuckTest.js
+++ b/src/utils/resistFingerprintingDuckTest.js
@@ -1,0 +1,49 @@
+/**
+ * Tests if "privacy.resistFingerprinting" is enabled.
+ *
+ * "privacy.resistFingerprinting" is a firefox browser setting which,
+ * if enabled, limits some browser APIs including reading the canvas.
+ * The callback will receive a param which is true if the setting is enabled.
+ *
+ * Usage example in a Vue component:
+ *    mounted () {
+ *      resistFingerprintingDuckTest((isEnabled) => {
+ *        if (isEnabled) {
+ *          // Warn user about enabled "privacy.resistFingerprinting" setting
+ *        }
+ *      })
+ *   }
+ */
+export default function resistFingerprintingDuckTest (callback) {
+  const canvas = document.createElement('canvas')
+  const ctx = canvas.getContext('2d')
+
+  // Draw something on the canvas
+  ctx.fillStyle = 'rgb(0,0,0)'
+  ctx.fillRect(0, 0, 10, 10)
+
+  // Convert canvas to data URL
+  const dataUrl = canvas.toDataURL()
+
+  // Check if the produced data URL corresponds to the expected black square
+  const image = new Image()
+
+  image.onload = function () {
+    // Draw the image onto a new canvas to read the pixel values
+    const testCanvas = document.createElement('canvas')
+    const testCtx = testCanvas.getContext('2d')
+    testCanvas.width = image.width
+    testCanvas.height = image.height
+    testCtx.drawImage(image, 0, 0)
+
+    // Check the first pixel
+    const pixelData = testCtx.getImageData(0, 0, 1, 1).data
+
+    // If the pixel is black, we assume that resistFingerprinting is disabled
+    const resistFingerprintingEnabled = !(pixelData[0] === 0 && pixelData[1] === 0 && pixelData[2] === 0)
+
+    callback(resistFingerprintingEnabled)
+  }
+
+  image.src = dataUrl
+}


### PR DESCRIPTION
As we might need this in several contexts, it is added in demosplan-ui.

Related tickets: 

- https://demoseurope.youtrack.cloud/issue/ProdArchiv-66/Klick-auf-Karte-wahlt-Plane-aus-die-nicht-auf-dem-Punkt-liegen-Firefox
- https://demoseurope.youtrack.cloud/issue/DPLAN-11647/Klick-Problem-auf-der-Seite-Importierte-Stellungnahmen-uberprufen-Schulung