### PR TITLE
fix(refs DPLAN-12886): fix overlapping flyout by adjusting css [VUE2]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+
+- ([#1094](https://github.com/demos-europe/demosplan-ui/pull/1094)) DpTableRow: Fix overlapping of columns ([@muellerdemos](https://github.com/muellerdemos))
+
 ## v0.3.38 - 2024-11-15
 
 ### Fixed

--- a/src/components/DpDataTable/DpTableRow.vue
+++ b/src/components/DpDataTable/DpTableRow.vue
@@ -33,7 +33,7 @@
     <td
       v-for="(field, idx) in fields"
       :key="`${field}:${idx}`"
-      :class="{ 'c-data-table__resizable': isTruncatable }"
+      :class="{ 'c-data-table__resizable': isTruncatable } + ' overflow-hidden'"
       :data-col-idx="`${idx}`">
       <div
         v-if="isTruncatable"
@@ -47,8 +47,8 @@
             v-if="searchTerm && item[field]"
             v-html="highlighted(field)" />
           <span
-             v-else
-             v-text="item[field]" />
+            v-else
+            v-text="item[field]" />
         </slot>
       </div>
       <template v-else>
@@ -67,7 +67,7 @@
 
     <td
       v-if="hasFlyout"
-      class="overflow-visible">
+      class="overflow-hidden min-w-[50px]">
       <slot
         name="flyout"
         v-bind="item" />
@@ -75,7 +75,7 @@
 
     <td
       v-if="isExpandable"
-      class="c-data-table__cell--narrow"
+      class="overflow-hidden min-w-[50px]"
       :class="{ 'is-open': expanded }"
       :title="Translator.trans(expanded ? 'aria.collapse' : 'aria.expand')"
       @click="toggleExpand(item[trackBy])">
@@ -86,7 +86,7 @@
 
     <td
       v-if="isTruncatable"
-      class="c-data-table__cell--narrow"
+      class="c-data-table__cell--narrow overflow-hidden min-w-[50px]"
       :class="{ 'is-open': wrapped }"
       :title="Translator.trans(wrapped ? 'aria.collapse' : 'aria.expand')"
       @click="toggleWrap(item[trackBy])">


### PR DESCRIPTION
### Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-12886/Abschnitte-Tabelle-Wenn-alle-Spalten-gewahlt-sind-Ellipsis-lauft-uber-den-Schritt-Text

### Description:
This PR adds some small css adjustments to the `dp-table-row` component of `dp-data-table` and aims to prevent the flyout trigger button to be overlapped by a column when re-adjusting the size of the column.

### Related PRs:
Vue3 PR: https://github.com/demos-europe/demosplan-ui/pull/1093