### PR TITLE
fix(refs DPLAN-12823): Add 'reset' type to DpButton

### DIFF
--- a/src/components/DpButton/DpButton.vue
+++ b/src/components/DpButton/DpButton.vue
@@ -128,12 +128,14 @@ export default {
 
     /**
      * The type attribute can be set to a value of `submit` manually, if the button is used to post a form.
+     * When set to 'reset', the button will reset all the form fields in the form it is placed in. Use with caution,
+     * since users tend to find this annoying.
      */
     type: {
       required: false,
       type: String,
       default: 'button',
-      validator: (prop: string): boolean  => ['button', 'submit'].includes(prop)
+      validator: (prop: string): boolean  => ['button', 'reset', 'submit'].includes(prop)
     },
 
     /**


### PR DESCRIPTION
**Ticket:** [DPLAN-12823](https://demoseurope.youtrack.cloud/issue/DPLAN-12823)

This PR adds 'reset' to the possible values for the `type` prop in DpButton. This allows us to use DpButton as a reset button in a form.