### PR TITLE
fix(DPLAN-12013): styling of draggable element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Added
 
+- ([#1158](https://github.com/demos-europe/demosplan-ui/pull/1158)) DpTreeList: remove padding for draggable leaves and keep it only for categories ([@sakutademos](https://github.com/sakutademos)
 - ([#1139](https://github.com/demos-europe/demosplan-ui/pull/1139)) DpFlyout: Add unit test ([@hwiem](https://github.com/hwiem))
 
 

--- a/src/components/DpTreeList/DpTreeListNode.vue
+++ b/src/components/DpTreeList/DpTreeListNode.vue
@@ -55,7 +55,7 @@
       :is="draggable ? 'dp-draggable' : 'div'"
       :drag-across-branches="options.dragAcrossBranches"
       class="list-style-none u-mb-0 u-1-of-1"
-      :class="[(children.length <= 0 && draggable) ? 'o-sortablelist__empty' : '']"
+      :class="{'o-sortablelist__empty': isBranch && draggable}"
       data-cy="treeListChild"
       draggable-tag="ul"
       :group-id="nodeId"
@@ -69,6 +69,7 @@
       <dp-tree-list-node
         v-for="(child, idx) in children"
         v-show="isExpanded"
+        :align-toggle="alignToggle"
         :data-cy="`treeListChild:${idx}`"
         :ref="`node_${child.id}`"
         :key="child.id"

--- a/src/components/DpTreeList/DpTreeListNode.vue
+++ b/src/components/DpTreeList/DpTreeListNode.vue
@@ -55,7 +55,7 @@
       :is="draggable ? 'dp-draggable' : 'div'"
       :drag-across-branches="options.dragAcrossBranches"
       class="list-style-none u-mb-0 u-1-of-1"
-      :class="{'o-sortablelist__empty': isBranch && draggable}"
+      :class="{'o-sortablelist__empty': children.length <= 0 && draggable && isBranch}"
       data-cy="treeListChild"
       draggable-tag="ul"
       :group-id="nodeId"

--- a/src/components/DpTreeList/DpTreeListNode.vue
+++ b/src/components/DpTreeList/DpTreeListNode.vue
@@ -2,7 +2,7 @@
   <li class="border--top relative">
     <div class="c-treelist__node flex">
       <div
-        class="inline-block u-p-0_25 u-pr-0 u-mt-0_125"
+        class="inline-block p-1 pr-0 mt-0.5"
         :class="dragHandle"
         v-if="isDraggable">
         <dp-icon
@@ -20,12 +20,12 @@
         :style="indentationStyle">
         <dp-tree-list-toggle
           v-if="isBranch"
-          class="c-treelist__folder text--left u-pv-0_25"
+          class="c-treelist__folder text-left py-1"
           :class="{'cursor-not-allowed': 0 === children.length}"
           :disabled="!hasToggle"
           :icon-class-prop="iconClassFolder"
           v-model="isExpanded" />
-        <div class="grow u-pl-0 u-p-0_25">
+        <div class="grow u-pl-0 p-1">
           <slot
             v-if="isBranch"
             name="branch"
@@ -54,8 +54,8 @@
     <component
       :is="draggable ? 'dp-draggable' : 'div'"
       :drag-across-branches="options.dragAcrossBranches"
-      class="list-style-none u-mb-0 u-1-of-1"
-      :class="{'o-sortablelist__empty': children.length <= 0 && draggable && isBranch}"
+      class="list-style-none mb-0 w-full"
+      :class="{'pb-3': draggable && isBranch}"
       data-cy="treeListChild"
       draggable-tag="ul"
       :group-id="nodeId"


### PR DESCRIPTION
**Description:** This PR fixes issue when every draggable element (branch or a leaf) has an extra padding bottom.

- add this class only to a branch
- it could be reduced the padding-bottom a bit in the core


!Question: could the padding bottom be added to every draggable branch, to enable dragging elements from one branch to another without expanding it. Should it be possible? Then it could be renamed and added to each branch.. 

It was decided to add padding-bottom to every branch for now and to refactor it later by adding padding on hover. It could be done during further development.

PR in Core: https://github.com/demos-europe/demosplan-core/pull/4281