### PR TITLE
fix(refs DPLAN-15338, #AB26283): set headerCellCount on mounted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 ### Fixed
 
 - ([#1239](https://github.com/demos-europe/demosplan-ui/pull/1239)) DpSearchField: Allow setting an input width for the search field ([@hwiem](https://github.com/hwiem))
+- ([#1242](https://github.com/demos-europe/demosplan-ui/pull/1242)) DpDataTable: Set correct colCount for empty data table ([@hwiem](https://github.com/hwiem))
 
 ## v0.4.12 - 2025-04-08
 

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -715,6 +715,8 @@ export default {
     }
 
     this.forceElementSelections(this.shouldBeSelectedItems)
+
+    this.headerCellCount = this.headerFields.length
   }
 }
 </script>


### PR DESCRIPTION
**Ticket:** [DPLAN-15338](https://demoseurope.youtrack.cloud/issue/DPLAN-15338/ADO-Issue-26283-Hinzufugen-konfigurierbare-Felder-auf-Abschnittsebene-Part-1-Anlegen)

If we set `headerCellCount` on `beforeUpdate`, the `headerFields` length is still 0, and the `colCount` is not calculated correctly if the table is empty

**Before:**
![table_before](https://github.com/user-attachments/assets/4f74ab87-3e53-4d74-b1a8-b9bd770defe0)

**After:**
![table_after](https://github.com/user-attachments/assets/df69441e-8397-4850-bdc7-919c8ebe1134)
