### PR TITLE
fix: Select All should only select selectable items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Changed
+
+- ([#878](https://github.com/demos-europe/demosplan-ui/pull/878)) BREAKING: Prevent "select all" in DpDataTable to select "locked" items. Before all items per page where selected, independed of the the lock state ([@salisdemos](https://github.com/salisdemos))
+
 ### Added
 
 - ([#875](https://github.com/demos-europe/demosplan-ui/pull/875)) Utils: add resistFingerprintingDuckTest ([@spiess-demos](https://github.com/spiess-demos))
@@ -12,7 +16,6 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Changed
 
-- ([#878](https://github.com/demos-europe/demosplan-ui/pull/878)) BREAKING: Prevent "select all" in DpDataTable to select "locked" items. Before all items per page where selected, independed of the the lock state ([@salisdemos](https://github.com/salisdemos))
 - ([#856](https://github.com/demos-europe/demosplan-ui/pull/856)) Bump @tiptap to 2.4.0 ([@spiess-demos](https://github.com/spiess-demos))
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Changed
 
+- ([#878](https://github.com/demos-europe/demosplan-ui/pull/878)) BREAKING: Prevent "select all" in DpDataTable to select "locked" items. Before all items per page where selected, independed of the the lock state ([@salisdemos](https://github.com/salisdemos))
 - ([#856](https://github.com/demos-europe/demosplan-ui/pull/856)) Bump @tiptap to 2.4.0 ([@spiess-demos](https://github.com/spiess-demos))
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Changed
 
-- ([#878](https://github.com/demos-europe/demosplan-ui/pull/878)) BREAKING: Prevent "select all" in DpDataTable to select "locked" items. Before all items per page where selected, independed of the the lock state ([@salisdemos](https://github.com/salisdemos))
+- ([#878](https://github.com/demos-europe/demosplan-ui/pull/878)) BREAKING: Prevent "select all" in DpDataTable from selecting "locked" items. Before, all items per page were selected, independent of the lock state ([@salisdemos](https://github.com/salisdemos))
 
 ### Added
 

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -419,7 +419,7 @@ export default {
       if (this.multiPageSelectionItemsTotal > 0) {
         return this.multiPageSelectionItemsToggled === this.multiPageSelectionItemsTotal || this.multiPageAllSelected
       } else {
-        return this.items.filter(item => this.elementSelections[item[this.trackBy]]).length === this.items.length
+        return this.items.filter(item => this.elementSelections[item[this.trackBy]]).length === this.selectableItems.length
       }
     },
 
@@ -466,6 +466,10 @@ export default {
 
     searchTermSet () {
       return this.searchTerm.source !== '(?:)'
+    },
+
+    selectableItems () {
+      return this.lockCheckboxBy ? this.items.filter(item => !item[this.lockCheckboxBy]) : this.items
     }
   },
 
@@ -600,10 +604,10 @@ export default {
     },
 
     toggleSelectAll (status = this.allSelected === false) {
-      this.elementSelections = this.setElementSelections(this.items, status)
+      this.elementSelections = this.setElementSelections(this.selectableItems, status)
       this.selectedElements = this.filterElementSelections()
       this.$emit('items-selected', this.selectedElements)
-      this.$emit('items-toggled', this.items.map(el => {
+      this.$emit('items-toggled', this.selectableItems.map(el => {
         return { id: el[this.trackBy] }
       }), status)
 

--- a/src/components/DpDataTableExtended/DpDataTableExtended.vue
+++ b/src/components/DpDataTableExtended/DpDataTableExtended.vue
@@ -35,18 +35,10 @@
     </dp-sticky-element>
 
     <dp-data-table
-      :has-flyout="hasFlyout"
-      :header-fields="headerFields"
-      :is-expandable="isExpandable"
-      :is-loading="isLoading"
-      :is-resizable="isResizable"
-      :is-selectable="isSelectable"
-      :is-truncatable="isTruncatable"
+      v-bind="$props"
       @items-selected="emitSelectedItems"
       :items="onPageItems"
-      :search-string="searchString"
-      :should-be-selected-items="currentlySelectedItems"
-      :track-by="trackBy">
+      :should-be-selected-items="currentlySelectedItems">
       <template
         v-for="el in sortableFilteredFields"
         v-slot:[`header-${el.field}`]="element">
@@ -195,6 +187,16 @@ export default {
       type: Array,
       required: false,
       default: () => [10, 50, 100, 200]
+    },
+
+    /**
+     * Use a Boolean Property of the Item to set the Checkbox to a locked state.
+     * This should only be set if `isSelectable` is true.
+     */
+    lockCheckboxBy: {
+      type: String,
+      required: false,
+      default: null
     },
 
     /**


### PR DESCRIPTION
In dpDataTable:
If the feature "lock item" (`lockCheckboxBy`) is on, these items shouldn't be selected when using select all.
