### PR TITLE
bug(refs DPLAN-2071): Escape special characters for searching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+- ([#891](https://github.com/demos-europe/demosplan-ui/pull/891)) DpDataTabele: Escape whitespaces and plus signs for searching ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
+
 ## v0.3.17 - 2024-05-30
 
 ### Changed

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -460,7 +460,7 @@ export default {
       if (this.searchString === null || this.searchString.length < 1) {
         return new RegExp()
       }
-      const searchTerm = this.searchString.replace(/\s*/ig, '\\s*')
+      const searchTerm = this.escapeSpecialCharacters(this.searchString)
       return new RegExp(searchTerm, 'ig')
     },
 
@@ -495,6 +495,23 @@ export default {
       const tableRow = this.$refs.tableRows[idx]
 
       return tableRow.$el.classList.add('is-hovered-content')
+    },
+
+    /**
+     * This method is used to escape special characters in a string.
+     * It specifically targets spaces and plus signs.
+     *
+     * @param {string} string - The string to be processed.
+     * @returns {string} - The processed string with special characters escaped.
+     */
+    escapeSpecialCharacters (string) {
+      return string.replace(/[\s+]/g, (match) => {
+        if (match === ' ') {
+          return '\\s*';
+        } else if (match === '+') {
+          return '\\+';
+        }
+      })
     },
 
     extractTranslations (keys) {

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -505,13 +505,9 @@ export default {
      * @returns {string} - The processed string with special characters escaped.
      */
     escapeSpecialCharacters (string) {
-      return string.replace(/[\s+]/g, (match) => {
-        if (match === ' ') {
-          return '\\s*';
-        } else if (match === '+') {
-          return '\\+';
-        }
-      })
+      return string
+        .replace(/(\s)/g, ' ')
+        .replace(/([+])/g, '\\$&')
     },
 
     extractTranslations (keys) {


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-2071/Text-fehlt-wenn-die-Verfahrenssuche-ein-enthalt

Escape whitspaces and `+` for searching the table. 