### PR TITLE
fix(refs DPLAN-12808): make sure 'sr-only' is applied if hide is true [vue 2]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+
+- ([#1088](https://github.com/demos-europe/demosplan-ui/pull/1088)) DpLabel: Fix hiding the label via `hide` prop ([@hwiem](https://github.com/hwiem))
+
 ### Added
 - ([#1086](https://github.com/demos-europe/demosplan-ui/pull/1086)) DpButton: Add 'reset' to possible values for type prop ([@hwiem](https://github.com/hwiem))
 - ([#1084](https://github.com/demos-europe/demosplan-ui/pull/1084)) DpContextualHelp: Allow passing v-tooltip options ([@hwiem](https://github.com/hwiem))

--- a/src/components/DpLabel/DpLabel.vue
+++ b/src/components/DpLabel/DpLabel.vue
@@ -1,6 +1,6 @@
 <template>
   <label
-    :class="prefixClass(['o-form__label flex', bold ? 'weight--bold' : 'weight--normal', hints.length > 0 ? 'has-hint' : '', hide ?? 'sr-only'])"
+    :class="prefixClass(['o-form__label flex', bold ? 'weight--bold' : 'weight--normal', hints.length > 0 ? 'has-hint' : '', hide ? 'sr-only' : ''])"
     :for="labelFor">
     <span>
       <span v-cleanhtml="text" /><span v-if="required">*</span>


### PR DESCRIPTION
**Ticket:** [DPLAN-12808](https://demoseurope.youtrack.cloud/issue/DPLAN-12808/Button-verschoben-Einreichende-suchen)

This PR ensures that the label is hidden if we pass `hide="true"` to `DpLabel`.
Before, with the nullish coalescing operator, 'sr-only' was only applied if `hide` was `undefined` or `null`, which was not the desired behavior.
Instead we want to apply the 'sr-only' class if `hide` is `true`, so we are now using a ternary operator instead.