### PR TITLE
Refac: DpLabel: adjust position of the tooltip and hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 ### Changed
 - ([#1156](https://github.com/demos-europe/demosplan-ui/pull/1156)) DpSearchField: Introduce condensed search field with attached search button ([@hwiem](https://github.com/hwiem))
 - ([#1074](https://github.com/demos-europe/demosplan-ui/pull/1080)) DpEditableList: Use DpButton instead of buttons and use new icons ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
+- ([#1191](https://github.com/demos-europe/demosplan-ui/pull/1191)) DpLabel: adjust position of the tooltip and hint ([@sakutademos](https://github.com/sakutademos)
 
 ### Fixed
-
 - ([#1157](https://github.com/demos-europe/demosplan-ui/pull/1157)) build: add missing dependency ([@hwiem](https://github.com/hwiem))
 
 ## v0.4.3 - 2024-12-11

--- a/src/components/DpLabel/DpLabel.vue
+++ b/src/components/DpLabel/DpLabel.vue
@@ -3,21 +3,21 @@
     :class="classes"
     :for="labelFor">
     <span>
-      <span v-cleanhtml="text" /><span v-if="required">*</span>
-      <span
-        v-if="hints.length > 0"
-        :class="prefixClass('block text-sm font-normal')">
-        <span
-          :class="prefixClass('inline-block')"
-          :key="i"
-          v-for="(h, i) in hints"
-          v-cleanhtml="h" />
-      </span>
+      <span v-cleanhtml="text" /><span v-if="required" aria-hidden="true">*</span>
+      <dp-contextual-help
+        v-if="tooltip"
+        :class="prefixClass('ml-0.5')"
+        :text="tooltip" />
     </span>
-    <dp-contextual-help
-      v-if="tooltip !== ''"
-      :class="prefixClass('shrink-0 mt-px ml-0.5')"
-      :text="tooltip" />
+    <span
+      v-if="hints.length"
+      :class="prefixClass('block text-sm font-normal')">
+      <span
+        v-for="(hint, i) in hints"
+        :key="i"
+        :class="prefixClass('inline-block')"
+        v-cleanhtml="hint" />
+    </span>
   </label>
 </template>
 
@@ -72,7 +72,7 @@ const props = defineProps({
 })
 
 const classes = computed(() : string[] => {
-  let cssClasses: string[] = ['flex']
+  let cssClasses: string[] = ['flex flex-col']
 
   if (props.hide) {
     cssClasses.push('sr-only')


### PR DESCRIPTION
**Description:** This PR adjusts the position of the tooltip inside the DpLabel component. There are some layout issues when the hint is provided: the tooltip is placed too far from the label.

before:
![image](https://github.com/user-attachments/assets/7c50239c-b3c6-4a63-b3b6-5e2cf6c150e9)
after:
![image](https://github.com/user-attachments/assets/5e959b5a-b26b-402b-9a2a-0a9590d9e04a)
