### PR TITLE
F dplan 11885 upgrade jest test vue3

### DIFF
--- a/tests/Obscure.spec.js
+++ b/tests/Obscure.spec.js
@@ -1,5 +1,3 @@
-
-import { createLocalVue, shallowMount } from '@vue/test-utils'
 import shallowMountWithGlobalMocks from '../jest/shallowMountWithGlobalMocks'
 import DpObscure from '~/components/DpObscure'
 

--- a/tests/components/DpTreeList/DpTreeList.spec.js
+++ b/tests/components/DpTreeList/DpTreeList.spec.js
@@ -21,7 +21,7 @@ describe('DpTreeList', () => {
   })
 
   afterEach(() => {
-    wrapper.destroy()
+    wrapper.unmount()
   })
 
   it('renders component correctly', () => {
@@ -30,7 +30,7 @@ describe('DpTreeList', () => {
 
   it('returns an empty array if a nodes "nodeIsSelected" state is false', () => {
     wrapper = shallowMount(DpTreeList, {
-      propsData: {
+      props: {
         branchIdentifier: jest.fn(),
         draggable: true,
         onMove: jest.fn(),
@@ -48,7 +48,7 @@ describe('DpTreeList', () => {
 
   it('returns an array with the selected nodes if the node has a positive "nodeIsSelected" state', () => {
     wrapper = shallowMount(DpTreeList, {
-      propsData: {
+      props: {
         branchIdentifier: jest.fn(),
         draggable: true,
         onMove: jest.fn(),

--- a/tests/components/DpTreeList/DpTreeListNode.spec.js
+++ b/tests/components/DpTreeList/DpTreeListNode.spec.js
@@ -41,13 +41,17 @@ describe('DpTreeListNode', () => {
 
     wrapper = shallowMount(DpTreeListNode, {
       propsData,
-      mocks,
-      stubs
+      global: {
+        stubs,
+        mocks
+      }
     })
   })
 
   afterEach(() => {
-    wrapper.destroy()
+    if (wrapper) {
+      wrapper.unmount()
+    }
   })
 
   it('renders component correctly', () => {
@@ -93,7 +97,7 @@ describe('DpTreeListNode', () => {
 
   it('does not call the function setSelectionRecursively when the node has no children', () => {
     wrapper = shallowMount(DpTreeListNode, {
-      propsData: {
+      props: {
         children: [],
         draggable: true,
         handleChange: jest.fn(),


### PR DESCRIPTION
https://demoseurope.youtrack.cloud/issue/DPLAN-11885/Unit-Tests-schreiben
https://demoseurope.youtrack.cloud/issue/DPLAN-23/vue-test-utils-von-v1-auf-v2-upgraden
https://test-utils.vuejs.org/migration/

- Upgrade Jest setup to work with vue3 compat mode.
- destroy is now unmount to match Vue 3.
- propsData is now props.
- No more createLocalVue.