### PR TITLE
bug(refs DPLAN-1879): Add hidden attribute for label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+- ([#892](https://github.com/demos-europe/demosplan-ui/pull/892)) DpInput: Add hidden attribute for label ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
+
 ## v0.3.17 - 2024-05-30
 
 ### Changed

--- a/src/components/DpInput/DpInput.vue
+++ b/src/components/DpInput/DpInput.vue
@@ -2,13 +2,13 @@
   <div :class="containerWidth !== '' ? prefixClass(containerWidth) : false">
     <dp-label
       v-if="label.text !== ''"
-      :class="{ 'hide-visually': label.hidden }"
       v-bind="{
         ...label,
         for: id,
         hint: labelHint,
         required: required
-      }" /><!--
+      }"
+      :class="{ 'hide-visually': label.hidden }" /><!--
  --><input
       :id="id"
       :name="name !== '' ? name : null"

--- a/src/components/DpInput/DpInput.vue
+++ b/src/components/DpInput/DpInput.vue
@@ -2,6 +2,7 @@
   <div :class="containerWidth !== '' ? prefixClass(containerWidth) : false">
     <dp-label
       v-if="label.text !== ''"
+      :class="{ 'hide-visually': label.hidden }"
       v-bind="{
         ...label,
         for: id,
@@ -133,12 +134,13 @@ export default {
       type: Object,
       default: () => ({
         bold: true,
+        hidden: false,
         hint: '',
         text: '',
         tooltip: ''
       }),
       validator: (prop) => {
-        return Object.keys(prop).every(key => ['bold', 'hint', 'text', 'tooltip'].includes(key))
+        return Object.keys(prop).every(key => ['bold', 'hidden', 'hint', 'text', 'tooltip'].includes(key))
       }
     },
 


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-2759

Sometimes we don't want a label visually, but there should be one nonetheless for accessibility reasons.

Related PR
https://github.com/demos-europe/demosplan-core/pull/3235