### PR TITLE
bug(refs DPLAN-14948): Add two disabled props for button row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+- ([#1183](https://github.com/demos-europe/demosplan-ui/pull/1183)) DpButtonRow: Add separate props for disabling primary and secondary button ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
+
 ## v0.3.47 - 2025-02-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 ## UNRELEASED
 
 ### Added
-- ([#1183](https://github.com/demos-europe/demosplan-ui/pull/1183)) DpButtonRow: Add separate props for disabling primary and secondary button ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
+- ([#1183](https://github.com/demos-europe/demosplan-ui/pull/1183)) DpButtonRow: Add option for prop disabled to disable only primary or secondary button or both ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
 
 ## v0.3.47 - 2025-02-18
 

--- a/src/components/DpButtonRow/DpButtonRow.vue
+++ b/src/components/DpButtonRow/DpButtonRow.vue
@@ -6,7 +6,7 @@
       v-if="primary"
       :busy="busy"
       :data-cy="`${dataCy}:saveButton`"
-      :disabled="disabledPrimary"
+      :disabled="isDisabledPrimary"
       :text="primaryText"
       :variant="variant"
       @click.prevent="$emit('primary-action')" />
@@ -14,7 +14,7 @@
       v-if="secondary"
       color="secondary"
       :data-cy="`${dataCy}:abortButton`"
-      :disabled="disabledSecondary"
+      :disabled="isDisabledSecondary"
       :href="href"
       :text="secondaryText"
       :variant="variant"
@@ -60,19 +60,15 @@ export default {
     },
 
     /**
-     * The primary button may have a "disabled" state to prevent unwanted user interaction e.g if no data is changed yet.
+     * The primary, secondary or both buttons may have a "disabled" state to prevent unwanted user interaction e.g if no data is changed yet.
+     *
+     * @type {Boolean|Object} - Can be a boolean to disable both buttons or an object to specify which button to disable.
+     * @property {Boolean} [primary] - If true, disables the primary button.
+     * @property {Boolean} [secondary] - If true, disables the secondary button.
+     * @default false - By default, no buttons are disabled.
      */
-    disabledPrimary: {
-      type: Boolean,
-      required: false,
-      default: false
-    },
-
-    /**
-     * The secondary button may have a "disabled" state to prevent unwanted user interaction.
-     */
-    disabledSecondary: {
-      type: Boolean,
+    disabled: {
+      type: [Boolean, Object],
       required: false,
       default: false
     },
@@ -138,6 +134,14 @@ export default {
   computed: {
     align () {
       return this.alignment === 'left' ? 'text-left' : 'text-right'
+    },
+
+    isDisabledPrimary () {
+      return this.disabled === true || (this.disabled.primary || false)
+    },
+
+    isDisabledSecondary () {
+      return this.disabled === true || (this.disabled.secondary || false)
     }
   }
 }

--- a/src/components/DpButtonRow/DpButtonRow.vue
+++ b/src/components/DpButtonRow/DpButtonRow.vue
@@ -6,7 +6,7 @@
       v-if="primary"
       :busy="busy"
       :data-cy="`${dataCy}:saveButton`"
-      :disabled="disabled"
+      :disabled="disabledPrimary"
       :text="primaryText"
       :variant="variant"
       @click.prevent="$emit('primary-action')" />
@@ -14,7 +14,7 @@
       v-if="secondary"
       color="secondary"
       :data-cy="`${dataCy}:abortButton`"
-      :disabled="disabled"
+      :disabled="disabledSecondary"
       :href="href"
       :text="secondaryText"
       :variant="variant"
@@ -62,7 +62,16 @@ export default {
     /**
      * The primary button may have a "disabled" state to prevent unwanted user interaction e.g if no data is changed yet.
      */
-    disabled: {
+    disabledPrimary: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+
+    /**
+     * The secondary button may have a "disabled" state to prevent unwanted user interaction.
+     */
+    disabledSecondary: {
       type: Boolean,
       required: false,
       default: false


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-14948/Aktuelles-Textbaustein-einfugen-moglich-auf-Einfugen-zu-klicken-obwohl-keine-Textbaustein-hinzugefugt-ist

It should be possible to disable only the primary button, because often times it makes sense that the secondary button is still active.

No uses of `DpButtonRow` with disabled prop were found in demosplan-ui.