### PR TITLE
fix: Escape multiline break chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+- ([#1209](https://github.com/demos-europe/demosplan-ui/pull/1209)) Escape Multiline String Endings to avoid \n in classlist in DpButton ([@salisdemos](https://github.com/salisdemos))
+
 ## v0.4.5 - 2025-03-04
 
 ### Fixed

--- a/src/components/DpButton/DpButton.vue
+++ b/src/components/DpButton/DpButton.vue
@@ -251,85 +251,85 @@ const allColorClasses = {
      * The same border is applied to outline buttons.
      */
     solidOutline: `
-      border border-interactive
-      hover:border-interactive-hover
-      focus:border-interactive-hover
-      focus-visible:border-interactive-hover
+      border border-interactive\
+      hover:border-interactive-hover\
+      focus:border-interactive-hover\
+      focus-visible:border-interactive-hover\
       active:border-interactive-active `,
     // outlineSubtle: classes that apply to "outline" and "subtle" button color variants.
     outlineSubtle: `
-      bg-surface text-interactive
-      hover:bg-interactive-subtle-hover hover:text-interactive-hover
-      focus:bg-interactive-subtle-hover focus:text-interactive-hover
-      focus-visible:bg-interactive-subtle-hover focus-visible:text-interactive-hover
+      bg-surface text-interactive\
+      hover:bg-interactive-subtle-hover hover:text-interactive-hover\
+      focus:bg-interactive-subtle-hover focus:text-interactive-hover\
+      focus-visible:bg-interactive-subtle-hover focus-visible:text-interactive-hover\
       active:bg-interactive-subtle-active active:text-interactive-active `,
     // solid: classes that only apply to "solid" button color variant.
     solid: `
-      bg-interactive text-on-dark
-      hover:text-on-dark hover:no-underline hover:bg-interactive-hover
-      focus:bg-interactive-hover
-      focus-visible:bg-interactive-hover
+      bg-interactive text-on-dark\
+      hover:text-on-dark hover:no-underline hover:bg-interactive-hover\
+      focus:bg-interactive-hover\
+      focus-visible:bg-interactive-hover\
       active:bg-interactive-active `,
     // subtle: classes that only apply to "subtle" button color variant.
     subtle: `
-      border border-on-dark
-      hover:border-interactive-subtle-hover
-      focus:border-interactive-subtle-hover
-      focus-visible:border-interactive-subtle-hover
+      border border-on-dark\
+      hover:border-interactive-subtle-hover\
+      focus:border-interactive-subtle-hover\
+      focus-visible:border-interactive-subtle-hover\
       active:border-interactive-subtle-active `
   },
   secondary: {
     solidOutlineSubtle: ' outline outline-4 outline-offset-0 outline-transparent focus-visible:outline-[#595959]/50 ',
     solidOutline: `
-      border border-interactive-secondary
-      hover:border-interactive-secondary-hover
-      focus:border-interactive-secondary-hover
-      focus-visible:border-interactive-secondary-hover
+      border border-interactive-secondary\
+      hover:border-interactive-secondary-hover\
+      focus:border-interactive-secondary-hover\
+      focus-visible:border-interactive-secondary-hover\
       active:border-interactive-secondary-active `,
     outlineSubtle: `
-      bg-surface text-interactive-secondary
-      hover:bg-interactive-secondary-subtle-hover hover:text-interactive-secondary-hover
-      focus:bg-interactive-secondary-subtle-hover focus:text-interactive-secondary-hover
-      focus-visible:bg-interactive-secondary-subtle-hover focus-visible:text-interactive-secondary-hover
+      bg-surface text-interactive-secondary\
+      hover:bg-interactive-secondary-subtle-hover hover:text-interactive-secondary-hover\
+      focus:bg-interactive-secondary-subtle-hover focus:text-interactive-secondary-hover\
+      focus-visible:bg-interactive-secondary-subtle-hover focus-visible:text-interactive-secondary-hover\
       active:bg-interactive-secondary-subtle-active active:text-interactive-secondary-active `,
     solid: `
-      bg-interactive-secondary text-on-dark
-      hover:text-on-dark hover:no-underline hover:bg-interactive-secondary-hover
-      focus:bg-interactive-secondary-hover
-      focus-visible:bg-interactive-secondary-hover
+      bg-interactive-secondary text-on-dark\
+      hover:text-on-dark hover:no-underline hover:bg-interactive-secondary-hover\
+      focus:bg-interactive-secondary-hover\
+      focus-visible:bg-interactive-secondary-hover\
       active:bg-interactive-secondary-active `,
     subtle: `
-      border border-on-dark
-      hover:border-interactive-secondary-subtle-hover
-      focus:border-interactive-secondary-subtle-hover
-      focus-visible:border-interactive-secondary-subtle-hover
+      border border-on-dark\
+      hover:border-interactive-secondary-subtle-hover\
+      focus:border-interactive-secondary-subtle-hover\
+      focus-visible:border-interactive-secondary-subtle-hover\
       active:border-interactive-secondary-subtle-active `
   },
   warning: {
     solidOutlineSubtle: ' outline outline-4 outline-offset-0 outline-transparent focus-visible:outline-[#B20000]/50 ',
     solidOutline: `
-      border border-interactive-warning
-      hover:border-interactive-warning-hover
-      focus:border-interactive-warning-hover
-      focus-visible:border-interactive-warning-hover
+      border border-interactive-warning\
+      hover:border-interactive-warning-hover\
+      focus:border-interactive-warning-hover\
+      focus-visible:border-interactive-warning-hover\
       active:border-interactive-warning-active `,
     outlineSubtle: `
-      bg-surface text-interactive-warning
-      hover:bg-interactive-warning-subtle-hover hover:text-interactive-warning-hover
-      focus:bg-interactive-warning-subtle-hover focus:text-interactive-warning-hover
-      focus-visible:bg-interactive-warning-subtle-hover focus-visible:text-interactive-warning-hover
+      bg-surface text-interactive-warning\
+      hover:bg-interactive-warning-subtle-hover hover:text-interactive-warning-hover\
+      focus:bg-interactive-warning-subtle-hover focus:text-interactive-warning-hover\
+      focus-visible:bg-interactive-warning-subtle-hover focus-visible:text-interactive-warning-hover\
       active:bg-interactive-warning-subtle-active active:text-interactive-warning-active `,
     solid: `
-      bg-interactive-warning text-on-dark
-      hover:text-on-dark hover:no-underline hover:bg-interactive-warning-hover
-      focus:bg-interactive-warning-hover
-      focus-visible:bg-interactive-warning-hover
+      bg-interactive-warning text-on-dark\
+      hover:text-on-dark hover:no-underline hover:bg-interactive-warning-hover\
+      focus:bg-interactive-warning-hover\
+      focus-visible:bg-interactive-warning-hover\
       active:bg-interactive-warning-active `,
     subtle: `
-      border border-on-dark
-      hover:border-interactive-warning-subtle-hover
-      focus:border-interactive-warning-subtle-hover
-      focus-visible:border-interactive-warning-subtle-hover
+      border border-on-dark\
+      hover:border-interactive-warning-subtle-hover\
+      focus:border-interactive-warning-subtle-hover\
+      focus-visible:border-interactive-warning-subtle-hover\
       active:border-interactive-warning-subtle-active `
   }
 }


### PR DESCRIPTION
Using multilines in Js causes \n in the string. They appeard in the classlist, where they dont belong. So we had to escape them