### PR TITLE
fix(refs DPLAN-12969): allow setting the width of the search field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+
+- ([#1239](https://github.com/demos-europe/demosplan-ui/pull/1239)) DpSearchField: Allow setting an input width for the search field ([@hwiem](https://github.com/hwiem))
 
 ## v0.4.12 - 2025-04-08
 

--- a/src/components/DpSearchField/DpSearchField.vue
+++ b/src/components/DpSearchField/DpSearchField.vue
@@ -62,6 +62,11 @@ export default {
     }
   },
 
+  emits: [
+    'search',
+    'reset'
+  ],
+
   data () {
     return {
       translations: {

--- a/src/components/DpSearchField/DpSearchField.vue
+++ b/src/components/DpSearchField/DpSearchField.vue
@@ -1,7 +1,7 @@
 <template>
   <span
     class="inline-flex"
-    :class="{ 'w-full': inputWidth === ''}">
+    :class="{ 'w-full': inputWidth === '' }">
     <dp-resettable-input
       id="searchField"
       v-model="searchTerm"

--- a/src/components/DpSearchField/DpSearchField.vue
+++ b/src/components/DpSearchField/DpSearchField.vue
@@ -1,7 +1,7 @@
 <template>
   <span
     class="inline-flex"
-    :class="{ 'w-full': inputWidth !== '' }">
+    :class="{ 'w-full': inputWidth === ''}">
     <dp-resettable-input
       id="searchField"
       v-model="searchTerm"


### PR DESCRIPTION
This got lost with the vue 3 update and is now restored.

See the old PR: https://github.com/demos-europe/demosplan-ui/pull/1147