### PR TITLE
 fix (refs DPLAN-1952): Fix cut methode for TipTap Editor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+
+- ([#917](https://github.com/demos-europe/demosplan-ui/pull/917)) Fix cut methode for TipTap Editor. ([@ahmad-demos](https://github.com/ahmad-demos))
+
 ### Added
 
 - ([#916](https://github.com/demos-europe/demosplan-ui/pull/916)) Add data attributes for E-2-E Test ([@ahmad-demos](https://github.com/ahmad-demos))

--- a/src/components/DpEditor/DpEditor.vue
+++ b/src/components/DpEditor/DpEditor.vue
@@ -803,10 +803,25 @@ export default {
       return extensions
     },
 
-    cut () {
+    async cut () {
       const selection = window.getSelection()
 
-      selection.deleteFromDocument()
+      if (navigator.clipboard) {
+        try {
+          await navigator.clipboard.writeText(selection.toString())
+          selection.deleteFromDocument()
+        } catch (err) {
+          console.error(err)
+        }
+      } else {
+        // If Browser don't support Clipboard API.
+        try {
+          document.execCommand('cut')
+          selection.deleteFromDocument()
+        } catch (err) {
+          console.error(err)
+        }
+      }
     },
 
     executeSubMenuButtonAction (button, menu, activateOne = false) {


### PR DESCRIPTION
https://demoseurope.youtrack.cloud/issue/DPLAN-1952/Tiptap-Shortcut-Strg-v-fugt-nicht-den-Text-ein-welcher-zuvor-mit-dem-Ausschneiden-Button-entfernt-wurde

- Fix cut methode for TipTap Editor.
- execCommand command is no longer recommended, some browsers don't support it.
- getSelection method itself does not inherently copy or move the selected text to the system clipboard directly.