### PR TITLE
fix(refs DPLAN-15153): fix imports for mention extension [vue 3]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 ### Fixed
 - ([#1202](https://github.com/demos-europe/demosplan-ui/pull/1202)) Catch full-width class in dpFormRow ([@salisdemos](https://github.com/salisdemos))
 - ([#1203](https://github.com/demos-europe/demosplan-ui/pull/1203)) Fix typo in DpTreeListNode ([@salisdemos](https://github.com/salisdemos))
+- ([#1204](https://github.com/demos-europe/demosplan-ui/pull/1204)) DpEditor: Fix imports for mention extension ([@hwiem](https://github.com/hwiem))
 
 ## v0.4.4 - 2025-02-26
 

--- a/src/components/DpEditor/DpEditor.vue
+++ b/src/components/DpEditor/DpEditor.vue
@@ -328,6 +328,7 @@ import {
   History,
   Italic,
   ListItem,
+  Mention,
   OrderedList,
   Paragraph,
   Strike,
@@ -351,8 +352,7 @@ import {
   CustomLink,
   CustomMark,
   InsertAtCursorPos,
-  Obscure,
-  Mention
+  Obscure
 } from './libs/customExtensions'
 import DpIcon from '../DpIcon/DpIcon'
 import DpLinkModal from './DpLinkModal'

--- a/src/components/DpEditor/libs/editorCustomInsert.js
+++ b/src/components/DpEditor/libs/editorCustomInsert.js
@@ -1,7 +1,5 @@
 import {
   Mark,
-  markInputRule,
-  markPasteRule,
 } from '@tiptap/core'
 import { de } from '../../shared/translations'
 

--- a/src/components/DpEditor/libs/tiptapExtensions.js
+++ b/src/components/DpEditor/libs/tiptapExtensions.js
@@ -7,9 +7,7 @@ import History from '@tiptap/extension-history'
 import Italic from '@tiptap/extension-italic'
 import Link from '@tiptap/extension-link'
 import ListItem from '@tiptap/extension-list-item'
-// THIS IS A WORKAROUND.
-// In our setup per default the cjs-file is used. That file for some reason has a problem to resolve an internal dependency (Suggestion) properly.
-import { Mention } from '../../../../node_modules/@tiptap/extension-mention/dist/index.js'
+import { Mention } from '@tiptap/extension-mention'
 import OrderedList from '@tiptap/extension-ordered-list'
 import Paragraph from '@tiptap/extension-paragraph'
 import Strike from '@tiptap/extension-strike'


### PR DESCRIPTION
Ticket: [DPLAN-15153](https://demoseurope.youtrack.cloud/issue/DPLAN-15153/Benutzer-Menu-Verwalten-und-Plattformtools-Links-funktionieren-nicht-auf-Verfahrenstyp-bearbeiten-Seite)

The workaround for the mention extension import is no longer needed and it is now imported from the correct file in DpEditor.vue.