### PR TITLE
b-DPLAN-14659: add keys to navigate to preventEditing.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+
+- ([#1172](https://github.com/demos-europe/demosplan-ui/pull/1172)) preventEditing.js: Allow keys to navigate with keyboard([@riechedemos](https://github.com/riechedemos))
+
 ## v0.3.45 - 2025-01-30
 
 ### Added

--- a/src/components/DpEditor/libs/preventEditing.js
+++ b/src/components/DpEditor/libs/preventEditing.js
@@ -16,13 +16,14 @@ export default Extension.create({
           handlePaste() {
             return true
           },
-          handleKeyDown() {
-            return true
+          handleKeyDown(view, event) {
+            // Allow arrow keys, shift, control/command, and tab for text selection and navigation
+            const allowedKeys = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Shift', 'Control', 'Meta', 'Tab']
+            return !(allowedKeys.includes(event.key))
           },
           handleDOMEvents: {
-            drop (_view, event) {
+            drop(_view, event) {
               event.preventDefault()
-
               return true
             }
           }


### PR DESCRIPTION
DPLAN-14659:
Description: added keys to navigate with keyboard to custom tiptap extention preventEditing.js 
  
Testing:  Verfahren / Abwägungstabelle/ tab to 2. checkbox and check it/ try shift + arrow to mark text 