### PR TITLE
fix(refs DPLAN-12886): fix overlapping flyout by adjusting css [VUE3]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+
+- ([#1093](https://github.com/demos-europe/demosplan-ui/pull/1093)) DpTableRow: Fix overlapping of columns ([@muellerdemos](https://github.com/muellerdemos))
+
 ## v0.4.1 - 2024-10-07
 
 ### Added

--- a/src/components/DpDataTable/DpTableRow.vue
+++ b/src/components/DpDataTable/DpTableRow.vue
@@ -33,7 +33,7 @@
     <td
       v-for="(field, idx) in fields"
       :key="`${field}:${idx}`"
-      :class="{ 'c-data-table__resizable': isTruncatable } + ' overflow-hidden min-w-[50px]'"
+      :class="{ 'c-data-table__resizable': isTruncatable } + ' overflow-hidden'"
       :data-col-idx="`${idx}`">
       <div
         :class="[

--- a/src/components/DpDataTable/DpTableRow.vue
+++ b/src/components/DpDataTable/DpTableRow.vue
@@ -33,36 +33,26 @@
     <td
       v-for="(field, idx) in fields"
       :key="`${field}:${idx}`"
-      :class="{ 'c-data-table__resizable': isTruncatable } + ' overflow-hidden'"
+      :class="{ 'c-data-table__resizable': isTruncatable } + ' overflow-hidden min-w-[50px]'"
       :data-col-idx="`${idx}`">
       <div
-        v-if="isTruncatable"
-        class="break-words"
-        :class="wrapped ? 'c-data-table__resizable--wrapped' : 'c-data-table__resizable--truncated'"
-        :style="elementStyle(field)">
+        :class="[
+          isTruncatable ?? 'break-words',
+          isTruncatable
+            ? wrapped
+              ? 'c-data-table__resizable--wrapped'
+              : 'c-data-table__resizable--truncated'
+            : ''
+        ]"
+        :style="isTruncatable ?? elementStyle(field)">
         <slot
+          v-if="$slots[field](item)[0].children.length > 0"
           :name="field"
-          v-bind="item" >
-          <span
-            v-if="searchTerm && item[field]"
-            v-html="highlighted(field)" />
-          <span
-            v-else
-            v-text="item[field]" />
-        </slot>
+          v-bind="item" />
+        <span
+          v-else
+          v-cleanhtml="highlighted(field)" />
       </div>
-      <template v-else>
-        <slot
-          :name="field"
-          v-bind="item">
-          <span
-            v-if="searchTerm && item[field]"
-            v-html="highlighted(field)" />
-          <span
-            v-text="item[field]"
-            v-else />
-        </slot>
-      </template>
     </td>
 
     <td
@@ -75,9 +65,9 @@
 
     <td
       v-if="isExpandable"
-      class="overflow-hidden min-w-[50px]"
+      class="c-data-table__cell--narrow overflow-hidden min-w-[50px]"
       :class="{ 'is-open': expanded }"
-      :title="Translator.trans(expanded ? 'aria.collapse' : 'aria.expand')"
+      :title="expanded ? translations.ariaCollapse : translations.ariaExpand"
       @click="toggleExpand(item[trackBy])">
       <dp-wrap-trigger
         :data-cy="`isExpandableWrapTrigger:${$attrs.index}`"
@@ -88,7 +78,7 @@
       v-if="isTruncatable"
       class="c-data-table__cell--narrow overflow-hidden min-w-[50px]"
       :class="{ 'is-open': wrapped }"
-      :title="Translator.trans(wrapped ? 'aria.collapse' : 'aria.expand')"
+      :title="wrapped ? translations.ariaCollapse : translations.ariaExpand"
       @click="toggleWrap(item[trackBy])">
       <dp-wrap-trigger
         :data-cy="`isTruncatableWrapTrigger:${$attrs.index}`"
@@ -98,6 +88,8 @@
 </template>
 
 <script>
+import { CleanHtml } from '~/directives'
+import { de } from '~/components/shared/translations'
 import DpIcon from '~/components/DpIcon'
 import DpWrapTrigger from './DpWrapTrigger'
 import DomPurify from 'dompurify'
@@ -108,6 +100,10 @@ export default {
   components: {
     DpIcon,
     DpWrapTrigger
+  },
+
+  directives: {
+    cleanhtml: CleanHtml
   },
 
   props: {
@@ -122,6 +118,9 @@ export default {
       default: ''
     },
 
+    /**
+     * Is the expandable content currently expanded?
+     */
     expanded: {
       type: Boolean,
       required: false,
@@ -133,6 +132,14 @@ export default {
       required: true
     },
 
+    /**
+     * The header of every column of the table is defined here.
+     *
+     * Each column is represented by an object with a `field` key whose value should match
+     * a key of the objects inside `items`. The `label` key controls the header of the column.
+     * The header can also have a tooltip. To define the width the column is initially
+     * rendered with when `isResizable` is used, the key `initialWidth` takes a px value.
+     */
     headerFields: {
       type: Array,
       required: true
@@ -166,12 +173,18 @@ export default {
       default: false
     },
 
+    /**
+     * The item can be locked for selection. Instead of the checkbox, a lock icon is rendered with a tooltip.
+     */
     isLocked: {
       type: Boolean,
       required: false,
       default: false
     },
 
+    /**
+     * If an item is locked for selection, the message to be shown inside the tooltip can be set here.
+     */
     isLockedMessage: {
       type: String,
       required: false,
@@ -211,6 +224,10 @@ export default {
       required: true
     },
 
+    /**
+     * Is the truncatable content currently truncated?
+     * Rename to `notTruncated`?
+     */
     wrapped: {
       type: Boolean,
       required: false,
@@ -218,10 +235,24 @@ export default {
     }
   },
 
+  data () {
+    return {
+      translations: {
+        ariaCollapse: de.aria.collapse.element,
+        ariaExpand: de.aria.expand.element
+      }
+    }
+  },
+
   computed: {
     highlighted () {
       return (field) => {
         let itemValue = this.item[field]
+
+        if (this.searchTerm === '') {
+          return itemValue
+        }
+
         itemValue = DomPurify.sanitize(itemValue)
 
         return itemValue.replace(this.searchTerm, '<span style="background-color: yellow;">$&</span>')
@@ -247,6 +278,7 @@ export default {
       }
     }
   },
+
   methods: {
     toggleSelect (id) {
       this.$emit('toggle-select', id)
@@ -259,6 +291,8 @@ export default {
     toggleExpand (id) {
       this.$emit('toggle-expand', id)
     }
+  },
+  mounted () {
   }
 }
 </script>


### PR DESCRIPTION
### Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-12886/Abschnitte-Tabelle-Wenn-alle-Spalten-gewahlt-sind-Ellipsis-lauft-uber-den-Schritt-Text

### Description:
This PR adds some small css adjustments to the `dp-table-row` component of `dp-data-table` and aims to prevent the flyout trigger button to be overlapped by a column when re-adjusting the size of the column.

### Related PRs:
Vue2 PR: https://github.com/demos-europe/demosplan-ui/pull/1094