### PR TITLE
bug(refs DPLAN-14948): Add option for prop disabled 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Added
 - ([#1176](https://github.com/demos-europe/demosplan-ui/pull/1176), [#1182](https://github.com/demos-europe/demosplan-ui/pull/1182), [#1189](https://github.com/demos-europe/demosplan-ui/pull/1189)) DpIcon: Add new icons 'dots-three', 'map-pin', and 'faders' ([@hwiem](https://github.com/hwiem), [@spiess-demos](https://github.com/spiess-demos))
+- ([#1193](https://github.com/demos-europe/demosplan-ui/pull/1193)) DpButtonRow: Add option for prop disabled to disable only primary or secondary button or both ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
 
 ### Changed
 - ([#1156](https://github.com/demos-europe/demosplan-ui/pull/1156)) DpSearchField: Introduce condensed search field with attached search button ([@hwiem](https://github.com/hwiem))

--- a/src/components/DpButtonRow/DpButtonRow.vue
+++ b/src/components/DpButtonRow/DpButtonRow.vue
@@ -6,7 +6,7 @@
       v-if="primary"
       :busy="busy ? true : null"
       :data-cy="`${dataCy}:saveButton`"
-      :disabled="disabled"
+      :disabled="isDisabledPrimary"
       :text="primaryText"
       :variant="variant"
       @click.prevent="$emit('primary-action')" />
@@ -14,7 +14,7 @@
       v-if="secondary"
       color="secondary"
       :data-cy="`${dataCy}:abortButton`"
-      :disabled="disabled"
+      :disabled="isDisabledSecondary"
       :href="href"
       :text="secondaryText"
       :variant="variant"
@@ -65,10 +65,15 @@ export default {
     },
 
     /**
-     * The primary button may have a "disabled" state to prevent unwanted user interaction e.g if no data is changed yet.
+     * The primary, secondary or both buttons may have a "disabled" state to prevent unwanted user interaction e.g if no data is changed yet.
+     *
+     * @type {Boolean|Object} - Can be a boolean to disable both buttons or an object to specify which button to disable.
+     * @property {Boolean} [primary] - If true, disables the primary button.
+     * @property {Boolean} [secondary] - If true, disables the secondary button.
+     * @default false - By default, no buttons are disabled.
      */
     disabled: {
-      type: Boolean,
+      type: [Boolean, Object],
       required: false,
       default: false
     },
@@ -134,6 +139,14 @@ export default {
   computed: {
     align () {
       return this.alignment === 'left' ? 'text-left' : 'text-right'
+    },
+
+    isDisabledPrimary () {
+      return this.disabled === true || (this.disabled.primary || false)
+    },
+
+    isDisabledSecondary () {
+      return this.disabled === true || (this.disabled.secondary || false)
     }
   }
 }


### PR DESCRIPTION
[Ticket](https://demoseurope.youtrack.cloud/issue/DPLAN-14948/Aktuelles-Textbaustein-einfugen-moglich-auf-Einfugen-zu-klicken-obwohl-keine-Textbaustein-hinzugefugt-ist)

Add option for prop disabled to disable only primary or secondary button or both

Related PR https://github.com/demos-europe/demosplan-ui/pull/1183