### PR TITLE
fix(refs DPLAN-12823): Add 'reset' type to DpButton [vue 3]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+
+- ([#1087](https://github.com/demos-europe/demosplan-ui/pull/1087)) DpButton: Add 'reset' to possible values for type prop ([@hwiem](https://github.com/hwiem))
+
 ### Changed
 
 - ([#1053](https://github.com/demos-europe/demosplan-ui/pull/1053)) Make `rootDraggable` Option work for dp-draggable ([@salisdemos](https://github.com/salisdemos))

--- a/src/components/DpButton/DpButton.vue
+++ b/src/components/DpButton/DpButton.vue
@@ -131,12 +131,14 @@ const props = defineProps({
 
   /**
    * The type attribute can be set to a value of `submit` manually, if the button is used to post a form.
+   * When set to 'reset', the button will reset all the form fields in the form it is placed in. Use with caution,
+   * since users tend to find this annoying.
    */
   type: {
     type: String as PropType<ButtonType>,
     required: false,
     default: 'button',
-    validator: (prop: ButtonType): boolean  => ['button', 'submit'].includes(prop)
+    validator: (prop: ButtonType): boolean  => ['button', 'reset', 'submit'].includes(prop)
   },
 
   /**


### PR DESCRIPTION
**Ticket:** [DPLAN-12823](https://demoseurope.youtrack.cloud/issue/DPLAN-12823)

This PR adds 'reset' to the possible values for the `type` prop in DpButton. This allows us to use DpButton as a reset button in a form.