### PR TITLE
refac(DPLAN-15036): expand the DpTreeListNode only when children exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+- ([#1194](https://github.com/demos-europe/demosplan-ui/pull/1194)) DpTreeListNode: Expand the DpTreeListNode only when children exist ([@sakutademos](https://github.com/sakutademos)
+
 ## v0.3.48 - 2025-02-20
 
 ### Fixed

--- a/src/components/DpTreeList/DpTreeListNode.vue
+++ b/src/components/DpTreeList/DpTreeListNode.vue
@@ -96,12 +96,6 @@
             v-bind="scope" />
         </template>
       </dp-tree-list-node>
-      <li
-        v-if="isBranch && !hasChildren && hasDraggableChildren"
-        v-show="isExpanded"
-        class="ml-2 mr-4 mt-2">
-        <div class="o-sortablelist__spacer relative" />
-      </li>
     </component>
   </li>
 </template>

--- a/src/components/DpTreeList/DpTreeListNode.vue
+++ b/src/components/DpTreeList/DpTreeListNode.vue
@@ -21,7 +21,7 @@
         <dp-tree-list-toggle
           v-if="isBranch"
           class="c-treelist__folder text-left py-1"
-          :class="{'cursor-not-allowed': 0 === children.length}"
+          :class="{'cursor-not-allowed': !hasChildren}"
           :disabled="!hasToggle"
           :icon-class-prop="iconClassFolder"
           v-model="isExpanded" />
@@ -97,7 +97,7 @@
         </template>
       </dp-tree-list-node>
       <li
-        v-if="isBranch && children.length <= 0 && hasDraggableChildren"
+        v-if="isBranch && hasChildren && hasDraggableChildren"
         v-show="isExpanded"
         class="ml-2 mr-4 mt-2">
         <div class="o-sortablelist__spacer relative" />
@@ -223,16 +223,20 @@ export default {
       return str.substring(1, str.length)
     },
 
+    hasChildren () {
+      return this.children.length > 0
+    },
+
     hasDraggableChildren () {
       return this.isBranch && (this.options.dragLeaves || this.options.dragBranches) && this.draggable
     },
 
     hasToggle () {
-      return this.isBranch && (this.children.length > 0 || this.hasDraggableChildren)
+      return this.isBranch && this.hasChildren
     },
 
     iconClassFolder () {
-      const hasContent = this.children.length > 0
+      const hasContent = this.hasChildren
       let folderClass
       if (hasContent) {
         folderClass = this.isExpanded ? 'fa-folder-open' : 'fa-folder'
@@ -297,6 +301,12 @@ export default {
   },
 
   watch: {
+    children () {
+      if (!this.hasChildren) {
+        this.isExpanded = false
+      }
+    },
+
     parentSelected (val) {
       if (this.options.selectOn.parentSelect || this.options.deselectOn.parentDeselect) {
         this.setSelectionState(val)
@@ -355,7 +365,11 @@ export default {
   },
 
   mounted () {
-    this.$root.$on('treelist:toggle-all', (expanded) => (this.isExpanded = expanded))
+    this.$root.$on('treelist:toggle-all', (expanded) => {
+      if (this.hasChildren) {
+        this.isExpanded = expanded
+      }
+    })
   }
 }
 </script>

--- a/src/components/DpTreeList/DpTreeListNode.vue
+++ b/src/components/DpTreeList/DpTreeListNode.vue
@@ -97,7 +97,7 @@
         </template>
       </dp-tree-list-node>
       <li
-        v-if="isBranch && hasChildren && hasDraggableChildren"
+        v-if="isBranch && !hasChildren && hasDraggableChildren"
         v-show="isExpanded"
         class="ml-2 mr-4 mt-2">
         <div class="o-sortablelist__spacer relative" />


### PR DESCRIPTION
**Ticket:** https://demoseurope.youtrack.cloud/agiles/141-245/current?issue=DPLAN-15036

**Description:** This PR improves UX: when the treeListNode is empty, it should not be possible to expand it.