### PR TITLE
bug(refs DPLAN-13085): Add break words to table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Fixed
 
-- ([#1120](https://github.com/demos-europe/demosplan-ui/pull/1120)) DpDataTable: Add break words to columns to avoid overlapping content with resizable columns ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
+- ([#1120](https://github.com/demos-europe/demosplan-ui/pull/1120)) DpDataTable: Add break words to columns to avoid overlapping content with resizable columns and make header truncatable ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
 
 ## v0.3.42 - 2024-12-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+
+- ([#1120](https://github.com/demos-europe/demosplan-ui/pull/1120)) DpDataTable: Add break words to columns to avoid overlapping content with resizable columns ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
+
 ## v0.3.42 - 2024-12-16
 
 ### Changed
@@ -13,7 +17,6 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 ### Fixed
 
 - ([#1116](https://github.com/demos-europe/demosplan-ui/pull/1116)) DpDataTable: Remove overflow hidden from normal table rows and add a node type check for first children ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
-- ([#1120](https://github.com/demos-europe/demosplan-ui/pull/1120)) DpDataTable: Add break words to columns to avoid overlapping content with resizable columns ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
 
 
 ## v0.3.41 - 2024-11-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Fixed
 
-([#1116](https://github.com/demos-europe/demosplan-ui/pull/1116)) DpDataTable: Remove overflow hidden from normal table rows and add a node type check for first children ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
+- ([#1116](https://github.com/demos-europe/demosplan-ui/pull/1116)) DpDataTable: Remove overflow hidden from normal table rows and add a node type check for first children ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
+- ([#1120](https://github.com/demos-europe/demosplan-ui/pull/1120)) DpDataTable: Add break words to columns to avoid overlapping content with resizable columns ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
 
 
 ## v0.3.41 - 2024-11-28

--- a/src/components/DpDataTable/DpResizableColumn.vue
+++ b/src/components/DpDataTable/DpResizableColumn.vue
@@ -2,7 +2,7 @@
   <th
     v-tooltip="headerField.tooltip || headerField.label"
     ref="resizableColumn"
-    class="c-data-table__resizable"
+    class="c-data-table__resizable break-words"
     :class="{ 'u-pr-0' : isLast }"
     :data-col-field="headerField.field"
     :data-col-idx="idx">

--- a/src/components/DpDataTable/DpTableHeader.vue
+++ b/src/components/DpDataTable/DpTableHeader.vue
@@ -36,7 +36,9 @@
         <slot
           :name="`header-${hf.field}`"
           v-bind="hf">
-          <span v-if="hf.label" v-text="hf.label" />
+          <div :class="{ 'c-data-table__resizable--truncated': isTruncatable }">
+            <span v-if="hf.label" v-text="hf.label" />
+          </div>
         </slot>
       </dp-resizable-column>
       <th

--- a/src/components/DpDataTable/DpTableRow.vue
+++ b/src/components/DpDataTable/DpTableRow.vue
@@ -34,6 +34,7 @@
       v-for="(field, idx) in fields"
       :key="`${field}:${idx}`"
       :class="{ 'c-data-table__resizable': isTruncatable }"
+      class="break-words"
       :data-col-idx="`${idx}`">
       <div
         v-if="isTruncatable"

--- a/src/components/DpDataTable/DpTableRow.vue
+++ b/src/components/DpDataTable/DpTableRow.vue
@@ -33,8 +33,7 @@
     <td
       v-for="(field, idx) in fields"
       :key="`${field}:${idx}`"
-      :class="{ 'c-data-table__resizable': isTruncatable }"
-      class="break-words"
+      :class="[{ 'c-data-table__resizable': isTruncatable },  { 'break-words': isResizable }]"
       :data-col-idx="`${idx}`">
       <div
         v-if="isTruncatable"


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-13085/Institutionen-gruppieren-Toggle-fur-Spalte-geht-uber-den-Kategorie-Text

- Add break words to table columns to avoid overlapping content with resizable columns.
- Make header truncatable