### PR TITLE
test(refs DPLAN-12969): add unit test for DpFlyout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+
+- ([#1139](https://github.com/demos-europe/demosplan-ui/pull/1139)) DpFlyout: Add unit test ([@hwiem](https://github.com/hwiem))
+
 ### Changed
-- 
+
 - ([#1144](https://github.com/demos-europe/demosplan-ui/pull/1144)) DpTreeList: Add spacer for empty draggable categories ([@salisdemos](https://github.com/salisdemos))
 
 

--- a/tests/components/DpFlyout.spec.js
+++ b/tests/components/DpFlyout.spec.js
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, expect, it } from '@jest/globals'
+import DpFlyout from '~/components/DpFlyout'
+import shallowMountWithGlobalMocks from '../../jest/shallowMountWithGlobalMocks'
+
+describe('DpFlyout', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = shallowMountWithGlobalMocks(DpFlyout, {})
+  })
+
+  afterEach(() => {
+    wrapper.destroy()
+  })
+
+  it('renders with expected css classes with default props', () => {
+    expect(wrapper.exists()).toBe(true)
+    expect(wrapper.classes()).toContain('o-flyout')
+    expect(wrapper.classes()).toContain('o-flyout--right')
+    expect(wrapper.classes()).toContain('o-flyout--padded')
+    expect(wrapper.classes()).toContain('o-flyout--menu')
+  })
+
+  it('toggles isExpanded when button is clicked', async () => {
+    const button = wrapper.find('.o-flyout__trigger')
+    await button.trigger('click')
+
+    expect(wrapper.vm.isExpanded).toBe(true)
+
+    await button.trigger('click')
+    expect(wrapper.vm.isExpanded).toBe(false)
+  })
+
+  it('emits \'open\' event when flyout is expanded', async () => {
+    const button = wrapper.find('.o-flyout__trigger')
+    await button.trigger('click')
+
+    expect(wrapper.emitted().open).toBeTruthy()
+  })
+
+  it('emits \'close\' event when flyout is collapsed', async () => {
+    const button = wrapper.find('.o-flyout__trigger')
+    await button.trigger('click') // open
+    await button.trigger('click') // close
+
+    expect(wrapper.emitted().close).toBeTruthy()
+  })
+
+  it('closes when close method is triggered by clicking outside', async () => {
+    wrapper.vm.isExpanded = true
+    await wrapper.vm.close()
+
+    expect(wrapper.vm.isExpanded).toBe(false)
+  })
+
+  it('displays content passed into the slot', () => {
+    const slotContent = '<div class="slot-content">Slot Content</div>'
+    const wrapper = shallowMountWithGlobalMocks(DpFlyout, {
+      slots: {
+        default: slotContent
+      }
+    })
+
+    expect(wrapper.find('.slot-content').exists()).toBe(true)
+    expect(wrapper.find('.slot-content').text()).toBe('Slot Content')
+  })
+})


### PR DESCRIPTION
**Related ticket:** [DPLAN-12969](https://demoseurope.youtrack.cloud/issue/DPLAN-12969/ADO-Issue-21841-Admin-Institutionsliste-Institutionen-konnen-nach-Schlagworten-gefiltert-werden)

Adds unit test for DpFlyout. I'm particularly interested in feedback on the first test case, `'renders with expected css classes with default props'` - is this useful? Is there a better way to test it? Do we want to test it at all?