### PR TITLE
Fix token build breakpoints 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+- ([#](https://github.com/demos-europe/demosplan-ui/pull/)) Fix breakpoint values in Tailwind config ([@spiess-demos](https://github.com/spiess-demos))
+
 ## v0.4.0 - 2024-08-21
 
 **Upgrade to Vue 3**
@@ -211,7 +214,7 @@ to `~0.3.*` in your package.json.
 
 - ([#783](https://github.com/demos-europe/demosplan-ui/pull/783)) Improve error validation for DpMultiselect and DpSelect components ([@sakutademos](https://github.com/sakutademos))
 
-### Changed 
+### Changed
 
 - ([#774](https://github.com/demos-europe/demosplan-ui/pull/774)) Improve render performance of the DpTreeList component ([@sakutademos](https://github.com/sakutademos))
 - ([#784](https://github.com/demos-europe/demosplan-ui/pull/784)) dpApi.get: Always serialize request params ([@spiess-demos](https://github.com/spiess-demos))
@@ -244,8 +247,8 @@ to `~0.3.*` in your package.json.
 
 - ([#739](https://github.com/demos-europe/demosplan-ui/pull/739)) Add missing data attr for E-2-E Test ([@ahmad-demos](https://github.com/ahmad-demos))
 - ([#721](https://github.com/demos-europe/demosplan-ui/pull/721)) Pass the allowEmpty prop to vue-multiselect, which prevents the deselection of values ([@sakutademos](https://github.com/sakutademos))
-- ([#718](https://github.com/demos-europe/demosplan-ui/pull/718)) Add missing data attr for E-2-E Test ([@ahmad-demos](https://github.com/ahmad-demos)) 
-- ([#714](https://github.com/demos-europe/demosplan-ui/pull/714)) add csrf token to dpRpc to prevent missing csrf errors ([@muellerdemos](https://github.com/muellerdemos)) 
+- ([#718](https://github.com/demos-europe/demosplan-ui/pull/718)) Add missing data attr for E-2-E Test ([@ahmad-demos](https://github.com/ahmad-demos))
+- ([#714](https://github.com/demos-europe/demosplan-ui/pull/714)) add csrf token to dpRpc to prevent missing csrf errors ([@muellerdemos](https://github.com/muellerdemos))
 - ([#734](https://github.com/demos-europe/demosplan-ui/pull/734)) Allow mailto links in DpEditor link modal ([@spiess-demos](https://github.com/spiess-demos))
 
 ## v0.3.5-1 - 2024-02-13
@@ -597,7 +600,7 @@ Unfortunately, we had a minor log-entry merge mishap and that wasn't noticed unt
 
 ## v0.0.17 - 2023-03-23
 
-- ([#133](https://github.com/demos-europe/demosplan-ui/pull/133)) Import `a11y-datepicker` not as es Module anymore, to make it resolvable 
+- ([#133](https://github.com/demos-europe/demosplan-ui/pull/133)) Import `a11y-datepicker` not as es Module anymore, to make it resolvable
 
 ## v0.0.16 - 2023-03-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 ## UNRELEASED
 
 ### Fixed
-- ([#](https://github.com/demos-europe/demosplan-ui/pull/)) Fix breakpoint values in Tailwind config ([@spiess-demos](https://github.com/spiess-demos))
+- ([#1012](https://github.com/demos-europe/demosplan-ui/pull/1012)) Fix breakpoint values in Tailwind config ([@spiess-demos](https://github.com/spiess-demos))
 
 ## v0.4.0 - 2024-08-21
 

--- a/scripts/utils/transformTokens.js
+++ b/scripts/utils/transformTokens.js
@@ -33,11 +33,17 @@ const lowerCamelToDash = (str) => {
 
 // Build Css variables chain to resolve aliases
 const transformTailwindTokenValue = (token, formatterArguments) => {
+  let current = token
+
+  // Css variables are not supported within media queries. See https://stackoverflow.com/a/40723269
+  if (token.path[0] === 'breakpoints') {
+    return current.original.value
+  }
+
   const { dictionary, platform } = formatterArguments
   const varName = `--${platform.prefix}${transformTailwindTokenName(token, true).replace(/\./g, '-')}`
   let fallback = resolveValue(token, dictionary)
 
-  let current = token
   let cssVar = `var(${varName}`
   while (current.original && current.original.value.startsWith('{')) {
     const ref = dictionary.getReferences(current.original.value)[0]


### PR DESCRIPTION
This fix is also applied to the 0.3.x branch in #1011 

We cannot use Css variables within media queries. As we do not need to override breakpoints anyway, at least for now, the primitive px value is taken instead.

The change leads to the file `tokens/dist/tailwind/breakpoints.js` looking like this:

```js
module.exports = {
  "sm": "620px",
  "md": "904px",
  "lg": "1200px",
  "xl": "1400px"
};
```

instead of this:

```js
module.exports = {
  "sm": "var(--dp-breakpoints-sm, 620px)",
  "md": "var(--dp-breakpoints-md, 904px)",
  "lg": "var(--dp-breakpoints-lg, 1200px)",
  "xl": "var(--dp-breakpoints-xl, 1400px)"
};
```