### PR TITLE
fix: Catch Full-width in dpFormRow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+- ([#1202](https://github.com/demos-europe/demosplan-ui/pull/1202)) Catch full-width class in dpFormRow ([@salisdemos](https://github.com/salisdemos))
+
+
 ## v0.4.4 - 2025-02-26
 
 ### Added

--- a/src/components/DpFormRow/DpFormRow.vue
+++ b/src/components/DpFormRow/DpFormRow.vue
@@ -34,6 +34,11 @@ export default {
      */
     determineRowWidth () {
       if (this.elementsWidths.length > 0) {
+        if (this.elementsWidths[0] === 'w-full') {
+          this.isFullRow = true
+
+          return
+        }
         // U-firstWidthValue-of-y
         const firstWidthValues = this.elementsWidths.map(width => parseInt(width.match(/\d+/)))
         // Add firstWidthValues together


### PR DESCRIPTION
width tailwind we got a new full-width-class wich has to be catched