### PR TITLE
feat(refs DPLAN-12969,#AB21841): Add new styling to filter flyout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+
+- ([#1145](https://github.com/demos-europe/demosplan-ui/pull/1145)) DpFlyout: Add prop variant to change trigger background ([@gruenbergerdemos](https://github.com/gruenbergerdemos), [@hwiem](https://github.com/hwiem))
 
 ## v0.3.43 - 2025-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Added
 
-- ([#1145](https://github.com/demos-europe/demosplan-ui/pull/1145)) DpFlyout: Add prop variant to change trigger background ([@gruenbergerdemos](https://github.com/gruenbergerdemos), [@hwiem](https://github.com/hwiem))
+- ([#1145](https://github.com/demos-europe/demosplan-ui/pull/1145)) DpFlyout: Add prop `variant` to change trigger background ([@gruenbergerdemos](https://github.com/gruenbergerdemos), [@hwiem](https://github.com/hwiem))
 
 ### Changed
 

--- a/src/components/DpFlyout/DpFlyout.vue
+++ b/src/components/DpFlyout/DpFlyout.vue
@@ -7,7 +7,7 @@
       'o-flyout--padded': padded,
       'is-expanded': isExpanded,
       'o-flyout--menu': hasMenu,
-      'bg-surface-medium py-0.5 mx-0.5 rounded-md': mode === 'dark'
+      'bg-surface-medium rounded-md': mode === 'dark'
     }"
     v-click-outside="close"
     data-cy="flyoutTrigger">
@@ -15,7 +15,7 @@
       :disabled="disabled"
       type="button"
       aria-haspopup="true"
-      class="o-flyout__trigger btn--blank o-link--default u-ph-0_25 line-height--2 whitespace-nowrap pb-0.5"
+      class="o-flyout__trigger btn--blank o-link--default px-1 line-height--2 whitespace-nowrap"
       :data-cy="dataCy"
       @click="toggle">
       <slot

--- a/src/components/DpFlyout/DpFlyout.vue
+++ b/src/components/DpFlyout/DpFlyout.vue
@@ -1,6 +1,6 @@
 <template>
   <span
-    class="o-flyout"
+    class="o-flyout bg-surface-medium py-0.5 mx-0.5 rounded-md"
     :class="{
       'o-flyout--left': align === 'left',
       'o-flyout--right': align === 'right',
@@ -14,7 +14,7 @@
       :disabled="disabled"
       type="button"
       aria-haspopup="true"
-      class="o-flyout__trigger btn--blank o-link--default u-ph-0_25 line-height--2 whitespace-nowrap"
+      class="o-flyout__trigger btn--blank o-link--default u-ph-0_25 line-height--2 whitespace-nowrap pb-0.5"
       :data-cy="dataCy"
       @click="toggle">
       <slot

--- a/src/components/DpFlyout/DpFlyout.vue
+++ b/src/components/DpFlyout/DpFlyout.vue
@@ -1,12 +1,13 @@
 <template>
   <span
-    class="o-flyout bg-surface-medium py-0.5 mx-0.5 rounded-md"
+    class="o-flyout"
     :class="{
       'o-flyout--left': align === 'left',
       'o-flyout--right': align === 'right',
       'o-flyout--padded': padded,
       'is-expanded': isExpanded,
-      'o-flyout--menu': hasMenu
+      'o-flyout--menu': hasMenu,
+      'bg-surface-medium py-0.5 mx-0.5 rounded-md': mode === 'dark'
     }"
     v-click-outside="close"
     data-cy="flyoutTrigger">
@@ -65,6 +66,13 @@ export default {
       required: false,
       type: Boolean,
       default: true
+    },
+
+    mode: {
+      required: false,
+      type: String,
+      default: 'light',
+      validator: (prop) => ['light', 'dark'].includes(prop)
     },
 
     padded: {

--- a/src/components/DpFlyout/DpFlyout.vue
+++ b/src/components/DpFlyout/DpFlyout.vue
@@ -7,7 +7,7 @@
       'o-flyout--padded': padded,
       'is-expanded': isExpanded,
       'o-flyout--menu': hasMenu,
-      'bg-surface-medium rounded-md': mode === 'dark'
+      'bg-surface-medium rounded-md': variant === 'dark'
     }"
     v-click-outside="close"
     data-cy="flyoutTrigger">
@@ -68,18 +68,18 @@ export default {
       default: true
     },
 
-    mode: {
+    padded: {
+      required: false,
+      type: Boolean,
+      default: true
+    },
+
+    variant: {
       required: false,
       type: String,
       default: 'light',
       validator: (prop) => ['light', 'dark'].includes(prop)
     },
-
-    padded: {
-      required: false,
-      type: Boolean,
-      default: true
-    }
   },
 
   data () {


### PR DESCRIPTION
Ticket https://demoseurope.youtrack.cloud/issue/DPLAN-12969

A prop `variant` is added to `DpFlyout`. It can be set to `'dark'` to set a darker background-color for the flyout trigger. The default value is `'light'`, so if the prop is not set, the flyout trigger will look as before.