### PR TITLE
fix(DPLAN-2800): pagination: next page issue

### DIFF
--- a/src/components/DpSlidingPagination/DpSlidingPagination.vue
+++ b/src/components/DpSlidingPagination/DpSlidingPagination.vue
@@ -15,7 +15,7 @@
     }"
     :current="current"
     :total="total"
-    @page-change="payload => $emit('page-change', payload)" />
+    @page-change="pageChange" />
 </template>
 
 <script>
@@ -55,6 +55,12 @@ export default {
   },
 
   methods: {
+    pageChange (page) {
+      if (page >= 1 && page <= this.total) {
+        this.$emit('page-change', page)
+      }
+    },
+
     prefixClass (classList) {
       return prefixClass(classList)
     }


### PR DESCRIPTION
**Ticket:** [DPLAN-2800](https://demoseurope.youtrack.cloud/issue/DPLAN-2800) Weiter Button in Listenansicht funktioniert auf Seite 1 nicht

**Description:**  This PR fixes an issue with pagination by adding an additional check to emit the 'page-change' event only when the page number does not exceed the total page count.

**The second issue:** unable to go to the next page from the first page by clicking the "Next" button is due to the logic within the external library `vue-sliding-pagination`. As i see, we cannot influence this behavior directly, as it is part of the component’s [internal implementation](https://github.com/eFrane/vue-sliding-pagination/blob/main/src/SlidingPagination.vue#L304-L325) and matches the behavior shown in the [documentation example](https://vue-sliding-pagination.efrane.com/examples.html#very-basic-example).