### PR TITLE
Fix token build breakpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+- ([#](https://github.com/demos-europe/demosplan-ui/pull/)) Fix breakpoint values in Tailwind config ([@spiess-demos](https://github.com/spiess-demos))
+
 ## v0.3.30 - 2024-09-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 ## UNRELEASED
 
 ### Fixed
-- ([#](https://github.com/demos-europe/demosplan-ui/pull/)) Fix breakpoint values in Tailwind config ([@spiess-demos](https://github.com/spiess-demos))
+- ([#1011](https://github.com/demos-europe/demosplan-ui/pull/1011)) Fix breakpoint values in Tailwind config ([@spiess-demos](https://github.com/spiess-demos))
 
 ## v0.3.30 - 2024-09-04
 

--- a/scripts/utils/transformTokens.js
+++ b/scripts/utils/transformTokens.js
@@ -33,11 +33,17 @@ const lowerCamelToDash = (str) => {
 
 // Build Css variables chain to resolve aliases
 const transformTailwindTokenValue = (token, formatterArguments) => {
+  let current = token
+
+  // Css variables are not supported within media queries. See https://stackoverflow.com/a/40723269
+  if (token.path[0] === 'breakpoints') {
+    return current.original.value
+  }
+
   const { dictionary, platform } = formatterArguments
   const varName = `--${platform.prefix}${transformTailwindTokenName(token, true).replace(/\./g, '-')}`
   let fallback = resolveValue(token, dictionary)
 
-  let current = token
   let cssVar = `var(${varName}`
   while (current.original && current.original.value.startsWith('{')) {
     const ref = dictionary.getReferences(current.original.value)[0]


### PR DESCRIPTION
We cannot use Css variables within media queries. As we do not need to override breakpoints anyway, at least for now, the primitive px value is taken instead.

The change leads to the file `tokens/dist/tailwind/breakpoints.js` looking like this:

```js
module.exports = {
  "sm": "620px",
  "md": "904px",
  "lg": "1200px",
  "xl": "1400px"
};
```

instead of this:

```js
module.exports = {
  "sm": "var(--dp-breakpoints-sm, 620px)",
  "md": "var(--dp-breakpoints-md, 904px)",
  "lg": "var(--dp-breakpoints-lg, 1200px)",
  "xl": "var(--dp-breakpoints-xl, 1400px)"
};
```