### PR TITLE
fix(refs DPLAN-12907): fix DpUploadFiles imports [vue 3]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+- ([#1092](https://github.com/demos-europe/demosplan-ui/pull/1092)) DpUploadModal: Fix import of DpUploadFiles adjusted in [#1082](https://github.com/demos-europe/demosplan-ui/pull/1082) ([@hwiem](https://github.com/hwiem))
+
 ### Added
 - ([#1087](https://github.com/demos-europe/demosplan-ui/pull/1087)) DpButton: Add 'reset' to possible values for type prop ([@hwiem](https://github.com/hwiem))
 - ([#1085](https://github.com/demos-europe/demosplan-ui/pull/1085)) DpContextualHelp: Allow passing v-tooltip options ([@hwiem](https://github.com/hwiem))

--- a/src/components/DpEditor/DpUploadModal.vue
+++ b/src/components/DpEditor/DpUploadModal.vue
@@ -11,10 +11,12 @@
     </h3>
     <h3
       v-else
-      class="u-mb">
+      class="mb-2">
       {{ translations.insertImage }}
     </h3>
-    <div v-if="!editAltTextOnly">
+    <div
+      v-if="!editAltTextOnly"
+      class="mb-2">
       <dp-upload-files
         allowed-file-types="img"
         :basic-auth="basicAuth"

--- a/src/components/DpEditor/DpUploadModal.vue
+++ b/src/components/DpEditor/DpUploadModal.vue
@@ -65,7 +65,7 @@
 import { de } from '../shared/translations'
 import DpInput from '~/components/DpInput'
 import DpModal from '~/components/DpModal'
-import DpUploadFiles from '~/components/DpUploadFiles'
+import { DpUploadFiles } from '~/components/DpUploadFiles'
 
 export default {
   name: 'DpUploadModal',

--- a/src/components/DpUploadFiles/DpUploadFiles.stories.mdx
+++ b/src/components/DpUploadFiles/DpUploadFiles.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta } from '@storybook/addon-docs'
-import DpUploadFiles from './'
+import { DpUploadFiles } from './'
 
 <Meta
     title="Components/UploadFiles"

--- a/tests/DpUpload/DpUploadFiles.spec.js
+++ b/tests/DpUpload/DpUploadFiles.spec.js
@@ -1,4 +1,4 @@
-import DpUploadFiles from '~/components/DpUploadFiles'
+import { DpUploadFiles } from '~/components/DpUploadFiles'
 import { shallowMount } from '@vue/test-utils'
 
 


### PR DESCRIPTION
**Ticket:** [DPLAN-12907](https://demoseurope.youtrack.cloud/issue/DPLAN-12907/Bild-einfugen-nicht-moglich-Erwiderung-verfassen)

When adjusting the exports in DpUploadFiles/index.ts in https://github.com/demos-europe/demosplan-ui/pull/1082, adjusting some of the imports from that file was forgotten. The imports are fixed in this PR.
Also, a minor styling adjustment was made to make spacing in the DpUploadModal more consistent.