### PR TITLE
fix(refs DPLAN-12746): allow passing options to v-tooltip [vue 3]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+- ([#1085](https://github.com/demos-europe/demosplan-ui/pull/1085)) DpContextualHelp: Allow passing v-tooltip options ([@hwiem](https://github.com/hwiem))
+
 ### Changed
 
 - ([#1053](https://github.com/demos-europe/demosplan-ui/pull/1053)) Make `rootDraggable` Option work for dp-draggable ([@salisdemos](https://github.com/salisdemos))

--- a/src/components/DpContextualHelp/DpContextualHelp.vue
+++ b/src/components/DpContextualHelp/DpContextualHelp.vue
@@ -4,14 +4,14 @@
     :icon="icon"
     :size="size"
     class="inline-block"
-    v-tooltip="text" />
+    v-tooltip="tooltip" />
 </template>
 
 <script setup lang="ts">
+import { computed, onMounted, PropType } from 'vue'
 import { IconName, IconSize } from '../../../types'
 import { de } from '~/components/shared/translations'
 import DpIcon from '~/components/DpIcon'
-import { PropType } from 'vue'
 import { SIZES as ICON_SIZES } from '~/components/DpIcon/util/iconConfig'
 import { Tooltip } from '~/directives'
 
@@ -39,12 +39,39 @@ const props = defineProps({
 
   /**
    * A string representing the actual tooltip content. May include html.
+   * If you want to pass additional options, use the 'tooltipOptions' prop instead
+   * ('tooltipOptions.content' for text)
    */
   text: {
     type: String,
-    required: true
+    required: false,
+    default: ''
+  },
+  /**
+   * For available options check https://floating-vue.starpad.dev/api/#directive-options
+   * When using, pass text via the 'content' property instead of using the 'text' prop above
+   */
+  tooltipOptions: {
+    type: Object,
+    required: false,
+    default: () => ({})
   }
 })
 
 const ariaLabel = de.contextualHelp
+
+/**
+ * @return {string|object} Returns either text only or text and other options
+ */
+const tooltip = computed(() => {
+  return Object.keys(props.tooltipOptions).length > 0
+    ? props.tooltipOptions
+    : props.text
+})
+
+onMounted(() => {
+  if (!props.text && !props.tooltipOptions.content) {
+    console.error('DpContextualHelp: No tooltip content provided. Add the "tooltipOptions.content" prop.')
+  }
+})
 </script>


### PR DESCRIPTION
Ticket: [DPLAN-12746](https://demoseurope.youtrack.cloud/issue/DPLAN-12746/Hinzufugen-von-Textbaustein-zu-Mitteilung-Invalid-Prop)

- in order to pass tooltip options to v-tooltip in `DpContextualHelp`, we can now use the `tooltipOptions` prop; in that case, we need to include the tooltip text via the `tooltipOptions` 'content' property instead of using the `text` prop
- for all available options see https://floating-vue.starpad.dev/api/#directive-options (Note that the `classes` option has been renamed to`popperClass` in the vue 3 version (see https://floating-vue.starpad.dev/migration/migration-from-v2#directive, "Renamed props")
- if we don't want to pass options, we can keep using the `text` prop as before
- since the `text` prop can no longer be required, an error is displayed in the console if neither `text` nor `tooltipOptions.content` are provided