### PR TITLE
fix(refs DPLAN-15771, #AB29551): adjust condition for disabled btn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 - ([#1268](https://github.com/demos-europe/demosplan-ui/pull/1268)) DpAutocomplete: replace vue-omnibox with custom logic ([@salisdemos](https://github.com/salisdemos)
 - ([#1267](https://github.com/demos-europe/demosplan-ui/pull/1267) Update Storybook to v8, enhance component documentation ([@spiess-demos](https://github.com/spiess-demos))
 - ([#1271](https://github.com/demos-europe/demosplan-ui/pull/1271)) DpTreeList: initialize the Stickier instances in nextTick and if the element’s height is greater than zero ([@sakutademos](https://github.com/sakutademos)
-
+- ([#1289](https://github.com/demos-europe/demosplan-ui/pull/1289)) DpMultiselect: Adjust condition for button disabling / adjust custom event names in 6 files ([@rafelddemos](https://github.com/rafelddemos))
 
 ## v0.4.15 - 2025-05-07
 

--- a/src/components/DpDataTable/DpDataTable.stories.tsx
+++ b/src/components/DpDataTable/DpDataTable.stories.tsx
@@ -42,7 +42,7 @@ interface IDpDataTable {
   'changed-order'?: (event: any, item: any) => void
   'items-selected'?: (items: string[]) => void
   'items-toggled'?: (items: {id: string}[], selected: boolean) => void
-  'select-all'?: (selected: boolean) => void
+  'selectAll'?: (selected: boolean) => void
 }
 
 const meta: Meta<typeof DpDataTable> = {
@@ -85,8 +85,8 @@ const meta: Meta<typeof DpDataTable> = {
       action: 'items-selected',
       description: 'Event emitted when items are selected'
     },
-    'select-all': {
-      action: 'select-all',
+    'selectAll': {
+      action: 'selectAll',
       description: 'Event emitted when all items are selected or deselected'
     }
   }

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -640,7 +640,7 @@ export default {
       }), status)
 
       // Used by multi-page selection in SegmentsList to determine whether to track selected or deselected items.
-      this.$emit('select-all', status)
+      this.$emit('selectAll', status)
     },
 
     toggleWrap (id) {

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -394,6 +394,14 @@ export default {
       default: () => ({})
     }
   },
+
+  emits: [
+    'changed-order',
+    'items-selected',
+    'items-toggled',
+    'selectAll'
+  ],
+
   data () {
     return {
       allExpanded: false,

--- a/src/components/DpMultiselect/DpMultiselect.mdx
+++ b/src/components/DpMultiselect/DpMultiselect.mdx
@@ -55,6 +55,6 @@ The component supports grouped options. To use groups:
 The multiselect component can include selection controls by setting the `selectionControls` prop to `true`.
 This adds "Select All" and "Clear Selection" buttons to help users quickly select or deselect all options.
 
-When using selection controls, you'll need to handle the `@select-all` and `@unselect-all` events in your application code.
+When using selection controls, you'll need to handle the `@selectAll` and `@unselectAll` events in your application code.
 
 <Canvas of={DpMultiselectStories.WithSelectionControls} />

--- a/src/components/DpMultiselect/DpMultiselect.mdx
+++ b/src/components/DpMultiselect/DpMultiselect.mdx
@@ -55,6 +55,6 @@ The component supports grouped options. To use groups:
 The multiselect component can include selection controls by setting the `selectionControls` prop to `true`.
 This adds "Select All" and "Clear Selection" buttons to help users quickly select or deselect all options.
 
-When using selection controls, you'll need to handle the `@selectAll` and `@unselectAll` events in your application code.
+When using selection controls, you'll need to handle the `@selectAll` and `@deselectAll` events in your application code.
 
 <Canvas of={DpMultiselectStories.WithSelectionControls} />

--- a/src/components/DpMultiselect/DpMultiselect.stories.tsx
+++ b/src/components/DpMultiselect/DpMultiselect.stories.tsx
@@ -19,7 +19,7 @@ interface IDpMultiselect {
   'search-change': (query: string) => void
   'select': (option: any) => void
   'selectAll': () => void
-  'unselectAll': () => void
+  'deselectAll': () => void
 }
 
 const meta: Meta<typeof DpMultiselect> = {
@@ -59,7 +59,7 @@ const meta: Meta<typeof DpMultiselect> = {
       // Handle unselect all action
       const unselectAllHandler = () => {
         // Call the original action handler
-        args['unselectAll']()
+        args['deselectAll']()
 
         // Clear the value
         args.value = args.multiple ? [] : ''
@@ -94,7 +94,7 @@ const meta: Meta<typeof DpMultiselect> = {
           @search-change="args['search-change']"
           @select="args.select"
           @selectAll="selectAllHandler"
-          @unselectAll="unselectAllHandler" />
+          @deselectAll="unselectAllHandler" />
       </div>
     `
   })
@@ -158,7 +158,7 @@ export const WithSelectionControls: Story = {
   argTypes: {
     'input': { action: 'input' },
     'selectAll': { action: 'selectAll' },
-    'unselectAll': { action: 'unselectAll' }
+    'deselectAll': { action: 'deselectAll' }
   },
   parameters: {
     docs: {

--- a/src/components/DpMultiselect/DpMultiselect.stories.tsx
+++ b/src/components/DpMultiselect/DpMultiselect.stories.tsx
@@ -18,8 +18,8 @@ interface IDpMultiselect {
   'remove': (value: any) => void
   'search-change': (query: string) => void
   'select': (option: any) => void
-  'select-all': () => void
-  'unselect-all': () => void
+  'selectAll': () => void
+  'unselectAll': () => void
 }
 
 const meta: Meta<typeof DpMultiselect> = {
@@ -48,7 +48,7 @@ const meta: Meta<typeof DpMultiselect> = {
       // Handle select all action
       const selectAllHandler = () => {
         // Call the original action handler
-        args['select-all']()
+        args['selectAll']()
 
         // Set the value to all options
         if (args.multiple) {
@@ -59,7 +59,7 @@ const meta: Meta<typeof DpMultiselect> = {
       // Handle unselect all action
       const unselectAllHandler = () => {
         // Call the original action handler
-        args['unselect-all']()
+        args['unselectAll']()
 
         // Clear the value
         args.value = args.multiple ? [] : ''
@@ -93,8 +93,8 @@ const meta: Meta<typeof DpMultiselect> = {
           @remove="args.remove"
           @search-change="args['search-change']"
           @select="args.select"
-          @select-all="selectAllHandler"
-          @unselect-all="unselectAllHandler" />
+          @selectAll="selectAllHandler"
+          @unselectAll="unselectAllHandler" />
       </div>
     `
   })
@@ -157,8 +157,8 @@ export const WithSelectionControls: Story = {
   },
   argTypes: {
     'input': { action: 'input' },
-    'select-all': { action: 'select-all' },
-    'unselect-all': { action: 'unselect-all' }
+    'selectAll': { action: 'selectAll' },
+    'unselectAll': { action: 'unselectAll' }
   },
   parameters: {
     docs: {

--- a/src/components/DpMultiselect/DpMultiselect.vue
+++ b/src/components/DpMultiselect/DpMultiselect.vue
@@ -80,7 +80,7 @@
             class="btn--blank weight--bold u-ph-0_5 u-pv-0_25"
             :disabled="value.length === 0"
             type="button"
-            @click="$emit('unselectAll')"
+            @click="$emit('deselectAll')"
             v-text="translations.deselectAll" />
         </div>
       </slot>
@@ -328,7 +328,7 @@ export default {
 
     /**
      * Shows "Select All" and "Deselect All" buttons in the dropdown.
-     * When enabled, you should handle @selectAll and @unselectAll events.
+     * When enabled, you should handle @selectAll and @deselectAll events.
      * Only meaningful when multiple=true.
      */
     selectionControls: {
@@ -416,7 +416,7 @@ export default {
     'select',
     'selectAll',
     'tag',
-    'unselectAll'
+    'deselectAll'
   ],
 
   data () {

--- a/src/components/DpMultiselect/DpMultiselect.vue
+++ b/src/components/DpMultiselect/DpMultiselect.vue
@@ -71,7 +71,7 @@
         <div class="border-bottom">
           <button
             class="btn--blank weight--bold u-ph-0_5 u-pv-0_25"
-            :disabled="value.length === options.length === 0"
+            :disabled="value.length === options.length"
             type="button"
             @click="$emit('select-all')"
             v-text="translations.selectAll" />

--- a/src/components/DpMultiselect/DpMultiselect.vue
+++ b/src/components/DpMultiselect/DpMultiselect.vue
@@ -73,14 +73,14 @@
             class="btn--blank weight--bold u-ph-0_5 u-pv-0_25"
             :disabled="value.length === options.length"
             type="button"
-            @click="$emit('select-all')"
+            @click="$emit('selectAll')"
             v-text="translations.selectAll" />
 
           <button
             class="btn--blank weight--bold u-ph-0_5 u-pv-0_25"
             :disabled="value.length === 0"
             type="button"
-            @click="$emit('unselect-all')"
+            @click="$emit('unselectAll')"
             v-text="translations.deselectAll" />
         </div>
       </slot>
@@ -328,7 +328,7 @@ export default {
 
     /**
      * Shows "Select All" and "Deselect All" buttons in the dropdown.
-     * When enabled, you should handle @select-all and @unselect-all events.
+     * When enabled, you should handle @selectAll and @unselectAll events.
      * Only meaningful when multiple=true.
      */
     selectionControls: {
@@ -414,9 +414,9 @@ export default {
     'remove',
     'search-change',
     'select',
-    'select-all',
+    'selectAll',
     'tag',
-    'unselect-all'
+    'unselectAll'
   ],
 
   data () {

--- a/src/mixins/tableSelectAllItems.js
+++ b/src/mixins/tableSelectAllItems.js
@@ -15,7 +15,7 @@
  *   :multi-page-selection-items-toggled="toggledItems.length"
  *   :should-be-selected-items="currentlySelectedItems"
  *   track-by="id"
- *   @select-all="handleSelectAll"
+ *   @selectAll="handleSelectAll"
  *   @items-toggled="handleToggleItem" />
  */
 


### PR DESCRIPTION
This PR is related to [this one ](https://github.com/demos-europe/demosplan-core/pull/4782). It fixes a bug that got noticed while working on the US. The condition for the 'selectAll' button had to be adjusted to enable it getting disabled when all options have already been selected.

Additionally, it adjusts the names of the custom events relevant to the story to camelCase.