### PR TITLE
Fix(Dplan-12442): dp editor improvement for the screenreader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 ## UNRELEASED
 
 ### Fixed
+- ([#1022](https://github.com/demos-europe/demosplan-ui/pull/1022)) DpEditor: Make EditorContent accessible to the screen readers by adding the 'role' attribute ([@sakutademos](https://github.com/sakutademos)
 - ([#1012](https://github.com/demos-europe/demosplan-ui/pull/1012)) Fix breakpoint values in Tailwind config ([@spiess-demos](https://github.com/spiess-demos))
 
 ## v0.4.0 - 2024-08-21

--- a/src/components/DpEditor/DpEditor.vue
+++ b/src/components/DpEditor/DpEditor.vue
@@ -1065,6 +1065,10 @@ export default {
         this.emitValue()
       },
       editorProps: {
+        attributes: {
+          role: 'textbox'
+        },
+
         handleDrop: (_view, _event, _slice, moved) => {
           if (!moved) {
             return true


### PR DESCRIPTION
**Ticket:** [DPLAN-12442](https://demoseurope.youtrack.cloud/issue/DPLAN-12442/Barrierefreiheit-nicht-moglich-um-in-Stellungnahme-Textfeld-zu-schreiben-mit-der-Hilfe-von-Screen-reader)

**Description:** This PR makes the EditorContent accessible to the screen readers by adding the `role` attribute.