### PR TITLE
feat: Allow "reset" as dp-button type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+- ([#1078](https://github.com/demos-europe/demosplan-ui/pull/1078)) New Type for DpButton: "reset" ([@salisdemos](https://github.com/salisdemos))
+
+
 ## v0.3.35 - 2024-11-04
 
 ### Added

--- a/src/components/DpButton/DpButton.vue
+++ b/src/components/DpButton/DpButton.vue
@@ -133,7 +133,7 @@ export default {
       required: false,
       type: String,
       default: 'button',
-      validator: (prop: string): boolean  => ['button', 'submit'].includes(prop)
+      validator: (prop: string): boolean  => ['button', 'submit', 'reset'].includes(prop)
     },
 
     /**


### PR DESCRIPTION
To use DpButton in standard Forms as Resete button, we have to allow the button-Type "reset".