### PR TITLE
Reduce package size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,4 +3,5 @@ node_modules
 .github
 .storybook
 yarn.lock
+tests
 

--- a/babel-jest-transformer.js
+++ b/babel-jest-transformer.js
@@ -1,7 +1,0 @@
-const babelConfig = {
-    plugins: [
-        '@babel/plugin-transform-modules-commonjs',
-    ],
-};
-
-module.exports = require('babel-jest').createTransformer(babelConfig);


### PR DESCRIPTION
There is no need to include the tests in the published package of this library. They are now excluded. Additionally, a file that used to be part of the build stack was removed. The build behaviour and tests do not change at all with or without that file and it is referenced nowhere.