### PR TITLE
bug(refs DPLAN-13085): Add break words to table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Fixed
 
+- ([#1121](https://github.com/demos-europe/demosplan-ui/pull/1121)) DpDataTable: Add break words to columns to avoid overlapping content with resizable columns and make header truncatable ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
+
+### Fixed
+
 - ([#1093](https://github.com/demos-europe/demosplan-ui/pull/1096)) Fix jest tests ([@muellerdemos](https://github.com/muellerdemos))
 - ([#1092](https://github.com/demos-europe/demosplan-ui/pull/1092)) DpUploadModal: Fix import of DpUploadFiles adjusted in [#1082](https://github.com/demos-europe/demosplan-ui/pull/1082) ([@hwiem](https://github.com/hwiem))
 - ([#1093](https://github.com/demos-europe/demosplan-ui/pull/1093)) DpTableRow: Fix overlapping of columns ([@muellerdemos](https://github.com/muellerdemos))

--- a/src/components/DpDataTable/DpResizableColumn.vue
+++ b/src/components/DpDataTable/DpResizableColumn.vue
@@ -2,7 +2,7 @@
   <th
     v-tooltip="headerField.tooltip || headerField.label"
     ref="resizableColumn"
-    class="c-data-table__resizable"
+    class="c-data-table__resizable break-words"
     :class="{ 'u-pr-0' : isLast }"
     :data-col-field="headerField.field"
     :data-col-idx="idx">

--- a/src/components/DpDataTable/DpTableHeader.vue
+++ b/src/components/DpDataTable/DpTableHeader.vue
@@ -37,7 +37,9 @@
           v-if="$slots[`header-${hf.field}`] && $slots[`header-${hf.field}`](hf)[0].children?.length > 0"
           :name="`header-${hf.field}`"
           v-bind="hf">
-          <span v-if="hf.label" v-text="hf.label" />
+          <div :class="{ 'c-data-table__resizable--truncated': isTruncatable }">
+            <span v-if="hf.label" v-text="hf.label" />
+          </div>
         </slot>
         <span
           v-else-if="hf.label"

--- a/src/components/DpDataTable/DpTableRow.vue
+++ b/src/components/DpDataTable/DpTableRow.vue
@@ -33,7 +33,7 @@
     <td
       v-for="(field, idx) in fields"
       :key="`${field}:${idx}`"
-      :class="{ 'c-data-table__resizable': isTruncatable } + ' overflow-hidden'"
+      :class="[{ 'c-data-table__resizable': isTruncatable }, { 'break-words': isResizable }] + ' overflow-hidden'"
       :data-col-idx="`${idx}`">
       <div
         :class="[


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-13085/Institutionen-gruppieren-Toggle-fur-Spalte-geht-uber-den-Kategorie-Text

- Add break words to table columns to avoid overlapping content with resizable columns.
- Make header truncatable

Related PR (0.3.x)
https://github.com/demos-europe/demosplan-ui/pull/1120