### PR TITLE
fix(refs: DPLAN-15150 Increased margin between btns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 ### Changed
 
 - ([#1267](https://github.com/demos-europe/demosplan-ui/pull/1267) Update Storybook to v8, enhance component documentation ([@spiess-demos](https://github.com/spiess-demos))
+- ([#1272](https://github.com/demos-europe/demosplan-ui/pull/1246)) DpEditableList: Adjust margin between buttons ([@riechedemos](https://github.com/riechedemos))
+
 
 ## v0.4.15 - 2025-05-07
 

--- a/src/components/DpEditableList/DpEditableList.vue
+++ b/src/components/DpEditableList/DpEditableList.vue
@@ -24,7 +24,7 @@
             variant="subtle"
             @click.prevent="showUpdateForm(index)" />
           <dp-button
-            class="ml-0.5"
+            class="ml-1"
             :data-cy="`${dataCy}:deleteEntry`"
             hide-text
             icon="delete"


### PR DESCRIPTION
[DPLAN-15150](https://demoseurope.youtrack.cloud/issue/DPLAN-15150/Support-Items-haben-Edit-und-loschen-Icon-auf-weissem-Hintergrund)


Increased left margin for the second button to ensure the icon is more clearly visible and distinguishable on a white background.