### PR TITLE
fix(refs DPLAN-15169): fix image upload in DpEditor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+- ([#1217](https://github.com/demos-europe/demosplan-ui/pull/1217)) DpEditor: Fix image upload ([@hwiem](https://github.com/hwiem))
+
 ## v0.4.6 - 2025-03-18
 
 ### Fixed

--- a/src/components/DpEditor/DpEditor.vue
+++ b/src/components/DpEditor/DpEditor.vue
@@ -16,11 +16,12 @@
       :tus-endpoint="tusEndpoint"
       @insert-image="insertImage"
       @add-alt="addAltTextToImage"
-      @close="resetEditingImage" />
+      @close="resetImageId" />
     <slot
       name="modal"
       :appendText="appendText"
       :handleInsertText="handleInsertText" />
+
     <div
       v-if="editor"
       :class="prefixClass('row tiptap')">
@@ -538,7 +539,7 @@ export default {
         isOpen: false,
         buttons: []
       },
-      editingImage: null,
+      imageId: null,
       editor: null,
       editorHeight: '',
       isDiffMenuOpen: false,
@@ -689,8 +690,8 @@ export default {
 
   methods: {
     addAltTextToImage (text) {
-      this.$root.$emit('update-image:' + this.editingImage, { alt: text })
-      this.resetEditingImage()
+      this.$root.$emit('update-image:' + this.imageId, { alt: text })
+      this.resetImageId()
       this.emitValue()
     },
 
@@ -961,8 +962,8 @@ export default {
       }
     },
 
-    resetEditingImage () {
-      this.editingImage = null
+    resetImageId () {
+      this.imageId = null
     },
 
     resizeVertically (e) {
@@ -1130,7 +1131,7 @@ export default {
         return
       }
 
-      this.editingImage = imgId
+      this.imageId = imgId
       this.openUploadModal({ editAltOnly: true, currentAlt: event.target.getAttribute('alt'), imgSrc: event.target.getAttribute('src') })
     })
     /*

--- a/src/components/DpEditor/DpEditor.vue
+++ b/src/components/DpEditor/DpEditor.vue
@@ -311,7 +311,7 @@
             aria-hidden="true"
             :class="prefixClass('fa fa-angle-down resizeVertical')"
             @mousedown="resizeVertically"
-            draggable="true" />
+            :draggable="true" />
         </div>
       </div>
     </div>

--- a/src/components/DpEditor/DpEditor.vue
+++ b/src/components/DpEditor/DpEditor.vue
@@ -311,7 +311,7 @@
             aria-hidden="true"
             :class="prefixClass('fa fa-angle-down resizeVertical')"
             @mousedown="resizeVertically"
-            :draggable="true" />
+            draggable="true" />
         </div>
       </div>
     </div>

--- a/src/components/DpEditor/DpResizableImage.vue
+++ b/src/components/DpEditor/DpResizableImage.vue
@@ -40,8 +40,9 @@ export default {
   methods: {
     updateImageDimensions () {
       // The max width should not be wider than the editor.
-      const innerEditorWidth = this.$parent.$el.clientWidth - 40
-      const imgWidth = this.$refs.imagewrapper.$el.clientWidth
+      const imgEl = this.$refs.imagewrapper.$el
+      const innerEditorWidth = imgEl.parentElement.clientWidth - 40
+      const imgWidth = imgEl.clientWidth
       const width = (imgWidth < innerEditorWidth) ? imgWidth : innerEditorWidth
 
       if (width > 0) {

--- a/src/components/DpEditor/DpResizableImage.vue
+++ b/src/components/DpEditor/DpResizableImage.vue
@@ -92,7 +92,7 @@ export default {
 
     this.$refs.imagewrapper.$el.style.width = this.node.attrs.width + 'px'
 
-    const updateSize = (this.node.attrs.height > 0) === false || this.node.attrs.height === Infinity
+    const updateSize = this.node.attrs.height <= 0 || this.node.attrs.height === Infinity
     this.setRatio(updateSize)
   },
 

--- a/src/components/DpEditor/DpUploadModal.vue
+++ b/src/components/DpEditor/DpUploadModal.vue
@@ -72,6 +72,12 @@ import { DpUploadFiles } from '~/components/DpUploadFiles'
 export default {
   name: 'DpUploadModal',
 
+  emits: [
+    'add-alt',
+    'close',
+    'insert-image'
+  ],
+
   components: {
     DpInput,
     DpModal,

--- a/src/components/DpEditor/DpUploadModal.vue
+++ b/src/components/DpEditor/DpUploadModal.vue
@@ -49,7 +49,7 @@
         class="btn btn--primary"
         data-cy="uploadModal:save"
         type="button"
-        @click="emitAndClose()"
+        @click="emitAndClose"
         v-text="editAltTextOnly ? translations.save : translations.insert">
       </button>
       <button

--- a/src/components/DpTransitionExpand/DpTransitionExpand.vue
+++ b/src/components/DpTransitionExpand/DpTransitionExpand.vue
@@ -55,7 +55,11 @@ export default {
       }
     }
 
-    return h(Transition, data, () => this.$slots.default)
+    return h(
+      Transition,
+      data,
+      () => this.$slots.default ? this.$slots.default() : null
+    )
   }
 }
 </script>

--- a/src/components/DpUploadFiles/DpUpload.vue
+++ b/src/components/DpUploadFiles/DpUpload.vue
@@ -288,10 +288,10 @@ export default {
     this.uppy.on('upload-success', (file) => {
       const { name, size, type } = file.data
       const newFile = {
-        name: name,
+        name,
         hash: this.currentFileHash,
-        size: size,
-        type: type,
+        size,
+        type,
         id: file.id, // The uppy internal file id
         fileId: this.currentFileId // The id of the file within demosplan
       }

--- a/src/components/DpUploadFiles/DpUpload.vue
+++ b/src/components/DpUploadFiles/DpUpload.vue
@@ -303,7 +303,7 @@ export default {
 
   beforeUnmount () {
     if (this.uppy) {
-      this.uppy.close()
+      this.uppy.clear()
     }
   }
 }

--- a/src/components/DpUploadFiles/DpUpload.vue
+++ b/src/components/DpUploadFiles/DpUpload.vue
@@ -16,6 +16,14 @@ import Uppy from '@uppy/core'
 export default {
   name: 'DpUpload',
 
+  emits: [
+    'file-added',
+    'file-error',
+    'upload',
+    'uploads-completed',
+    'upload-success'
+  ],
+
   props: {
     /**
      * Array of mimeTypes or a defined preset as String

--- a/src/components/DpUploadFiles/DpUploadFiles.vue
+++ b/src/components/DpUploadFiles/DpUploadFiles.vue
@@ -61,6 +61,8 @@ export default {
     DpUploadedFileList
   },
 
+  emits: ['upload-success'],
+
   mixins: [prefixClassMixin, sessionStorageMixin],
 
   provide () {

--- a/src/components/DpUploadFiles/DpUploadedFile.vue
+++ b/src/components/DpUploadFiles/DpUploadedFile.vue
@@ -42,6 +42,8 @@ import { prefixClassMixin } from '~/mixins'
 export default {
   name: 'DpUploadedFile',
 
+  emits: ['file-remove'],
+
   inject: ['getFileByHash'],
 
   mixins: [prefixClassMixin],

--- a/src/components/DpUploadFiles/DpUploadedFileList.vue
+++ b/src/components/DpUploadFiles/DpUploadedFileList.vue
@@ -23,6 +23,8 @@ import { de } from "~/components/shared/translations"
 export default {
   name: 'DpUploadedFileList',
 
+  emits: ['file-remove'],
+
   components: {
     DpUploadedFile
   },


### PR DESCRIPTION
**Ticket:** [DPLAN-15169](https://demoseurope.youtrack.cloud/issue/DPLAN-15169/Nicht-moglich-um-ein-Bild-zu-einem-Kapitel-zu-hinzufugen)

Includes these fixes:
- uppy method `clear()` is used instead of `close()` (which does not exist and threw an error)
- `this.$parent` can't be used in vue 3 anymore and is replaced
- emitted events are now declared (not declaring them may cause problems and is expected in vue 3)
- prop is correctly passed as boolean (instead of string)
- render function in DpTransitionExpand is fixed so that the vue 3 render function api can be enabled, which in turn is needed to make tiptap/vue3 NodeViewWrapper work in DpResizableImage, as it uses the new api.

### Related PR
- [ ] https://github.com/demos-europe/demosplan-core/pull/4475