### PR TITLE
feat(refs DPLAN-3217): allow disabling secondary button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Changed
+
+- ([#1069](https://github.com/demos-europe/demosplan-ui/pull/1069)) DpButtonRow: also disable secondary button if 'disabled' is set to true ([@hwiem](https://github.com/hwiem))
+
 ## v0.4.2 - 2024-10-28
 
 ### Fixed

--- a/src/components/DpButtonRow/DpButtonRow.vue
+++ b/src/components/DpButtonRow/DpButtonRow.vue
@@ -14,6 +14,7 @@
       v-if="secondary"
       color="secondary"
       :data-cy="`${dataCy}:abortButton`"
+      :disabled="disabled"
       :href="href"
       :text="secondaryText"
       :variant="variant"


### PR DESCRIPTION
**Ticket:** [DPLAN-3217](https://demoseurope.youtrack.cloud/issue/DPLAN-3217/ADO-Issue-15115-Integration-EWM-Part-2-Stellungnahmedetailansicht-aus-EWM-und-dplan-vereinen)

if the prop 'disabled' is set to true, both primary and secondary button should be disabled