### PR TITLE
feat(DPLAN-15263): create custom dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+## v0.4.7 - 2025-03-20
+
 ### Fixed
 - ([#1217](https://github.com/demos-europe/demosplan-ui/pull/1217)) DpEditor: Fix image upload ([@hwiem](https://github.com/hwiem))
+
 
 ## v0.4.6 - 2025-03-18
 
@@ -18,7 +21,6 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 ### Added
 - ([#1215](https://github.com/demos-europe/demosplan-ui/pull/1215)) Reintroduce ClickOutside for some Components ([@salisdemos](https://github.com/salisdemos))
 - ([#1216](https://github.com/demos-europe/demosplan-ui/pull/1216)) DpInput: Add prop for rounded input to allow full or only left or right rounded input ([@gruenbergerdemos](https://github.com/gruenbergerdemos))
-
 
 
 ## v0.4.5 - 2025-03-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+- ([#1228](https://github.com/demos-europe/demosplan-ui/pull/1228)) Create DpConfirmDialog component ([@sakutademos](https://github.com/sakutademos)
+
 ## v0.4.9 - 2025-04-02
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demos-europe/demosplan-ui",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "license": "MIT",
   "description": "Vue components, Vue directives, Design Token and Scss files to build interfaces for demosPlan.",
   "main": "./dist/demosplan-ui.umd.js",

--- a/src/components/DpConfirmDialog/DpConfirmDialog.stories.mdx
+++ b/src/components/DpConfirmDialog/DpConfirmDialog.stories.mdx
@@ -1,0 +1,19 @@
+import { Meta } from '@storybook/addon-docs'
+import DpConfirmDialog from './'
+
+<Meta
+    title="Components/ConfirmDialog"
+    component={DpConfirmDialog}
+/>
+
+# DpConfirmDialog Component
+
+This is a modal dialog component that shows a message and offers confirm/cancel actions.
+
+## Default usage
+
+```html
+<dp-confirm-dialog
+  message="Are you sure you want to proceed?"
+  data-cy="default" />
+```

--- a/src/components/DpConfirmDialog/DpConfirmDialog.stories.tsx
+++ b/src/components/DpConfirmDialog/DpConfirmDialog.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/vue3'
+import type { Meta, StoryObj } from '@storybook/vue'
 import DpConfirmDialog from './'
 
 const meta: Meta<typeof DpConfirmDialog> = {

--- a/src/components/DpConfirmDialog/DpConfirmDialog.stories.tsx
+++ b/src/components/DpConfirmDialog/DpConfirmDialog.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import DpConfirmDialog from './'
+
+const meta: Meta<typeof DpConfirmDialog> = {
+  component: DpConfirmDialog,
+  title: 'Components/ConfirmDialog',
+  render: (args) => ({
+    components: {
+      DpConfirmDialog
+    },
+    setup() {
+      return { args }
+    },
+    template: `<dp-confirm-dialog v-bind="args" />`
+  })
+}
+
+interface IDpConfirmDialog {
+  dataCy?: string
+  message?: string
+  'modal:toggled': object
+}
+
+export default meta;
+type Story = StoryObj<IDpConfirmDialog>
+
+export const Default: Story = {
+  args: {
+    dataCy: 'default',
+    message: 'Are you sure you want to proceed?'
+  },
+  argTypes: {
+    'modal:toggled': { action: 'modal:toggled' }
+  }
+}

--- a/src/components/DpConfirmDialog/DpConfirmDialog.vue
+++ b/src/components/DpConfirmDialog/DpConfirmDialog.vue
@@ -7,15 +7,15 @@
     @modal:toggled="onModalToggled">
     <p
       id="dialogDescription"
-      class="break-words mb-3">
+      class="font-normal break-words mb-3">
       {{ message }}
     </p>
     <dp-button-row
       primary
       :primary-text="confirmButtonText"
       secondary
-      @primary-action="handleDialogResponse(true)"
-      @secondary-action="handleDialogResponse(false)" />
+      @primary-action="handleConfirm(true)"
+      @secondary-action="handleConfirm(false)" />
   </dp-modal>
 </template>
 
@@ -25,7 +25,7 @@ import DpButtonRow from '~/components/DpButtonRow'
 import DpModal from '~/components/DpModal'
 
 export default {
-  name: 'DpDialog',
+  name: 'DpConfirmDialog',
 
   components: {
     DpButtonRow,
@@ -42,7 +42,7 @@ export default {
     message: {
       type: String,
       required: false,
-      default: de.dialog.default
+      default: de.confirmDialog.confirm
     }
   },
 
@@ -53,7 +53,7 @@ export default {
     }
   },
   methods: {
-    handleDialogResponse (isConfirmed: boolean): void {
+    handleConfirm (isConfirmed: boolean): void {
       if (this.resolvePromise) {
         this.resolvePromise(isConfirmed)
         /* Clear the reference to the resolver to avoid reusing it later */

--- a/src/components/DpConfirmDialog/DpConfirmDialog.vue
+++ b/src/components/DpConfirmDialog/DpConfirmDialog.vue
@@ -1,0 +1,81 @@
+<template>
+  <dp-modal
+    ref="confirmDialog"
+    content-classes="w-2/3 xl:w-1/3"
+    :data-cy="`confirmDialog:${dataCy}`"
+    aria-describedby="dialogDescription"
+    @modal:toggled="onModalToggled">
+    <p
+      id="dialogDescription"
+      class="break-words mb-3">
+      {{ message }}
+    </p>
+    <dp-button-row
+      primary
+      :primary-text="confirmButtonText"
+      secondary
+      @primary-action="handleDialogResponse(true)"
+      @secondary-action="handleDialogResponse(false)" />
+  </dp-modal>
+</template>
+
+<script lang="ts">
+import { de } from '~/components/shared/translations'
+import DpButtonRow from '~/components/DpButtonRow'
+import DpModal from '~/components/DpModal'
+
+export default {
+  name: 'DpDialog',
+
+  components: {
+    DpButtonRow,
+    DpModal
+  },
+
+  props: {
+    dataCy: {
+      type: String,
+      required: false,
+      default: ''
+    },
+
+    message: {
+      type: String,
+      required: false,
+      default: de.dialog.default
+    }
+  },
+
+  data () {
+    return {
+      confirmButtonText: de.operations.confirm,
+      resolvePromise: null as ((result: boolean) => void) | null
+    }
+  },
+  methods: {
+    handleDialogResponse (isConfirmed: boolean): void {
+      if (this.resolvePromise) {
+        this.resolvePromise(isConfirmed)
+        /* Clear the reference to the resolver to avoid reusing it later */
+        this.resolvePromise = null
+      }
+      this.$refs.confirmDialog.toggle()
+    },
+
+    onModalToggled (isOpen: boolean): void {
+      if (!isOpen && this.resolvePromise) {
+        this.resolvePromise(false)
+        this.resolvePromise = null
+      }
+    },
+
+    open (): Promise<boolean> {
+      this.$refs.confirmDialog.toggle()
+
+      return new Promise(resolve => {
+        this.resolvePromise = resolve
+      })
+    }
+  }
+}
+</script>

--- a/src/components/DpConfirmDialog/index.ts
+++ b/src/components/DpConfirmDialog/index.ts
@@ -1,0 +1,2 @@
+export { default } from './DpConfirmDialog.vue'
+export * from './DpConfirmDialog.vue'

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -18,6 +18,7 @@ import DpDatepicker from './DpDatepicker'
 import DpDateRangePicker from './DpDateRangePicker'
 import DpDatetimePicker from './DpDatetimePicker'
 import DpDetails from './DpDetails'
+import DpConfirmDialog from './DpConfirmDialog'
 import DpDraggable from './DpDraggable'
 import DpEditor from './DpEditor'
 import DpEditableList from './DpEditableList'
@@ -67,6 +68,7 @@ export {
   DpBadge,
   DpButton,
   DpButtonRow,
+  DpConfirmDialog,
   DpDetails,
   DpIcon,
   DpInput,

--- a/src/components/shared/translations.js
+++ b/src/components/shared/translations.js
@@ -27,10 +27,10 @@ const de = {
   autocompleteNoResults: 'Keine Suchtreffer.',
   choose: "Auswählen",
   computer: 'Computer',
-  contextualHelp: 'Kontexthilfe',
-  dialog: {
-    default: 'Sind Sie sicher, dass Sie fortfahren möchten?'
+  confirmDialog: {
+    confirm: 'Sind Sie sicher, dass Sie fortfahren möchten?'
   },
+  contextualHelp: 'Kontexthilfe',
   dropdown: {
     close: "Einklappen",
     open: "Ausklappen"

--- a/src/components/shared/translations.js
+++ b/src/components/shared/translations.js
@@ -28,6 +28,9 @@ const de = {
   choose: "Auswählen",
   computer: 'Computer',
   contextualHelp: 'Kontexthilfe',
+  dialog: {
+    default: 'Sind Sie sicher, dass Sie fortfahren möchten?'
+  },
   dropdown: {
     close: "Einklappen",
     open: "Ausklappen"
@@ -128,6 +131,7 @@ const de = {
     deselect: {
       all: 'Auswahl aufheben'
     },
+    confirm: 'Bestätigen',
     insert: 'Einfügen',
     new: 'Neu',
     none: 'Keine',


### PR DESCRIPTION
**Ticket:** https://demoseurope.youtrack.cloud/issue/DPLAN-15263/Custom-confirm-Dialog-anstelle-des-nativen-Dialogs-window.confirm

**Description:** This PR introduces a new component: `DpConfirmDialog`, which replaces the native window.confirm functionality, as it is not accessible in certain situations (for example, when a user clicks to close all alert messages). DpConfirmDialog is built on the DpModal component.

PR In Core: https://github.com/demos-europe/demosplan-core/pull/4523