### PR TITLE
fix(refs dplan-12305): Prevent Cursor from jumping to End of file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Fixed
 
+- ([#995](https://github.com/demos-europe/demosplan-ui/pull/995)) Prevent cursor in editor to jump to the End of the file, when obscured text is present  ([@salisdemos](https://github.com/salisdemos))
 - ([#983](https://github.com/demos-europe/demosplan-ui/pull/983)) Fix issue where the project is not correctly installable. ([@spiess-demos](https://github.com/spiess-demos))
 
 ## v0.3.28 - 2024-08-08

--- a/src/components/DpEditor/DpEditor.vue
+++ b/src/components/DpEditor/DpEditor.vue
@@ -690,7 +690,7 @@ export default {
     addAltTextToImage (text) {
       this.$root.$emit('update-image:' + this.editingImage, { alt: text })
       this.resetEditingImage()
-      this.setValue()
+      this.emitValue()
     },
 
     appendText (text) {
@@ -992,11 +992,16 @@ export default {
       }
     },
 
-    setValue () {
+    transformObscureTag (value) {
+      const regex = new RegExp(`<span class="${this.prefixClass('u-obscure')}">(.*?)<\\/span>`, 'g')
+
+      return value.replace(regex, '<dp-obscure>$1</dp-obscure>')
+    },
+
+    emitValue () {
       this.currentValue = this.editor.getHTML()
-      const regex = new RegExp('<span class="' + this.prefixClass('u-obscure') + '">(.*?)<\\/span>', 'g')
-      this.currentValue = this.currentValue.replace(regex, '<dp-obscure>$1</dp-obscure>')
       const isEmpty = (this.currentValue.split('<p>').join('').split('</p>').join('').trim()) === ''
+
       this.$emit('input', isEmpty ? '' : this.currentValue)
     },
 
@@ -1056,7 +1061,7 @@ export default {
       disableInputRules: true,
       disablePasteRules: true,
       onUpdate: () => {
-        this.setValue()
+        this.emitValue()
       },
       editorProps: {
         handleDrop: (_view, _event, _slice, moved) => {
@@ -1089,11 +1094,15 @@ export default {
           // Strip img tags from pasted and dropped content
           returnContent = returnContent.replace(/<img.*?>/g, '')
 
+          returnContent = this.transformObscureTag(returnContent)
+
           return returnContent
         }
       },
 
       onInit: ({ view }) => {
+        this.currentValue = this.transformObscureTag(this.editor.getHTML())
+
         view._props.handleScrollToSelection = customHandleScrollToSelection
       }
     })
@@ -1190,10 +1199,12 @@ function getColorFromCSS (className) {
   div.className = className
   div.id = 'tmpIdToGetColor'
   body.appendChild(div)
+
   const tmpDiv = document.getElementById('tmpIdToGetColor')
   const color = window.getComputedStyle(tmpDiv).getPropertyValue('color')
 
   body.removeChild(tmpDiv)
+
   return color
 }
 </script>

--- a/src/components/DpEditor/libs/editorCustomMark.js
+++ b/src/components/DpEditor/libs/editorCustomMark.js
@@ -1,6 +1,4 @@
-import {
-  Mark,
-} from '@tiptap/core'
+import { Mark } from '@tiptap/core'
 import { de } from '../../shared/translations'
 
 export default Mark.create({

--- a/src/components/DpEditor/libs/editorCustomMark.js
+++ b/src/components/DpEditor/libs/editorCustomMark.js
@@ -1,5 +1,5 @@
-import { Mark } from '@tiptap/core'
 import { de } from '../../shared/translations'
+import { Mark } from '@tiptap/core'
 
 export default Mark.create({
   name: 'markText',

--- a/src/components/DpEditor/libs/editorObscure.js
+++ b/src/components/DpEditor/libs/editorObscure.js
@@ -11,7 +11,7 @@
 import {
   Mark,
   markInputRule,
-  markPasteRule,
+  markPasteRule
 } from '@tiptap/core'
 
 const markInputRegex = /(?:<o>)([^<o>]+)(?:<o>)$/


### PR DESCRIPTION
**Ticket** 
[DPLAN-12305](https://demoseurope.youtrack.cloud/issue/DPLAN-12305/Munchen-Cursor-springt-nach-Korrektur-an-Ende-von-Stellungnahmetext-LHM-Ticket-INC0438291)

If there was an obscured Tag in the text, the cursor jumped to the End of the text on edit. This was caused by an unnecessarily often triggered method which checked transformed these obscured tags to a proper format.

