### PR TITLE
feat: add a docker setup for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,20 @@
 [![Common Changelog](https://common-changelog.org/badge.svg)](https://common-changelog.org)
 
 Vue components, Vue directives, Design Token and Scss files to build interfaces for demosPlan.
+
+### Using the local Docker container
+
+To have a consistent environment for building demosplan-ui, a Docker configuration exists.
+For Docker Compose 1, the syntax has to be adapted to `docker-compose` instead of `docker compose`. 
+The below commands use Docker Compose 2 syntax.
+
+```shell
+# Start the container
+docker compose -f docker-compose.local.yml up -d
+
+# Shell into the container
+docker compose -f docker-compose.local.yml exec demosplan_ui_local sh
+
+# Stop container
+docker compose -f docker-compose.local.yml down
+```

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,9 @@
+services:
+  demosplan_ui_local:
+    image: node:18-alpine # Set to node:20-alpine for node 20
+    environment:
+      - TZ=Europe/Berlin # Jest tests related to date fail with a UTC container
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: sh -c "tail -f /dev/null"

--- a/package.json
+++ b/package.json
@@ -167,10 +167,6 @@
   "scripts": {
     "build:storybook": "storybook build",
     "build:tokens": "node scripts/buildTokens.js",
-    "c:dev": "yarn c:up && yarn c:shell",
-    "c:down": "docker compose -f docker-compose.local.yml down",
-    "c:shell": "docker compose -f docker-compose.local.yml exec demosplan_ui_local sh",
-    "c:up": "docker compose -f docker-compose.local.yml up -d",
     "prepack": "yarn build && yarn build:tokens",
     "storybook": "storybook dev -p 6006",
     "build": "yarn test && yarn build:prod",

--- a/package.json
+++ b/package.json
@@ -167,6 +167,10 @@
   "scripts": {
     "build:storybook": "storybook build",
     "build:tokens": "node scripts/buildTokens.js",
+    "c:dev": "yarn c:up && yarn c:shell",
+    "c:down": "docker compose -f docker-compose.local.yml down",
+    "c:shell": "docker compose -f docker-compose.local.yml exec demosplan_ui_local sh",
+    "c:up": "docker compose -f docker-compose.local.yml up -d",
     "prepack": "yarn build && yarn build:tokens",
     "storybook": "storybook dev -p 6006",
     "build": "yarn test && yarn build:prod",


### PR DESCRIPTION
To overcome the uncertainty of different node versions for local development, a docker container is used.

The container can be started and shelled into with `yarn c:dev`.