### PR TITLE
feat(refs DPLAN-12914, #AB17874): adjust toggle alignment, display tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+
+- ([#1099](https://github.com/demos-europe/demosplan-ui/pull/1099)) DpTreeList: Fix translation keys displayed as tooltip ([@hwiem](https://github.com/hwiem))
+
+### Added
+
+- ([#1099](https://github.com/demos-europe/demosplan-ui/pull/1099)) DpTreeList: Add prop to vertically center the toggle for branches;
+  display tooltips for the toggles ([@hwiem](https://github.com/hwiem))
+
 ## v0.3.39 - 2024-11-26
 
 ### Fixed

--- a/src/components/DpTreeList/DpTreeList.vue
+++ b/src/components/DpTreeList/DpTreeList.vue
@@ -42,6 +42,7 @@
       v-model="tree">
       <dp-tree-list-node
         v-for="(node, idx) in treeData"
+        :align-toggle="alignToggle"
         :data-cy="`treeListNode:${idx}`"
         :ref="`node_${node.id}`"
         :key="node.id"
@@ -103,6 +104,16 @@ export default {
   },
 
   props: {
+    /**
+     * Align toggle buttons in DpTreeListNode to the top or center
+     */
+    alignToggle: {
+      type: String,
+      required: false,
+      default: 'top',
+      validator: (prop) => ['top', 'center'].includes(prop)
+    },
+
     branchIdentifier: {
       type: Function,
       required: true

--- a/src/components/DpTreeList/DpTreeListNode.vue
+++ b/src/components/DpTreeList/DpTreeListNode.vue
@@ -16,13 +16,13 @@
         :string-value="nodeId"
         @check="setSelectionState(!node.nodeIsSelected)" />
       <div
-        class="flex grow items-start"
+        :class="['flex grow', alignToggle === 'top' ?  'items-start' : 'items-center']"
         :style="indentationStyle">
         <dp-tree-list-toggle
+          v-if="isBranch"
           class="c-treelist__folder text--left u-pv-0_25"
           :class="{'pointer-events-none': 0 === children.length}"
           :icon-class-prop="iconClassFolder"
-          v-if="isBranch"
           v-model="isExpanded" />
         <div class="grow u-pl-0 u-p-0_25">
           <slot
@@ -41,9 +41,9 @@
         </div>
       </div>
       <dp-tree-list-toggle
-        data-cy="treeListChildToggle"
         v-if="isBranch"
-        class="self-start"
+        :class="alignToggle === 'top' ? 'self-start' : 'self-center'"
+        data-cy="treeListChildToggle"
         :disabled="!hasToggle"
         v-tooltip="Translator.trans(!hasToggle ? 'no.elements.existing' : '')"
         v-model="isExpanded" />
@@ -121,6 +121,13 @@ export default {
   },
 
   props: {
+    alignToggle: {
+      type: String,
+      required: false,
+      default: 'top',
+      validator: (prop) => ['top', 'center'].includes(prop)
+    },
+
     checkBranch: {
       type: Function,
       required: true

--- a/src/components/DpTreeList/DpTreeListNode.vue
+++ b/src/components/DpTreeList/DpTreeListNode.vue
@@ -21,7 +21,8 @@
         <dp-tree-list-toggle
           v-if="isBranch"
           class="c-treelist__folder text--left u-pv-0_25"
-          :class="{'pointer-events-none': 0 === children.length}"
+          :class="{'cursor-not-allowed': 0 === children.length}"
+          :disabled="!hasToggle"
           :icon-class-prop="iconClassFolder"
           v-model="isExpanded" />
         <div class="grow u-pl-0 u-p-0_25">
@@ -45,7 +46,6 @@
         :class="alignToggle === 'top' ? 'self-start' : 'self-center'"
         data-cy="treeListChildToggle"
         :disabled="!hasToggle"
-        v-tooltip="Translator.trans(!hasToggle ? 'no.elements.existing' : '')"
         v-model="isExpanded" />
       <div
         v-else

--- a/src/components/DpTreeList/DpTreeListNode.vue
+++ b/src/components/DpTreeList/DpTreeListNode.vue
@@ -104,7 +104,6 @@ import DpDraggable from '~/components/DpDraggable'
 import DpIcon from '~/components/DpIcon'
 import DpTreeListCheckbox from './DpTreeListCheckbox'
 import DpTreeListToggle from './DpTreeListToggle'
-import { Tooltip } from '~/directives'
 
 export default {
   name: 'DpTreeListNode',
@@ -114,10 +113,6 @@ export default {
     DpIcon,
     DpTreeListCheckbox,
     DpTreeListToggle
-  },
-
-  directives: {
-    tooltip: Tooltip
   },
 
   props: {

--- a/src/components/DpTreeList/DpTreeListToggle.vue
+++ b/src/components/DpTreeList/DpTreeListToggle.vue
@@ -42,16 +42,21 @@ export default {
      * This is somewhat messy but removes cruft from DpTreeListNode.
      */
     iconClass () {
+      const icon = this.value ? 'fa-angle-up' : 'fa-angle-down'
+
       return this.iconClassProp !== ''
         ? this.iconClassProp
-        : ('font-size-large line-height--1 u-p-0_25 fa ' + (this.value ? 'fa-angle-up' : 'fa-angle-down'))
+        : `font-size-large line-height--1 u-p-0_25 fa ${icon}`
     },
 
     label () {
       // Here, the relatively generic term "element" is chosen to keep the wording generic.
+      const labelAll = this.value ? de.aria.collapse.all : de.aria.expand.all
+      const labelSingle = this.value ? de.aria.collapse.element : de.aria.expand.element
+
       return this.toggleAll
-        ? this.value ? de.aria.collapse.all : de.aria.expand.all
-        : this.value ? de.aria.collapse : de.aria.expand
+        ? labelAll
+        : labelSingle
     }
   },
 

--- a/src/components/DpTreeList/DpTreeListToggle.vue
+++ b/src/components/DpTreeList/DpTreeListToggle.vue
@@ -1,8 +1,9 @@
 <template>
   <button
-    type="button"
     class="o-link--default btn--blank"
-    :aria-label="label"
+    :disabled="disabled"
+    type="button"
+    v-tooltip="tooltip"
     @click="toggle">
     <i
       :class="iconClass"
@@ -11,13 +12,18 @@
 </template>
 
 <script>
+import { Tooltip } from '~/directives'
 import { de } from '~/components/shared/translations'
 
 export default {
   name: 'DpTreeListToggle',
 
+  directives: {
+    tooltip: Tooltip
+  },
+
   props: {
-    value: {
+    disabled: {
       type: Boolean,
       required: false,
       default: false
@@ -30,6 +36,18 @@ export default {
     },
 
     toggleAll: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+
+    tooltipOptions: {
+      type: Object,
+      required: false,
+      default: () => ({})
+    },
+
+    value: {
       type: Boolean,
       required: false,
       default: false
@@ -50,13 +68,25 @@ export default {
     },
 
     label () {
-      // Here, the relatively generic term "element" is chosen to keep the wording generic.
+      if (this.disabled) {
+        return de.elements.none
+      }
+
       const labelAll = this.value ? de.aria.collapse.all : de.aria.expand.all
       const labelSingle = this.value ? de.aria.collapse.element : de.aria.expand.element
 
       return this.toggleAll
         ? labelAll
         : labelSingle
+    },
+
+    tooltip () {
+      return Object.keys(this.tooltipOptions).length > 0
+        ?  {
+          ...this.tooltipOptions,
+          content: this.label
+        }
+        : this.label
     }
   },
 

--- a/src/components/shared/translations.js
+++ b/src/components/shared/translations.js
@@ -43,6 +43,9 @@ const de = {
     underline: 'Unterstrichen',
     undo: 'Rückgängig'
   },
+  elements: {
+    none: 'Keine Elemente vorhanden'
+  },
   entrySelected: "Eintrag ausgewählt",
   entriesSelected: "Einträge ausgewählt",
   error: {


### PR DESCRIPTION
Ticket: [DPLAN-12914](https://demoseurope.youtrack.cloud/issue/DPLAN-12914/ADO-Issue-17874-zentrale-mandantenweite-Schlagwort-Verwaltung-fur-alle-registrierten-Institutionen)

- `DpTreeListNode`: allow centering the toggles for branches ('top' remains the default)
- `DpTreeListNode`: display tooltips for toggles, fix tooltip for disabled toggles
- `DpTreelistToggle`: fix label (`[object object]` was displayed in some cases), now used as tooltip