### PR TITLE
fix(DPLAN-2800): add new prop to the DpEditableList

### DIFF
--- a/src/components/DpEditableList/DpEditableList.vue
+++ b/src/components/DpEditableList/DpEditableList.vue
@@ -63,7 +63,7 @@
       class="btn btn--primary"
       :data-cy="`${dataCy}:showInput`"
       :text="translationKeys.new"
-      @click.prevent="showNewForm()" />
+      @click.prevent="showNewForm" />
   </div>
 </template>
 
@@ -79,6 +79,12 @@ export default {
   },
 
   props: {
+    closeOnSuccess: {
+      required: false,
+      type: Boolean,
+      default: false
+    },
+
     dataCy: {
       type: String,
       required: false,
@@ -110,6 +116,14 @@ export default {
       required: false,
       type: Boolean,
       default: true
+    },
+  },
+
+  watch: {
+    closeOnSuccess (newVal) {
+      if (newVal) {
+        this.resetForm()
+      }
     }
   },
 


### PR DESCRIPTION
**Description:** This PR adds a new prop `closeOnSuccess` to the `DpEditableList` component:

- when using a dynamic `<component>` in our addons, it is not possible to call its methods via `refs`, so added an extra prop to enable closing the form.

PR in Addon: https://github.com/demos-europe/demosplan-addon-maillane/pull/183