### PR TITLE
fix(refs DPLAN-2786): adjust editor menu buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+## v0.4.15 - 2025-05-07
+
+### Fixed
+
+- ([#1264](https://github.com/demos-europe/demosplan-ui/pull/1264) DpEditor: Adjust editor menu buttons ([@meissnerdemos](https://github.com/meissnerdemos))
+
 ## v0.4.14 - 2025-04-24
 
 ### Fixed

--- a/src/components/DpEditor/DpEditor.vue
+++ b/src/components/DpEditor/DpEditor.vue
@@ -136,7 +136,7 @@
                 @click.stop="toggleSubMenu('diffMenu', !diffMenu.isOpen)"
                 @keydown.tab.shift.exact="toggleSubMenu('diffMenu', false)">
                 <dp-icon
-                  class="align-text-top inline-block"
+                  class="inline-block mr-0.5"
                   icon="highlighter" />
                 <i :class="prefixClass('fa fa-caret-down')" />
               </button>
@@ -172,7 +172,7 @@
                 @keydown.tab.shift.exact="() => { idx === 0 ? toggleSubMenu('diffMenu', false) : null }"
                 @click.stop="executeSubMenuButtonAction(button, 'diffMenu', true)">
                 <dp-icon
-                  class="align-text-top"
+                  class="inline-block"
                   icon="highlighter" />
               </button>
             </div>
@@ -257,7 +257,7 @@
                 :disabled="readonly"
                 @click.stop="toggleSubMenu('tableMenu', !tableMenu.isOpen)"
                 @keydown.tab.shift.exact="toggleSubMenu('tableMenu', false)">
-                <i :class="prefixClass('fa fa-table')" />
+                <i :class="prefixClass('fa fa-table mr-0.5')" />
                 <i :class="prefixClass('fa fa-caret-down')" />
               </button>
               <div


### PR DESCRIPTION
Change style of 'mark' button to be inline with other buttons. Slightly increase margin towards the caret icon for buttons that open a flyout.

Ticket: [DPLAN-2786](https://demoseurope.youtrack.cloud/issue/DPLAN-2786/Markierungs-Icon-verschoben)

### How to test

- change of mark button: see ticket
- margin increase: editor buttons with flyout are visible when editing a chapter