### PR TITLE
fix(refs DPLAN-12460): adjust styles for flyout menu

### DIFF
--- a/src/components/DpDataTable/DpTableRow.vue
+++ b/src/components/DpDataTable/DpTableRow.vue
@@ -75,7 +75,7 @@
 
     <td
       v-if="isExpandable"
-      class="overflow-hidden min-w-[50px]"
+      class="overflow-visible min-w-[50px]"
       :class="{ 'is-open': expanded }"
       :title="Translator.trans(expanded ? 'aria.collapse' : 'aria.expand')"
       @click="toggleExpand(item[trackBy])">


### PR DESCRIPTION
### Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-12460/Bei-Abschnittsliste-mit-wenigen-Eintragen-sind-nach-Klick-auf-drei-Punkte-die-Optionen-abgeschnitten

### Description:
The expanded flyout menu should always be accessible by a user hence the tailwind class overflow-hidden has been replaced with overflow-visible.