### PR TITLE
fix(refs DPLAN-12516): restore closeButton slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+
+- ([#1042](https://github.com/demos-europe/demosplan-ui/pull/1042)) DpModal: Add closeButton slot ([@hwiem](https://github.com/hwiem))
+
+## v0.3.33 - 2024-10-02
+
 ### Changed
 
 - ([#1033](https://github.com/demos-europe/demosplan-ui/pull/1029)) Dependencies: move 'vue' from peerDep to devDep; add @tiptap/extension-text-style ([@sakutademos](https://github.com/sakutademos)

--- a/src/components/DpModal/DpModal.vue
+++ b/src/components/DpModal/DpModal.vue
@@ -11,15 +11,17 @@
         :aria-label="ariaLabel"
         :class="prefixClass('o-modal__content ' + contentClasses)"
         role="dialog">
-        <button
-          :class="prefixClass('btn--blank o-link--default absolute u-right-0')"
-          :aria-label="title"
-          :title="title"
-          @click.prevent.stop="toggle()">
-          <dp-icon
-            icon="close"
-            size="large" />
-        </button>
+        <slot name="closeButton">
+          <button
+            :class="prefixClass('btn--blank o-link--default absolute u-right-0')"
+            :aria-label="title"
+            :title="title"
+            @click.prevent.stop="toggle()">
+            <dp-icon
+              icon="close"
+              size="large" />
+          </button>
+        </slot>
         <div :class="prefixClass('o-modal__body ' + contentBodyClasses)">
           <h2
             :class="prefixClass('font-size-h1 border--bottom u-pb-0_25 ' + contentHeaderClasses)"


### PR DESCRIPTION
**Ticket:** https://demoseurope.youtrack.cloud/issue/DPLAN-12516/Unnotiger-Leerraum-im-Stellungnahme-Fenster

It seems that at some point, we had a slot for the close button in the modal (it is used in the statement modal in demosplan), but somehow it got lost. It is hereby restored. :sparkles: 

### Tasks
- [x] Update changelog