### PR TITLE
feat(refs DPLAN-3217): allow disabling secondary button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 ### Added
 - ([#1050](https://github.com/demos-europe/demosplan-ui/pull/1050)) DpCheckbox: add additional type to 'selected' prop ([@sakutademos](https://github.com/sakutademos)
 
+### Changed
+
+-([#1068](https://github.com/demos-europe/demosplan-ui/pull/1068)) DpButtonRow: also disable secondary button if 'disabled' is set to true ([@hwiem](https://github.com/hwiem))
+
 ## v0.3.34 - 2024-10-09
 
 ### Added

--- a/src/components/DpButtonRow/DpButtonRow.vue
+++ b/src/components/DpButtonRow/DpButtonRow.vue
@@ -14,6 +14,7 @@
       v-if="secondary"
       color="secondary"
       :data-cy="`${dataCy}:abortButton`"
+      :disabled="disabled"
       :href="href"
       :text="secondaryText"
       :variant="variant"


### PR DESCRIPTION
**Ticket:** [DPLAN-3217](https://demoseurope.youtrack.cloud/issue/DPLAN-3217/ADO-Issue-15115-Integration-EWM-Part-2-Stellungnahmedetailansicht-aus-EWM-und-dplan-vereinen)

When `disabled` is set to true, not only the primary button, but also the secondary button should be disabled.