### PR TITLE
fix(Dplan-12449): dp-obscure tag not being applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 ## UNRELEASED
 
 ### Fixed
+- ([#1027](https://github.com/demos-europe/demosplan-ui/pull/1027)) DpEditor: transform obscure tag on update action ([@sakutademos](https://github.com/sakutademos)
 - ([#1021](https://github.com/demos-europe/demosplan-ui/pull/1021)) DpEditor: Make EditorContent accessible to the screen readers by adding the 'role' attribute ([@sakutademos](https://github.com/sakutademos)
 
 ## v0.3.31 - 2024-09-09

--- a/src/components/DpEditor/DpEditor.vue
+++ b/src/components/DpEditor/DpEditor.vue
@@ -994,8 +994,10 @@ export default {
 
     transformObscureTag (value) {
       const regex = new RegExp(`<span class="${this.prefixClass('u-obscure')}">(.*?)<\\/span>`, 'g')
+      this.currentValue = value.replace(regex, '<dp-obscure>$1</dp-obscure>')
+      const isEmpty = (this.currentValue.split('<p>').join('').split('</p>').join('').trim()) === ''
 
-      return value.replace(regex, '<dp-obscure>$1</dp-obscure>')
+      this.$emit('transformObscureTag', isEmpty ? '' : this.currentValue)
     },
 
     emitValue () {
@@ -1062,6 +1064,7 @@ export default {
       disablePasteRules: true,
       onUpdate: () => {
         this.emitValue()
+        this.transformObscureTag(this.editor.getHTML())
       },
       editorProps: {
         handleDrop: (_view, _event, _slice, moved) => {


### PR DESCRIPTION
**Ticket:** [DPLAN-12449](https://demoseurope.youtrack.cloud/issue/DPLAN-12449/Geschwarzte-Stellungnahme-Text-ist-sichtbar-in-Offentlichkeit-Ansicht)

**Description:** This PR fixes an issue where the `<dp-obscure>` tag was not being applied because the `transformObscureTag` function was not triggered. This function should be executed with every update action, otherwise, the `<dp-obscure>` tag will not be transformed as expected.

However, executing it with every update action causes another bug, [DPLAN-12305 Prevent Cursor from Jumping to End of File](https://github.com/demos-europe/demosplan-ui/pull/995). To resolve this, the transformed text should be pass outside the `input` event to avoid updating the `fullText` directly. 

I think it's because `fullText` is a `v-model` of the editor, and if its value is different from the HTML, it causes the cursor to jump. So, we shouldn't update `fullText` directly but store it in a different variable. I haven't found a better solution, I tried different approaches... If you have a better idea, feel free to share :)

[PR in core](https://github.com/demos-europe/demosplan-core/pull/3700)