### PR TITLE
refac: checkbox: add additional type to selected prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+- ([#1050](https://github.com/demos-europe/demosplan-ui/pull/1050)) DpCheckbox: add additional type to 'selected' prop ([@sakutademos](https://github.com/sakutademos)
+
 ## v0.3.34 - 2024-10-09
 
 ### Added

--- a/src/components/DpSelect/DpSelect.vue
+++ b/src/components/DpSelect/DpSelect.vue
@@ -127,7 +127,7 @@ export default {
     },
 
     selected: {
-      type: String,
+      type: [ String, Number ],
       required: false,
       default: ''
     }

--- a/src/components/DpSelect/DpSelect.vue
+++ b/src/components/DpSelect/DpSelect.vue
@@ -127,7 +127,7 @@ export default {
     },
 
     selected: {
-      type: [ String, Number ],
+      type: [String, Number],
       required: false,
       default: ''
     }


### PR DESCRIPTION
Description: This PR includes an additional type for the prop `selected`, since it can be a number. (like `organisation.paperCopy` in the `PaperCopyPreferences.vue` component)

[PR in Core
](https://github.com/demos-europe/demosplan-core/pull/3810)
