### PR TITLE
fix(refs dplan-12602): Allow DpEditor to dismiss HTML from Word (#1043)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added 
+
+- ([#1043](https://github.com/demos-europe/demosplan-ui/pull/1043)) New Flag for DpEditor: "allowPasteFromWord" (default false) to prevent pasting "html" from msOffice ([@salisdemos](https://github.com/salisdemos))
+
 ## v0.3.18-1 - 2024-08-23
 
 ### Fixed

--- a/src/components/shared/translations.js
+++ b/src/components/shared/translations.js
@@ -36,6 +36,9 @@ const de = {
       insert: 'Link einfügen',
       hint: 'URLs sollten mit \'https://\' beginnen.'
     },
+    paste: {
+      wordPasteExplanation: 'Um Text aus Word einzufügen, benutzen Sie bitte die Tastenkombination "Strg + Umschalt + v".'
+    },
     redo: 'Wiederholen',
     underline: 'Unterstrichen',
     undo: 'Rückgängig'


### PR DESCRIPTION
- domesticate greedy regex in ms-office parser
- Add alert to dismiss pasted html from Word (as editor flag)


This a cherry-pic from https://github.com/demos-europe/demosplan-ui/pull/1043
