### PR TITLE
chore: bump min node to 20.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Changed
+
+- ([#1105](https://github.com/demos-europe/demosplan-ui/pull/1105)) **breaking** Minimum required node version: 20.18.1 ([@salisdemos](https://github.com/salisdemos))
+
+
 ## v0.3.41 - 2024-11-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Changed
 
-- ([#1105](https://github.com/demos-europe/demosplan-ui/pull/1105)) **breaking** Minimum required node version: 20.18.1 ([@salisdemos](https://github.com/salisdemos))
+- ([#1105](https://github.com/demos-europe/demosplan-ui/pull/1105)) BREAKING: Minimum required node version: 20.18.1 ([@salisdemos](https://github.com/salisdemos))
 
 
 ## v0.3.41 - 2024-11-28

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,6 +1,6 @@
 services:
   demosplan_ui_local:
-    image: node:18-alpine # Set to node:20-alpine for node 20
+    image: node:20-alpine
     environment:
       - TZ=Europe/Berlin # Jest tests related to date fail with a UTC container
     working_dir: /app

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "webpack-cli": "^5.0.0"
   },
   "engines": {
-    "node": ">= 18.19.0"
+    "node": ">= 20.18.1"
   },
   "peerDependencies": {
     "prosemirror-history": "^1.3.0",


### PR DESCRIPTION
what the titles says