### PR TITLE
fix(refs dplan-12315): Pass Item to dataTable instead of header-fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+- ([#1052](https://github.com/demos-europe/demosplan-ui/pull/1052)) Pass RowData from DpDataTableExtended to DpDataTable slots ([@salisdemos](https://github.com/salisdemos))
+
 ## v0.4.1 - 2024-10-07
 
 ### Added

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -484,15 +484,18 @@ export default {
   },
 
   watch: {
-    headerFields () {
-      if (this.isResizable) {
-        this.$nextTick(() => {
-          const firstRow = this.tableEl.getElementsByTagName('tr')[0]
-          const tableHeaderElements = firstRow ? firstRow.children : null
+    headerFields: {
+      handler () {
+        if (this.isResizable) {
+          this.$nextTick(() => {
+            const firstRow = this.tableEl.getElementsByTagName('tr')[0]
+            const tableHeaderElements = firstRow ? firstRow.children : null
 
-          this.setColsWidth(tableHeaderElements)
-        })
-      }
+            this.setColsWidth(tableHeaderElements)
+          })
+        }
+      },
+      deep: false // HeaderFields are always replaces as a whole and therefor deep watch is not necessary
     },
 
     shouldBeSelectedItems () {

--- a/src/components/DpDataTableExtended/DpDataTableExtended.vue
+++ b/src/components/DpDataTableExtended/DpDataTableExtended.vue
@@ -65,7 +65,7 @@
         </slot>
       </template>
       <template
-        v-for="el in [...filteredFields, { field: 'expandedContent' }, { fields: 'flyout' }]"
+        v-for="el in [...filteredFields, { field: 'expandedContent' }, { field: 'flyout' }]"
         v-slot:[el.field]="item">
         <!-- table cells (TDs) -->
         <slot

--- a/src/components/DpDataTableExtended/DpDataTableExtended.vue
+++ b/src/components/DpDataTableExtended/DpDataTableExtended.vue
@@ -65,24 +65,12 @@
         </slot>
       </template>
       <template
-        v-for="el in filteredFields"
-        v-slot:[el.field]="element">
+        v-for="el in [...filteredFields, { field: 'expandedContent' }, { fields: 'flyout' }]"
+        v-slot:[el.field]="item">
         <!-- table cells (TDs) -->
         <slot
           :name="el.field"
-          v-bind="el" />
-      </template>
-      <template v-slot:expandedContent="el">
-        <!-- expanded content area -->
-        <slot
-          name="expandedContent"
-          v-bind="el" />
-      </template>
-      <template v-slot:flyout="el">
-        <!-- flyout content area -->
-        <slot
-          name="flyout"
-          v-bind="el" />
+          v-bind="item" />
       </template>
     </dp-data-table>
 


### PR DESCRIPTION
coming from DpDataTableExtended, the whole row-item should be available in slots, not the headerfield informations.