### PR TITLE
Remove !important tailwind config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 ### Changed
 
 - ([#900](https://github.com/demos-europe/demosplan-ui/pull/900)) Refactor: Use tailwind class for hiding elements visually instead of custom class ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
+- ([#](https://github.com/demos-europe/demosplan-ui/pull/)) Remove !important default setting in Tailwind config ([@spiess-demos](https://github.com/spiess-demos))
 
 ## v0.3.18 - 2024-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 ### Changed
 
 - ([#900](https://github.com/demos-europe/demosplan-ui/pull/900)) Refactor: Use tailwind class for hiding elements visually instead of custom class ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
-- ([#](https://github.com/demos-europe/demosplan-ui/pull/)) Remove !important default setting in Tailwind config ([@spiess-demos](https://github.com/spiess-demos))
+- ([#902](https://github.com/demos-europe/demosplan-ui/pull/902)) Remove !important default setting in Tailwind config ([@spiess-demos](https://github.com/spiess-demos))
 
 ## v0.3.18 - 2024-06-12
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -25,7 +25,6 @@ module.exports = {
     './src/components/**/*.{js,vue}',
     './src/directives/**/*.js'
   ],
-  important: true, // Utilities should always win https://sebastiandedeyne.com/why-we-use-important-with-tailwind/
   plugins: [
     plugin(function({ addUtilities }) {
       addUtilities({


### PR DESCRIPTION
As this setting may be added when extending tailwind.config.js from other projects, this does not need to be set here.

See https://github.com/demos-europe/demosplan-core/pull/3272 for reasoning about this change.