### PR TITLE
B(Dplan-12442): dp editor improvement for the screenreader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+- ([#1021](https://github.com/demos-europe/demosplan-ui/pull/1021)) DpEditor: Make EditorContent accessible to the screen readers by adding the 'role' attribute ([@sakutademos](https://github.com/sakutademos)
+
 ## v0.3.31 - 2024-09-09
 
 ### Fixed

--- a/src/components/DpEditor/DpEditor.vue
+++ b/src/components/DpEditor/DpEditor.vue
@@ -1067,6 +1067,7 @@ export default {
         attributes: {
           role: 'textbox'
         },
+
         handleDrop: (_view, _event, _slice, moved) => {
           if (!moved) {
             return true

--- a/src/components/DpEditor/DpEditor.vue
+++ b/src/components/DpEditor/DpEditor.vue
@@ -1064,6 +1064,9 @@ export default {
         this.emitValue()
       },
       editorProps: {
+        attributes: {
+          role: 'textbox'
+        },
         handleDrop: (_view, _event, _slice, moved) => {
           if (!moved) {
             return true


### PR DESCRIPTION
**Ticket:** [DPLAN-12442](https://demoseurope.youtrack.cloud/issue/DPLAN-12442/Barrierefreiheit-nicht-moglich-um-in-Stellungnahme-Textfeld-zu-schreiben-mit-der-Hilfe-von-Screen-reader)

**Description:** This PR makes the EditorContent accessible to the screen readers by adding the `role` attribute.