### PR TITLE
feat(refs DPLAN-3217, #AB15115): make DpUpload available to end users

### DIFF
--- a/src/components/DpUploadFiles/DpUploadFiles.stories.tsx
+++ b/src/components/DpUploadFiles/DpUploadFiles.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/vue'
-import DpUploadFiles from './'
+import { DpUploadFiles } from './index'
 
 const meta: Meta<typeof DpUploadFiles> = {
     component: DpUploadFiles,

--- a/src/components/DpUploadFiles/index.ts
+++ b/src/components/DpUploadFiles/index.ts
@@ -1,2 +1,2 @@
-export { default } from './DpUploadFiles.vue'
-export * from './DpUploadFiles.vue'
+export { default as DpUploadFiles } from './DpUploadFiles.vue'
+export { default as DpUpload } from './DpUpload.vue'

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -55,7 +55,10 @@ import DpTooltip from './DpTooltip'
 import DpTooltipIcon from './DpTooltipIcon'
 import DpTransitionExpand from './DpTransitionExpand'
 import DpTreeList from './DpTreeList'
-import DpUploadFiles from './DpUploadFiles'
+import {
+  DpUpload,
+  DpUploadFiles
+} from './DpUploadFiles'
 import DpVideoPlayer from './DpVideoPlayer'
 
 export {
@@ -115,6 +118,7 @@ export {
   DpTooltipIcon,
   DpTransitionExpand,
   DpTreeList,
+  DpUpload,
   DpUploadFiles,
   DpVideoPlayer,
   getFileIdsByHash


### PR DESCRIPTION
Sometimes we want to use `DpUpload` directly, without displaying the list of uploaded files (in `DpUploadFiles`); this is hereby made possible.