### PR TITLE
fix(DPLAN-DPLAN-15342): update currentValue when the user inputs text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+
+- ([#1236](https://github.com/demos-europe/demosplan-ui/pull/1236)) DpResettableInput: update currentValue on input ([@sakutademos](https://github.com/sakutademos)
+
 ## v0.4.11 - 2025-04-07
 
 ### Fixed

--- a/src/components/DpResettableInput/DpResettableInput.vue
+++ b/src/components/DpResettableInput/DpResettableInput.vue
@@ -8,7 +8,7 @@
       :required="required"
       :rounded="rounded"
       @blur="$emit('blur', currentValue)"
-      @input="$emit('input', currentValue)"
+      @input="onInput"
       @enter="$emit('enter', currentValue)"
       @focus="$emit('focus')"
       :pattern="pattern"
@@ -128,13 +128,12 @@ export default {
     }
   },
 
-  watch: {
-    value: function () {
-      this.currentValue = this.value
-    }
-  },
-
   methods: {
+    onInput (val) {
+      this.currentValue = val
+      this.$emit('input', val)
+    },
+
     resetValue () {
       this.$emit('reset')
     }

--- a/src/components/DpResettableInput/DpResettableInput.vue
+++ b/src/components/DpResettableInput/DpResettableInput.vue
@@ -128,6 +128,12 @@ export default {
     }
   },
 
+  watch: {
+    value: function () {
+      this.currentValue = this.value
+    }
+  },
+
   methods: {
     onInput (val) {
       this.currentValue = val


### PR DESCRIPTION
**Ticket:** https://demoseurope.youtrack.cloud/agiles/141-63/current?settings&tab=allgemeines&issue=DPLAN-15342

**Description:** This PR fixes an issue where the `DpResettableInput` was only updated after the second input. It now assigns `this.currentValue = val `when the user inputs text.

 There is also a warning about deprecated v-model usage, which I tried to fix, but it does not work as expected. Here is a [thread about the issue](https://demosdeutschland.slack.com/archives/C5BA8ABB2/p1744028862868659). it can be fixed in a separate PR.