### PR TITLE
feat (refs DPLAN-3428 AB#4195): Enable embedded videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Since v0.0.10, this Changelog is formatted according to the [Common Changelog][common-changelog] recommendations.
 
 ## UNRELEASED
+### Added
+- ([#1019](https://github.com/demos-europe/demosplan-ui/pull/1019)) DpVideoPlayer: Extend player to support embedded videos ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
 
 ### Fixed
 - ([#1012](https://github.com/demos-europe/demosplan-ui/pull/1012)) Fix breakpoint values in Tailwind config ([@spiess-demos](https://github.com/spiess-demos))

--- a/src/components/DpVideoPlayer/DpVideoPlayer.vue
+++ b/src/components/DpVideoPlayer/DpVideoPlayer.vue
@@ -1,33 +1,50 @@
 <template>
   <div class="relative">
-    <video
-      :aria-labelledby="ariaLabelledby"
-      :id="id"
-      playsinline
-      :data-poster="poster">
-      <source
-        v-for="source in sources"
-        :key="source.src"
-        :src="source.src"
-        :type="source.type">
-      <track
-        v-for="track in tracks"
-        :key="track.src"
-        :src="track.src"
-        :srclang="track.srclang"
-        :label="track.label"
-        :kind="track.kind"
-        :default="!!track.default">
-    </video>
+    <template v-if="isEmbeddedSource">
+      <div
+        :id="id"
+        :data-cy="dataCy"
+        :data-plyr-embed-id="primarySource.embedId"
+        :data-plyr-provider="primarySource.provider" />
+    </template>
+    <template v-else>
+      <video
+        :id="id"
+        :aria-labelledby="ariaLabelledby"
+        :data-cy="dataCy"
+        playsinline
+        :data-poster="poster">
+        <source
+          v-for="source in sources"
+          :key="source.src"
+          :src="source.src"
+          :type="source.type">
+        <track
+          v-for="track in tracks"
+          :key="track.src"
+          :default="!!track.default"
+          :kind="track.kind"
+          :label="track.label"
+          :src="track.src"
+          :srclang="track.srclang">
+      </video>
+    </template>
   </div>
 </template>
 
 <script>
+import { defineComponent } from 'vue'
 import Plyr from 'plyr/dist/plyr.polyfilled.min'
-export default {
+export default defineComponent({
   name: 'DpVideoPlayer',
 
   props: {
+    dataCy: {
+      type: String,
+      required: false,
+      default: 'videoPlayer'
+    },
+
     /**
      * You may pass the id of an element containing content that describes the video.
      */
@@ -50,17 +67,46 @@ export default {
       required: true
     },
 
+    isEmbedded: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+
     poster: {
       type: String,
       required: false,
       default: ''
     },
 
+    /**
+     * An array of video sources to be used by the player.
+     *
+     * This prop can handle both embedded video sources (e.g., YouTube, Vimeo)
+     * and traditional HTML5 video sources. The first source in the array is
+     * considered the `primarySource`, and it is used by the player first.
+     *
+     * For embedded videos:
+     * - `provider`: The video platform (e.g., 'youtube', 'vimeo').
+     * - `embedId`: The unique video ID or URL for the embedded video.
+     *
+     * For HTML5 videos:
+     * - `src`: The URL to the video file.
+     * - `type`: The MIME type of the video (e.g., 'video/mp4', 'video/webm').
+     *
+     * The player will automatically detect whether the source is for an embedded
+     * video or an HTML5 video and render the appropriate player markup.
+     *
+     * @type {Array<Object>}
+     * @default []
+     */
     sources: {
       required: false,
       validator: (value) => {
         // Check if all sources have a src and a type attribute
-        return Array.isArray(value) && value.filter(source => source.src && source.type).length === value.length
+        return Array.isArray(value) && value.every(source => {
+          return (source.src && source.type) || (source.embedId && source.provider)
+        })
       },
       default: () => ([])
     },
@@ -72,6 +118,15 @@ export default {
         return Array.isArray(value) && value.filter(track => track.kind && track.srclang && track.label && track.src).length === value.length
       },
       default: () => ([])
+    }
+  },
+
+  computed: {
+    isEmbeddedSource() {
+      return this.primarySource && this.primarySource.embedId && this.primarySource.provider
+    },
+    primarySource() {
+      return this.sources[0] || null
     }
   },
 
@@ -100,5 +155,5 @@ export default {
       ]
     })
   }
-}
+})
 </script>


### PR DESCRIPTION
Ticket: [DPLAN-3428](https://demoseurope.youtrack.cloud/issue/DPLAN-3428)

Extend video player so it can also use embedded videos like from YouTube. This feature was already approved for v0.3.x, see link below. 

Related PR
https://github.com/demos-europe/demosplan-ui/pull/1005