### PR TITLE
feat(refs: DPLAN-15554) basic settings validation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Changed
+
+- ([#1274](https://github.com/demos-europe/demosplan-ui/pull/1274)) dpValidateMixin.js: adding topic names to field names in error messages([@riechedemos](https://github.com/riechedemos))
+
 ## v0.4.16 - 2025-05-12
 
 ### Added

--- a/src/mixins/dpValidateMixin.js
+++ b/src/mixins/dpValidateMixin.js
@@ -45,13 +45,29 @@ export default {
         customErrors.forEach(error => dplan.notify.notify('error', error))
 
         if (customErrors.length === 0) {
-          const nonEmptyUniqueFieldNames = invalidFields
-            .map(field => field.getAttribute('data-dp-validate-error-fieldname'))
-            .filter(Boolean)
-            .filter((field, idx, arr) => arr.indexOf(field) === idx)
+          // Collect field information with topics for wizard
+          const fieldsWithTopics = []
 
-          if (nonEmptyUniqueFieldNames.length) {
-            const fieldsString = nonEmptyUniqueFieldNames ? nonEmptyUniqueFieldNames.join(', ') : ' '
+          invalidFields.forEach(field => {
+            const fieldName = field.getAttribute('data-dp-validate-error-fieldname')
+            if (!fieldName) return
+
+            // Search for parent element with data-dp-validate-topic
+            let topicElement = field.closest('[data-dp-validate-topic]')
+            let topicName = topicElement ? topicElement.getAttribute('data-dp-validate-topic') : ''
+
+            const existingIndex = fieldsWithTopics.findIndex(
+              item => item.fieldName === fieldName && item.topicName === topicName
+            )
+
+            if (existingIndex === -1) {
+              fieldsWithTopics.push({ fieldName, topicName })
+            }
+          })
+
+          if (fieldsWithTopics.length) {
+            const fieldsString = fieldsWithTopics.map(item => {
+              return item.topicName ? `${item.fieldName} (${item.topicName})` : item.fieldName }).join(', ')
             const errorMandatoryFields = de.error.mandatoryFields.intro + fieldsString + de.error.mandatoryFields.outro
             dplan.notify.notify('error', errorMandatoryFields)
           } else {


### PR DESCRIPTION
DPLAN-15554

This improves form validation error messages by adding topic names
to field names in error messages. Now, instead of showing only the field names
like "Please correct the following fields: Contact Person, Email Address",
the message will include the topic section names: "Please correct the following
fields: Contact Person (Procedure Information), Email Address (Internal)".-

This enhancement makes it easier for users to find and correct missing
required fields, especially in multi-step forms or wizard interfaces.

How to review
create new procedure, try edit it in "Grundeinstellungen"
the error message should display the corresponding field and topic

Linked PRs
https://github.com/demos-europe/demosplan-core/pull/4655