### PR TITLE
bug(refs DPLAN-1879): Move hidden prop to DpLabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 - ([#893](https://github.com/demos-europe/demosplan-ui/pull/893)) Add data attributes for E-2-E Test ([@ahmad-demos](https://github.com/ahmad-demos))
 - ([#892](https://github.com/demos-europe/demosplan-ui/pull/892)) DpInput: Add hidden attribute for label ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
+- ([#894](https://github.com/demos-europe/demosplan-ui/pull/894)) DpLabel: Add hidden attribute for visually hiding the label ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
 
 ## v0.3.17 - 2024-05-30
 

--- a/src/components/DpInput/DpInput.vue
+++ b/src/components/DpInput/DpInput.vue
@@ -133,13 +133,13 @@ export default {
       type: Object,
       default: () => ({
         bold: true,
-        hidden: false,
+        hide: false,
         hint: '',
         text: '',
         tooltip: ''
       }),
       validator: (prop) => {
-        return Object.keys(prop).every(key => ['bold', 'hidden', 'hint', 'text', 'tooltip'].includes(key))
+        return Object.keys(prop).every(key => ['bold', 'hide', 'hint', 'text', 'tooltip'].includes(key))
       }
     },
 

--- a/src/components/DpInput/DpInput.vue
+++ b/src/components/DpInput/DpInput.vue
@@ -7,8 +7,7 @@
         for: id,
         hint: labelHint,
         required: required
-      }"
-      :class="{ 'hide-visually': label.hidden }" /><!--
+      }" /><!--
  --><input
       :id="id"
       :name="name !== '' ? name : null"

--- a/src/components/DpLabel/DpLabel.vue
+++ b/src/components/DpLabel/DpLabel.vue
@@ -1,6 +1,6 @@
 <template>
   <label
-    :class="prefixClass(['o-form__label flex', bold ? 'weight--bold' : 'weight--normal', hints.length > 0 ? 'has-hint' : ''])"
+    :class="prefixClass(['o-form__label flex', bold ? 'weight--bold' : 'weight--normal', hints.length > 0 ? 'has-hint' : '', hidden ?? 'hide-visually'])"
     :for="labelFor">
     <span>
       <span v-cleanhtml="text" /><span v-if="required">*</span>
@@ -47,6 +47,12 @@ export default {
     for: {
       type: String,
       required: true
+    },
+
+    hidden: {
+      type: Boolean,
+      required: false,
+      default: false
     },
 
     // Can be string or array (the second element being the "maxlength" hint).

--- a/src/components/DpLabel/DpLabel.vue
+++ b/src/components/DpLabel/DpLabel.vue
@@ -1,6 +1,6 @@
 <template>
   <label
-    :class="prefixClass(['o-form__label flex', bold ? 'weight--bold' : 'weight--normal', hints.length > 0 ? 'has-hint' : '', hidden ?? 'hide-visually'])"
+    :class="prefixClass(['o-form__label flex', bold ? 'weight--bold' : 'weight--normal', hints.length > 0 ? 'has-hint' : '', hidden ?? 'sr-only'])"
     :for="labelFor">
     <span>
       <span v-cleanhtml="text" /><span v-if="required">*</span>

--- a/src/components/DpLabel/DpLabel.vue
+++ b/src/components/DpLabel/DpLabel.vue
@@ -1,6 +1,6 @@
 <template>
   <label
-    :class="prefixClass(['o-form__label flex', bold ? 'weight--bold' : 'weight--normal', hints.length > 0 ? 'has-hint' : '', hidden ?? 'sr-only'])"
+    :class="prefixClass(['o-form__label flex', bold ? 'weight--bold' : 'weight--normal', hints.length > 0 ? 'has-hint' : '', hide ?? 'sr-only'])"
     :for="labelFor">
     <span>
       <span v-cleanhtml="text" /><span v-if="required">*</span>
@@ -49,7 +49,8 @@ export default {
       required: true
     },
 
-    hidden: {
+    // This is used to hide the label visually, but keep it accessible for screen readers
+    hide: {
       type: Boolean,
       required: false,
       default: false


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-2759

Hidden prop should rather be handled directly in DpLabel instead of DpInput. 

Related PR
https://github.com/demos-europe/demosplan-ui/pull/892