### PR TITLE
feat: emit blur and focus events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+
+- ([#1243](https://github.com/demos-europe/demosplan-ui/pull/1243)) DpButton: emit blur and focus events ([@hwiem](https://github.com/hwiem))
+
 ### Fixed
 
 - ([#1239](https://github.com/demos-europe/demosplan-ui/pull/1239)) DpSearchField: Allow setting an input width for the search field ([@hwiem](https://github.com/hwiem))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Added
 
-- ([#1243](https://github.com/demos-europe/demosplan-ui/pull/1243)) DpButton: emit blur and focus events ([@hwiem](https://github.com/hwiem))
+- ([#1243](https://github.com/demos-europe/demosplan-ui/pull/1243)) DpButton: emit blur, focus and mousedown events ([@hwiem](https://github.com/hwiem))
 
 ### Fixed
 

--- a/src/components/DpButton/DpButton.vue
+++ b/src/components/DpButton/DpButton.vue
@@ -8,7 +8,9 @@
     :class="classes"
     :disabled="disabled"
     :aria-hidden="busy"
-    @click="emit('click', $event)">
+    @blur="emit('blur', $event)"
+    @click="emit('click', $event)"
+    @focus="emit('focus', $event)">
     <dp-icon
       v-if="icon"
       aria-hidden="true"
@@ -153,7 +155,11 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(['click'])
+const emit = defineEmits([
+  'blur',
+  'click',
+  'focus'
+])
 
 const iconOnly = computed(() => (props.icon || props.iconAfter) && props.hideText)
 

--- a/src/components/DpButton/DpButton.vue
+++ b/src/components/DpButton/DpButton.vue
@@ -10,7 +10,8 @@
     :aria-hidden="busy"
     @blur="emit('blur', $event)"
     @click="emit('click', $event)"
-    @focus="emit('focus', $event)">
+    @focus="emit('focus', $event)"
+    @mousedown="emit('mousedown', $event)">
     <dp-icon
       v-if="icon"
       aria-hidden="true"
@@ -158,7 +159,8 @@ const props = defineProps({
 const emit = defineEmits([
   'blur',
   'click',
-  'focus'
+  'focus',
+  'mousedown'
 ])
 
 const iconOnly = computed(() => (props.icon || props.iconAfter) && props.hideText)

--- a/src/components/DpButton/DpButton.vue
+++ b/src/components/DpButton/DpButton.vue
@@ -29,10 +29,10 @@
 
 <script setup lang="ts">
 import { computed, onMounted, PropType } from 'vue'
+import { proportions as ICON_PROPORTIONS, SIZES as ICON_SIZES } from '~/components/DpIcon/util/iconConfig'
 import { IconName, IconSize } from '../../../types'
 import DpIcon from '~/components/DpIcon/DpIcon.vue'
 import { sanitizeUrl } from '@braintree/sanitize-url'
-import { proportions as ICON_PROPORTIONS, SIZES as ICON_SIZES } from '~/components/DpIcon/util/iconConfig'
 import { Tooltip } from '~/directives'
 
 type ButtonColor = 'primary' | 'secondary' | 'warning'


### PR DESCRIPTION
To be able to handle `blur`, `focus` and `mousedown` events from DpButton, we need to emit them first.