### PR TITLE
fix(refs DPLAN-12460): addjust style to always display flyout properly

### DIFF
--- a/src/components/DpDataTable/DpTableRow.vue
+++ b/src/components/DpDataTable/DpTableRow.vue
@@ -67,7 +67,7 @@
 
     <td
       v-if="hasFlyout"
-      class="overflow-hidden min-w-[50px]">
+      class="overflow-visible min-w-[50px]">
       <slot
         name="flyout"
         v-bind="item" />
@@ -75,7 +75,7 @@
 
     <td
       v-if="isExpandable"
-      class="overflow-visible min-w-[50px]"
+      class="overflow-hidden min-w-[50px]"
       :class="{ 'is-open': expanded }"
       :title="Translator.trans(expanded ? 'aria.collapse' : 'aria.expand')"
       @click="toggleExpand(item[trackBy])">


### PR DESCRIPTION
### Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-12460/Bei-Abschnittsliste-mit-wenigen-Eintragen-sind-nach-Klick-auf-drei-Punkte-die-Optionen-abgeschnitten

### Description:
- the hidden and visible overflow styles were swapped by accident ... sorry, this should fix the issue now (hopefully but I double tested this now and this should do the trick finally)