### PR TITLE
fix(refs DPLAN-12574): fix upload files label position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 - ([#1029](https://github.com/demos-europe/demosplan-ui/pull/1029)) add new utility: capitalizeFirstLetter ([@sakutademos](https://github.com/sakutademos)
 
 ### Fixed
+- ([#1037](https://github.com/demos-europe/demosplan-ui/pull/1037)) adjust css of DpUploadFiles.vue to prevent visual breaks ([@muellerdemos](https://github.com/muellerdemos)
 - ([#1032](https://github.com/demos-europe/demosplan-ui/pull/1032)) remove max chunkSize on tus uploads ([@muellerdemos](https://github.com/muellerdemos)
 
 ## v0.3.32 - 2024-09-23

--- a/src/components/DpUploadFiles/DpUploadFiles.vue
+++ b/src/components/DpUploadFiles/DpUploadFiles.vue
@@ -1,5 +1,5 @@
 <template>
-  <fieldset :class="prefixClass('layout')">
+  <fieldset :class="prefixClass('layout--flush u-mt-0_25')">
     <legend
       class="sr-only"
       v-text="Translator.trans('upload.files')" />


### PR DESCRIPTION
### Description:
The label appears a little off on different occurrences hence some css adjustments were needed to go from:
![Screenshot_2024-10-07_14-14-48](https://github.com/user-attachments/assets/1e47c30c-151d-4d30-bc09-9e2f323e206c)
to:
![Screenshot_2024-10-07_14-15-31](https://github.com/user-attachments/assets/8ce59905-4a60-4671-bc75-1b9bb1a2cd99)

### Related PRs:
PR for vue3 version: 
https://github.com/demos-europe/demosplan-ui/pull/1036