### PR TITLE
feat(refs DPLAN-12967): fix table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 - ([#1105](https://github.com/demos-europe/demosplan-ui/pull/1105)) BREAKING: Minimum required node version: 20.18.1 ([@salisdemos](https://github.com/salisdemos))
 
+### Fixed
+
+([#1116](https://github.com/demos-europe/demosplan-ui/pull/1116)) DpDataTable: Remove overflow hidden from normal table rows and add a node type check for first children ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
+
 
 ## v0.3.41 - 2024-11-28
 

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -687,7 +687,7 @@ export default {
       // Remove styles set by initialMaxWidth and initialWidth after copying rendered width into th styles
       if (this.isResizable) {
         Array.from(tableHeaderElements).forEach(th => {
-          if (th.firstChild) {
+          if (th.firstChild && th.firstChild.nodeType === 1) {
             th.firstChild.style.width = null
             th.firstChild.style.maxWidth = null
             th.firstChild.style.minWidth = null

--- a/src/components/DpDataTable/DpTableRow.vue
+++ b/src/components/DpDataTable/DpTableRow.vue
@@ -33,7 +33,7 @@
     <td
       v-for="(field, idx) in fields"
       :key="`${field}:${idx}`"
-      :class="{ 'c-data-table__resizable': isTruncatable } + ' overflow-hidden'"
+      :class="{ 'c-data-table__resizable': isTruncatable }"
       :data-col-idx="`${idx}`">
       <div
         v-if="isTruncatable"


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12967/ADO-Issue-21834-Admin-Institutionsliste-Institutionen-konnen-verschlagwortet-werden

Some fixes for DpDataTable:
- Added a check to verify firstChild is an element node (nodeType === 1) before accessing its style property to prevent errors when firstChild is a text node (nodeType === 3).
- Remove overflow hidden from normal table rows, because with overflow hidden content in the table row eg selects are not shown correctly anymore. Overflow hidden was introduced to fix this [ticket](https://demoseurope.youtrack.cloud/issue/DPLAN-12886/Abschnitte-Tabelle-Wenn-alle-Spalten-gewahlt-sind-Ellipsis-lauft-uber-den-Schritt-Text), but imo it is not necessary, because the columns are resizable and the user can easily adjust the column to make more space for the menu. Without resizable columns enough space is automatically applied. 

Related PR
https://github.com/demos-europe/demosplan-core/pull/4115