### PR TITLE
feat (refs DPLAN-3428 AB#4195): Extend video player for embedded videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+- ([#1005](https://github.com/demos-europe/demosplan-ui/pull/1005)) DpVideoPlayer: Extend player to support embedded videos ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
+
 ## v0.3.29 - 2024-08-21
 
 ### Fixed

--- a/src/components/DpVideoPlayer/DpVideoPlayer.vue
+++ b/src/components/DpVideoPlayer/DpVideoPlayer.vue
@@ -50,7 +50,7 @@ export default {
     dataCy: {
       type: String,
       required: false,
-      default: 'videoplayer'
+      default: 'videoPlayer'
     },
 
     /**

--- a/src/components/DpVideoPlayer/DpVideoPlayer.vue
+++ b/src/components/DpVideoPlayer/DpVideoPlayer.vue
@@ -3,13 +3,15 @@
     <template v-if="isEmbeddedSource">
       <div
         :id="id"
+        :data-cy="dataCy"
         :data-plyr-embed-id="primarySource.embedId"
         :data-plyr-provider="primarySource.provider" />
     </template>
     <template v-else>
       <video
-          :aria-labelledby="ariaLabelledby"
           :id="id"
+          :aria-labelledby="ariaLabelledby"
+          :data-cy="dataCy"
           playsinline
           :data-poster="poster">
         <source
@@ -20,11 +22,11 @@
         <track
             v-for="track in tracks"
             :key="track.src"
-            :src="track.src"
-            :srclang="track.srclang"
-            :label="track.label"
+            :default="!!track.default"
             :kind="track.kind"
-            :default="!!track.default">
+            :label="track.label"
+            :src="track.src"
+            :srclang="track.srclang">
       </video>
     </template>
   </div>
@@ -43,6 +45,12 @@ export default {
       type: [String, Boolean],
       required: false,
       default: false
+    },
+
+    dataCy: {
+      type: String,
+      required: false,
+      default: 'videoplayer'
     },
 
     /**

--- a/src/components/DpVideoPlayer/DpVideoPlayer.vue
+++ b/src/components/DpVideoPlayer/DpVideoPlayer.vue
@@ -1,24 +1,32 @@
 <template>
   <div class="relative">
-    <video
-      :aria-labelledby="ariaLabelledby"
-      :id="id"
-      playsinline
-      :data-poster="poster">
-      <source
-        v-for="source in sources"
-        :key="source.src"
-        :src="source.src"
-        :type="source.type">
-      <track
-        v-for="track in tracks"
-        :key="track.src"
-        :src="track.src"
-        :srclang="track.srclang"
-        :label="track.label"
-        :kind="track.kind"
-        :default="!!track.default">
-    </video>
+    <template v-if="isEmbeddedSource">
+      <div
+        :id="id"
+        :data-plyr-embed-id="primarySource.embedId"
+        :data-plyr-provider="primarySource.provider" />
+    </template>
+    <template v-else>
+      <video
+          :aria-labelledby="ariaLabelledby"
+          :id="id"
+          playsinline
+          :data-poster="poster">
+        <source
+            v-for="source in sources"
+            :key="source.src"
+            :src="source.src"
+            :type="source.type">
+        <track
+            v-for="track in tracks"
+            :key="track.src"
+            :src="track.src"
+            :srclang="track.srclang"
+            :label="track.label"
+            :kind="track.kind"
+            :default="!!track.default">
+      </video>
+    </template>
   </div>
 </template>
 
@@ -50,17 +58,46 @@ export default {
       required: true
     },
 
+    isEmbedded: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+
     poster: {
       type: String,
       required: false,
       default: ''
     },
 
+    /**
+     * An array of video sources to be used by the player.
+     *
+     * This prop can handle both embedded video sources (e.g., YouTube, Vimeo)
+     * and traditional HTML5 video sources. The first source in the array is
+     * considered the `primarySource`, and it is used by the player first.
+     *
+     * For embedded videos:
+     * - `provider`: The video platform (e.g., 'youtube', 'vimeo').
+     * - `embedId`: The unique video ID or URL for the embedded video.
+     *
+     * For HTML5 videos:
+     * - `src`: The URL to the video file.
+     * - `type`: The MIME type of the video (e.g., 'video/mp4', 'video/webm').
+     *
+     * The player will automatically detect whether the source is for an embedded
+     * video or an HTML5 video and render the appropriate player markup.
+     *
+     * @type {Array<Object>}
+     * @default []
+     */
     sources: {
       required: false,
       validator: (value) => {
         // Check if all sources have a src and a type attribute
-        return Array.isArray(value) && value.filter(source => source.src && source.type).length === value.length
+        return Array.isArray(value) && value.every(source => {
+          return (source.src && source.type) || (source.embedId && source.provider)
+        })
       },
       default: () => ([])
     },
@@ -72,6 +109,16 @@ export default {
         return Array.isArray(value) && value.filter(track => track.kind && track.srclang && track.label && track.src).length === value.length
       },
       default: () => ([])
+    }
+  },
+
+  computed: {
+    isEmbeddedSource() {
+      return this.primarySource && this.primarySource.embedId && this.primarySource.provider
+    },
+
+    primarySource() {
+      return this.sources[0] || null
     }
   },
 


### PR DESCRIPTION
Ticket: [DPLAN-3428](https://demoseurope.youtrack.cloud/issue/DPLAN-3428)

Extend video player so it can also use embedded videos like from YouTube. 