### PR TITLE
chore: Add drop space for DpTreeList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Changed
+- 
+- ([#1144](https://github.com/demos-europe/demosplan-ui/pull/1144)) DpTreeList: Add spacer for empty draggable categories ([@salisdemos](https://github.com/salisdemos))
+
 
 ## v0.3.43 - 2025-01-17
 

--- a/src/components/DpTreeList/DpTreeList.vue
+++ b/src/components/DpTreeList/DpTreeList.vue
@@ -250,7 +250,7 @@ export default {
         const payload = {
           elementId: element.id,
           newIndex: newIndex,
-          parentId: nodeId
+          parentId: nodeId,
         }
         this.$emit('draggable:change', payload)
       }

--- a/src/components/DpTreeList/DpTreeList.vue
+++ b/src/components/DpTreeList/DpTreeList.vue
@@ -250,7 +250,7 @@ export default {
         const payload = {
           elementId: element.id,
           newIndex: newIndex,
-          parentId: nodeId,
+          parentId: nodeId
         }
         this.$emit('draggable:change', payload)
       }

--- a/src/components/DpTreeList/DpTreeListNode.vue
+++ b/src/components/DpTreeList/DpTreeListNode.vue
@@ -55,6 +55,7 @@
       :is="draggable ? 'dp-draggable' : 'div'"
       :drag-across-branches="options.dragAcrossBranches"
       class="list-style-none u-mb-0 u-1-of-1"
+      :class="[(children.length <= 0 && draggable) ? 'o-sortablelist__empty' : '']"
       data-cy="treeListChild"
       draggable-tag="ul"
       :group-id="nodeId"
@@ -67,7 +68,7 @@
       v-model="tree">
       <dp-tree-list-node
         v-for="(child, idx) in children"
-        v-show="true === isExpanded"
+        v-show="isExpanded"
         :data-cy="`treeListChild:${idx}`"
         :ref="`node_${child.id}`"
         :key="child.id"
@@ -94,6 +95,12 @@
             v-bind="scope" />
         </template>
       </dp-tree-list-node>
+      <li
+        v-if="isBranch && children.length <= 0 && hasDraggableChildren"
+        v-show="isExpanded"
+        class="ml-2 mr-4 mt-2">
+        <div class="o-sortablelist__spacer relative" />
+      </li>
     </component>
   </li>
 </template>
@@ -220,7 +227,7 @@ export default {
     },
 
     hasToggle () {
-      return this.isBranch && this.children.length > 0
+      return this.isBranch && (this.children.length > 0 || this.hasDraggableChildren)
     },
 
     iconClassFolder () {


### PR DESCRIPTION
Within DpTreeList: If you want to drop a draggable element in an empty category, its not possible since there is no space to drop it into. Therefor I added a spacer for that case.