### PR TITLE
b(refs: DPLAN-15161) add hasContent props for DpTreeListToggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+- ([#1224](https://github.com/demos-europe/demosplan-ui/pull/1224)) Changed DpTreeList to render toogle depending on content ([@riechedemos](https://github.com/riechedemos))
 
 ## v0.4.8 - 2025-03-24
 

--- a/src/components/DpTreeList/DpTreeList.vue
+++ b/src/components/DpTreeList/DpTreeList.vue
@@ -18,7 +18,7 @@
           <slot name="header" />
         </div>
         <dp-tree-list-toggle
-          v-if="hasContent"
+          v-if="treeData.length > 0"
           class="color--grey"
           data-cy="treeListNodeToggle"
           @input="toggleAll"
@@ -113,11 +113,6 @@ export default {
       type: Boolean,
       required: false,
       default: true
-    },
-
-    hasContent: {
-      type: Boolean,
-      required: true
     },
 
     /*

--- a/src/components/DpTreeList/DpTreeList.vue
+++ b/src/components/DpTreeList/DpTreeList.vue
@@ -18,6 +18,7 @@
           <slot name="header" />
         </div>
         <dp-tree-list-toggle
+          v-if="hasContent"
           class="color--grey"
           data-cy="treeListNodeToggle"
           @input="toggleAll"
@@ -112,6 +113,11 @@ export default {
       type: Boolean,
       required: false,
       default: true
+    },
+
+    hasContent: {
+      type: Boolean,
+      required: true
     },
 
     /*


### PR DESCRIPTION
## Ticket
DPLAN-15161

Add conditional rendering for the DpTreeListToggle component with a new hasContent prop and a computed property for evaluation.


Related PR: https://github.com/demos-europe/demosplan-core/pull/4506 