### PR TITLE
feat (refs DPLAN-3217 AB#12115): Allow numbers as value for input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+- ([#1074](https://github.com/demos-europe/demosplan-ui/pull/1074)) DpInput: Add additional type number for prop value ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
+
+### Changed
+
+-([#1074](https://github.com/demos-europe/demosplan-ui/pull/1074)) DpEditableList: Use DpButton instead of buttons and use new icons ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
+
 ## v0.3.35 - 2024-11-04
 
 ### Added

--- a/src/components/DpEditableList/DpEditableList.vue
+++ b/src/components/DpEditableList/DpEditableList.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
     <ul
-      class="u-mb-0_75"
-      v-if="entries.length > 0 || Object.keys(entries).length > 0">
+      v-if="entries.length > 0 || Object.keys(entries).length > 0"
+      class="u-mb-0_75">
       <li
         v-for="(entry, index) in entries"
         :key="index"
@@ -15,24 +15,22 @@
           :index="index" />
         <span
           v-if="true === hasPermissionToEdit">
-          <button
-            @click.prevent="showUpdateForm(index)"
-            :aria-label="translationKeys.update"
-            class="btn-icns u-m-0 u-ml-0_5"
-            :data-cy="`${dataCy}:updateEntry`">
-            <i
-              class="fa fa-pencil"
-              aria-hidden="true" />
-          </button>
-          <button
-            @click.prevent="deleteEntry(index)"
-            :aria-label="translationKeys.delete"
-            class="btn-icns u-m-0 u-pl-0"
-            :data-cy="`${dataCy}:deleteEntry`">
-            <i
-              class="fa fa-trash"
-              aria-hidden="true" />
-          </button>
+          <dp-button
+            class="ml-1"
+            :data-cy="`${dataCy}:updateEntry`"
+            hide-text
+            icon="edit"
+            :text="translationKeys.update"
+            variant="subtle"
+            @click.prevent="showUpdateForm(index)" />
+          <dp-button
+            class="-ml-1.5"
+            :data-cy="`${dataCy}:deleteEntry`"
+            hide-text
+            icon="delete"
+            :text="translationKeys.delete"
+            variant="subtle"
+            @click.prevent="deleteEntry(index)" />
         </span>
       </li>
     </ul>
@@ -47,36 +45,39 @@
         <slot name="form" />
       </div>
 
-      <button
-        @click.prevent="saveEntry"
+      <dp-button
         class="btn btn--primary"
-        :data-cy="currentlyUpdating !== '' ? `${dataCy}:saveEntry` : `${dataCy}:addEntry`">
-        {{ currentlyUpdating !== '' ? translationKeys.update : translationKeys.add }}
-      </button>
+        :data-cy="currentlyUpdating !== '' ? `${dataCy}:saveEntry` : `${dataCy}:addEntry`"
+        :text="currentlyUpdating !== '' ? translationKeys.update : translationKeys.add"
+        @click.prevent="saveEntry" />
 
-      <button
-        @click.prevent="resetForm"
+      <dp-button
         class="btn btn--secondary u-ml-0_5"
-        :data-cy="`${dataCy}:abort`">
-        {{ translationKeys.abort }}
-      </button>
+        :data-cy="`${dataCy}:abort`"
+        :text="translationKeys.abort"
+        @click.prevent="resetForm" />
     </div>
 
-    <button
-      @click.prevent="showNewForm()"
-      class="btn btn--primary"
+    <dp-button
       v-if="false === isFormVisible && true === hasPermissionToEdit"
-      :data-cy="`${dataCy}:showInput`">
-      {{ translationKeys.new }}
-    </button>
+      class="btn btn--primary"
+      :data-cy="`${dataCy}:showInput`"
+      :text="translationKeys.new"
+      @click.prevent="showNewForm()" />
   </div>
 </template>
 
 <script>
 import { de } from '~/components/shared/translations'
+import DpButton from '~/components/DpButton'
 
 export default {
   name: 'DpEditableList',
+
+  components: {
+    DpButton
+  },
+
   props: {
     dataCy: {
       type: String,

--- a/src/components/DpInput/DpInput.vue
+++ b/src/components/DpInput/DpInput.vue
@@ -211,7 +211,7 @@ export default {
     },
 
     value: {
-      type: String,
+      type: [String, Number],
       required: false,
       default: ''
     },


### PR DESCRIPTION
### Ticket
[DPLAN-3217](https://demoseurope.youtrack.cloud/issue/DPLAN-3217)

- DpInput: Also allow numbers as values
- DpEditableList: Use DpButton instead of button and use new phosphor icons instead of fontawesome

### Related PR
https://github.com/demos-europe/demosplan-core/pull/3896