### PR TITLE
chore: use default chunkSize value (Infinity) for tus uploads

### DIFF
--- a/src/components/DpUploadFiles/DpUpload.vue
+++ b/src/components/DpUploadFiles/DpUpload.vue
@@ -216,7 +216,7 @@ export default {
 
       this.uppy.use(Tus, {
         endpoint: this.tusEndpoint,
-        chunkSize: 819200, // 800 KiB
+        chunkSize: this.chunkSize,
         limit: 5,
         onAfterResponse: (_req, res) => {
           this.currentFileHash = res.getHeader('X-Demosplan-File-Hash')


### PR DESCRIPTION
### Description:
This PR removes the file upload max chunkSize from the DpUpload component and uses now the default value of the prop which resolves to `Infinity`. This change is for the demosplan vue3 compatible version.