### PR TITLE
fix(refs dplan-12602): Allow DpEditor to dismiss HTML from Word

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+
+- ([#1043](https://github.com/demos-europe/demosplan-ui/pull/1043)) New Flag for DpEditor: "allowPasteFromWord" (default false) to prevent pasting "html" from msOffice ([@salisdemos](https://github.com/salisdemos))
+
 ## v0.3.33 - 2024-10-02
 
 ### Changed

--- a/src/components/DpEditor/DpEditor.vue
+++ b/src/components/DpEditor/DpEditor.vue
@@ -383,6 +383,12 @@ export default {
   mixins: [prefixClassMixin],
 
   props: {
+    allowPasteFromWord: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+
     /**
      * The Tus endpoint requires basicAuth to be added to the file header.
      */
@@ -996,8 +1002,11 @@ export default {
       const regex = new RegExp(`<span class="${this.prefixClass('u-obscure')}">(.*?)<\\/span>`, 'g')
       this.currentValue = value.replace(regex, '<dp-obscure>$1</dp-obscure>')
       const isEmpty = (this.currentValue.split('<p>').join('').split('</p>').join('').trim()) === ''
+      const transformedText = isEmpty ? '' : this.currentValue
 
-      this.$emit('transformObscureTag', isEmpty ? '' : this.currentValue)
+      this.$emit('transformObscureTag', transformedText)
+
+      return transformedText
     },
 
     emitValue () {
@@ -1077,12 +1086,17 @@ export default {
           }
         },
 
-        transformPastedHTML: (slice) => {
+        transformPastedHTML: (pastedInput) => {
           /*
            * Due to the strange Html format from Word clipbord, lists would not be displayed properly,
            * so we have to handle paste from word manually.
            */
-          slice = handleWordPaste(slice)
+          const { slice, showMessage } = handleWordPaste(pastedInput, this.allowPasteFromWord)
+
+          if (showMessage && window.dpconfirm(de.editor.paste.wordPasteExplanation)) {
+            return ''
+          }
+
           // Handle obscure tags - to handle the paste of fully obscured strings we need to overwrite the default paste behaviour and before the content is pasted we replace the obscure-styles with 'u-obscure' class
           const obscureClass = this.prefixClass('u-obscure')
           const obscureColor = getColorFromCSS(obscureClass)
@@ -1094,7 +1108,7 @@ export default {
           }
 
           // Strip anchor tags if link functionality is not active
-          if (this.toolbar.linkButton === false) {
+          if (!this.toolbar.linkButton) {
             returnContent = returnContent.replace(/<a[^>]*>(.*?)<\/a>/g, '$1')
           }
 

--- a/src/components/DpEditor/libs/handleWordPaste.js
+++ b/src/components/DpEditor/libs/handleWordPaste.js
@@ -66,8 +66,8 @@ function createItemFrom365List (li) {
  * @returns {Object<listId, indent, type, content, listStyleType>}
  */
 function createItemFromMsoList (li) {
-  // "listInfo" is expected to be something something like "mso-list: l1 level1 lfo1"
-  const listInfo = li.getAttribute('style').match(/mso-list:([^'|^"|^;]*)/i)[0] // Find ListInfo
+  // "listInfo" is expected to be something like "mso-list: l1 level1 lfo1"
+  const listInfo = li.getAttribute('style').match(/mso-list:([^'";]*)/i)[0] // Find ListInfo
   const indent = parseInt(listInfo.match(/level\d+/i)[0].slice(5)) // Strip "level" // current level of indentation
   const listId = listInfo.match(/lfo\d+/i)[0] || '' // List ID
   /*
@@ -291,12 +291,14 @@ function prepareDataBeforeParsingMso (slice) {
  *
  * @return {string}
  */
-function handleWordPaste (slice) {
+function handleWordPaste (slice, allowPasteFromWord) {
   const isMso = checkIfMso(slice)
   const isOffice365 = checkIfOffice365(slice)
 
-  if ((isMso || isOffice365) === false) {
-    return slice
+  if (!isMso && !isOffice365) {
+    return { slice, showMessage: false }
+  } else if (!allowPasteFromWord) {
+    return { slice, showMessage: true }
   }
 
   // Strip meta though its not closed and would break the parser

--- a/src/components/DpEditor/libs/handleWordPaste.js
+++ b/src/components/DpEditor/libs/handleWordPaste.js
@@ -274,9 +274,9 @@ function prepareDataBeforeParsingMso (slice) {
      * Remove Microsoft IF comments and replace it with empty spans holding the data, that it can be processed later on
      * to determine if that one listStyleType may be part of an ordered or unordered list.
      */
-    .replace(/<!\[if !(.*?)\]>(.*?)<span(.*?)style='mso-list:Ignore'>(.*?)<!\[endif\]>/gmi, (match, p1, p2, p3, p4) => {
+    .replace(/<!\[if !(\w+)]>(<span[^>]*>)?(.*?)<!\[endif]>/gmi, (match, p1, _p2, p3) => {
       // Try to remove spacing spans
-      const listStyleType = p4
+      const listStyleType = p3
         .replace(/<span[^>]*>/gmi, '')
         .replace(/<\/span>/gmi, '')
         .replace(/(&nbsp;|\s|\\r|\\n|\r|\n)/gmi, '')

--- a/src/components/DpEditor/libs/handleWordPaste.js
+++ b/src/components/DpEditor/libs/handleWordPaste.js
@@ -265,9 +265,9 @@ function buildListAsHtmlString (list) {
 function prepareDataBeforeParsingMso (slice) {
   return slice
     // Strip line breaks
-    .replace(/(&nbsp;|\r|\n)/gmi, ' ')
+    .replace(/(&nbsp;|\r|\n|\\r|\\n)/gmi, ' ')
     // Strip head
-    .replace(/<head>(.|\n|\r)*?<\/head>/mi, '')
+    .replace(/<head>(.|\n|\r|\\r|\\n)*?<\/head>/mi, '')
     // Strip html wrapper and remove conentless and non html like elements "<o:p>"
     .replace(/<(\/)?(html|o:p)[^>]*>/gmi, '')
     /*
@@ -277,9 +277,8 @@ function prepareDataBeforeParsingMso (slice) {
     .replace(/<!\[if !(\w+)]>(<span[^>]*>)?(.*?)<!\[endif]>/gmi, (match, p1, _p2, p3) => {
       // Try to remove spacing spans
       const listStyleType = p3
-        .replace(/<span[^>]*>/gmi, '')
-        .replace(/<\/span>/gmi, '')
-        .replace(/(&nbsp;|\s|\\r|\\n|\r|\n)/gmi, '')
+        .replace(/(<span[^>]*>|<\/span>|&nbsp;|\s|\\r|\\n|\r|\n|")/gmi, '')
+
       return `<span data-val-${p1}="${listStyleType}" />`
     })
 }
@@ -300,6 +299,7 @@ function handleWordPaste (slice, allowPasteFromWord) {
   } else if (!allowPasteFromWord) {
     return { slice, showMessage: true }
   }
+
 
   // Strip meta though its not closed and would break the parser
   slice = slice.replace(/<meta[^>]*>/mi, '')
@@ -342,12 +342,15 @@ function handleWordPaste (slice, allowPasteFromWord) {
   })
 
   // Clear List item collection for the next run.
-  return parsedDom.documentElement.outerHTML
-    .replace(/&gt;/gmi, '>')
-    .replace(/&lt;/gmi, '<')
-    // Remove empty list wrapper
-    .replace(/<div[^>]*?class="ListContainerWrapper[^>]*?><ul[^>]*?><\/ul><\/div>/gm, '')
-    .replace(/<ul[^>]*?><\/ul>/gm, '')
+  return {
+    slice: parsedDom.documentElement.outerHTML
+      .replace(/&gt;/gmi, '>')
+      .replace(/&lt;/gmi, '<')
+      // Remove empty list wrapper
+      .replace(/<div[^>]*?class="ListContainerWrapper[^>]*?><ul[^>]*?><\/ul><\/div>/gm, '')
+      .replace(/<ul[^>]*?><\/ul>/gm, ''),
+    showMessage: false
+  }
 }
 
 export { handleWordPaste }

--- a/src/components/shared/translations.js
+++ b/src/components/shared/translations.js
@@ -36,6 +36,9 @@ const de = {
       insert: 'Link einfügen',
       hint: 'URLs sollten mit \'https://\' beginnen.'
     },
+    paste: {
+      wordPasteExplanation: 'Um Text aus Word einzufügen, benutzen Sie bitte die Tastenkombination "Strg + Umschalt + v".'
+    },
     redo: 'Wiederholen',
     underline: 'Unterstrichen',
     undo: 'Rückgängig'


### PR DESCRIPTION
**Ticket** [DPLAN-12602](https://demoseurope.youtrack.cloud/issue/DPLAN-12602/BLP-STN-Formular-es-wird-nicht-der-ganze-Inhalt-bei-Copy-Paste-aus-Word-ubernommen)

Since its really complicated to fetch all edgecases from msOffice Word "html", there now is an option to "protect" the editor by denying the html-input from word.

Additionally I optimized the regex a bit to be not so greedy and to better find breaks like \n or \r