### PR TITLE
refactor: Use tailwind class for hiding visually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 - ([#895](https://github.com/demos-europe/demosplan-ui/pull/895)) Add data attributes for E-2-E Test ([@ahmad-demos](https://github.com/ahmad-demos))
 
+### Changed
+
+- ([#900](https://github.com/demos-europe/demosplan-ui/pull/900)) Refactor: Use tailwind class for hiding elements visually instead of custom class ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
+
 ## v0.3.18 - 2024-06-12
 
 ### Fixed

--- a/src/components/DpButton/DpButton.vue
+++ b/src/components/DpButton/DpButton.vue
@@ -13,7 +13,7 @@
       :icon="icon"
       :size="iconSize" />
     <span
-      :class="{'hide-visually': hideText}"
+      :class="{'sr-only': hideText}"
       v-text="text" />
     <dp-icon
       v-if="iconAfter"

--- a/src/components/DpButtonIcon/DpButtonIcon.vue
+++ b/src/components/DpButtonIcon/DpButtonIcon.vue
@@ -9,7 +9,7 @@
     <i
       :class="`fa ${icon}`"
       aria-hidden="true" />
-    <span class="hide-visually">{{ text }}</span>
+    <span class="sr-only">{{ text }}</span>
   </button>
 </template>
 

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -4,7 +4,7 @@
       ref="tableEl"
       :data-cy="`${dataCy}:table`"
       :class="tableClass">
-      <caption class="hide-visually" v-text="tableDescription" />
+      <caption class="sr-only" v-text="tableDescription" />
       <colgroup
         v-if="headerFields.filter((field) => field.colClass).length > 0">
         <col v-if="isDraggable" />

--- a/src/components/DpEditableList/DpEditableList.stories.mdx
+++ b/src/components/DpEditableList/DpEditableList.stories.mdx
@@ -23,7 +23,7 @@ The component might include features like inline editing, or buttons for adding 
         <span>
           {{ entry.mail }}
           <input
-              class="hide-visually"
+              class="sr-only"
               type="email"
               :value="entry.mail">
         </span>

--- a/src/components/DpEditableList/DpEditableList.stories.tsx
+++ b/src/components/DpEditableList/DpEditableList.stories.tsx
@@ -84,7 +84,7 @@ const meta: Meta<typeof DpEditableList> = {
                 <span>
                   {{ entry.item }}
                   <input
-                      class="hide-visually"
+                      class="sr-only"
                       type="email"
                       :value="entry.item">
                 </span>

--- a/src/components/DpSplitButton/DpSplitButton.vue
+++ b/src/components/DpSplitButton/DpSplitButton.vue
@@ -20,7 +20,7 @@
       @click="toggleDropdown"
       @keyup.esc.prevent="isOpen ? isOpen = !isOpen : ''">
       <i class="fa fa-caret-down c-splitbutton__trigger-icon" />
-      <span class="hide-visually">{{ Translator.trans(isOpen ? 'dropdown.close' : 'dropdown.open') }}</span>
+      <span class="sr-only">{{ Translator.trans(isOpen ? 'dropdown.close' : 'dropdown.open') }}</span>
     </button>
     <div
       v-if="hasDropdownContent"

--- a/src/components/DpTreeList/DpTreeListCheckbox.vue
+++ b/src/components/DpTreeList/DpTreeListCheckbox.vue
@@ -8,7 +8,7 @@
       :checked="checked"
       :value="stringValue"
       @click="check">
-    <span class="hide-visually">{{ label }}</span>
+    <span class="sr-only">{{ label }}</span>
   </label>
 </template>
 

--- a/src/components/DpUploadFiles/DpUploadFiles.vue
+++ b/src/components/DpUploadFiles/DpUploadFiles.vue
@@ -1,7 +1,7 @@
 <template>
   <fieldset :class="prefixClass('layout')">
     <legend
-      class="hide-visually"
+      class="sr-only"
       v-text="Translator.trans('upload.files')" />
     <dp-label
       v-if="label.text"


### PR DESCRIPTION
Refactor: Use tailwind class for hiding visually instead of custom class. 

Related PR https://github.com/demos-europe/demosplan-core/pull/3249