### PR TITLE
fix(refs: DPLAN-12574): fix dp upload files label vue3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 - ([#1019](https://github.com/demos-europe/demosplan-ui/pull/1019)) DpVideoPlayer: Extend player to support embedded videos ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
 
 ### Fixed
+- ([#1036](https://github.com/demos-europe/demosplan-ui/pull/1036)) adjust css of DpUploadFiles.vue to prevent visual breaks ([@muellerdemos](https://github.com/muellerdemos)
 - ([#1031](https://github.com/demos-europe/demosplan-ui/pull/1031)) remove max chunkSize on tus uploads ([@muellerdemos](https://github.com/muellerdemos)
 - ([#1022](https://github.com/demos-europe/demosplan-ui/pull/1022)) DpEditor: Make EditorContent accessible to the screen readers by adding the 'role' attribute ([@sakutademos](https://github.com/sakutademos)
 - ([#1012](https://github.com/demos-europe/demosplan-ui/pull/1012)) Fix breakpoint values in Tailwind config ([@spiess-demos](https://github.com/spiess-demos))

--- a/src/components/DpUploadFiles/DpUploadFiles.vue
+++ b/src/components/DpUploadFiles/DpUploadFiles.vue
@@ -1,5 +1,5 @@
 <template>
-  <fieldset :class="prefixClass('layout')">
+  <fieldset :class="prefixClass('layout--flush u-mt-0_25')">
     <legend
       class="sr-only"
       v-text="mergedTranslations.uploadFiles" />


### PR DESCRIPTION
### Description:
The label appears a little off on different occurrences hence some css adjustments were needed to go from:
![Screenshot_2024-10-07_14-14-48](https://github.com/user-attachments/assets/1e47c30c-151d-4d30-bc09-9e2f323e206c)
to:
![Screenshot_2024-10-07_14-15-31](https://github.com/user-attachments/assets/8ce59905-4a60-4671-bc75-1b9bb1a2cd99)

### Related PRs:
PR for vue2 version: 
https://github.com/demos-europe/demosplan-ui/pull/1037