### PR TITLE
chore: allow linting single files

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "build:prod": "webpack --mode=production --define-process-env-node-env=production",
     "test": "jest",
     "watch": "webpack --watch",
-    "lint": "eslint ."
+    "lint": "eslint"
   },
   "packageManager": "yarn@4.2.2"
 }


### PR DESCRIPTION
- it is now possible to execute `yarn lint` for a single file by passing its path to the command
- it is still possible to execute `yarn lint` for all files by running `yarn lint .`

- [ ] Update documentation