### PR TITLE
fix(refs DPLAN-2798): adjust actionmenu behavior for tab and enter key

### DIFF
--- a/src/lib/ActionMenu.js
+++ b/src/lib/ActionMenu.js
@@ -75,9 +75,11 @@ class ActionMenu {
 
   handleTriggerKeydown (event) {
     switch (event.keyCode) {
-    // Down
+    // Down, Enter, Space
     case 40:
-      // Prevent page scrolling
+    case 13:
+    case 32:
+      // Prevent page scrolling and default button behavior
       event.preventDefault()
       this.openMenu()
       this.menu.classList.remove(prefixClass('has-focused-trigger'))
@@ -132,8 +134,31 @@ class ActionMenu {
       this.menuItems[this.currentlySelectedIndex].focus()
       break
 
-      // Tab, esc
+      // Tab
     case 9:
+      if (event.shiftKey) {
+        // Shift+Tab: go to previous item or exit if at first
+        if (this.currentlySelectedIndex === 0) {
+          this.trigger.focus()
+          this.closeMenu()
+        } else {
+          this.currentlySelectedIndex--
+          this.menuItems[this.currentlySelectedIndex].focus()
+        }
+        event.preventDefault()
+      } else if (this.currentlySelectedIndex === this.menuItems.length - 1) {
+        // Tab: exit if at last item
+        this.closeMenu()
+        // Let natural tab order continue to next page element
+      } else {
+        // Tab: go to next item
+        this.currentlySelectedIndex++
+        this.menuItems[this.currentlySelectedIndex].focus()
+        event.preventDefault()
+      }
+      break
+
+      // Esc
     case 27:
       this.trigger.focus()
       this.closeMenu()


### PR DESCRIPTION
### Ticket
[DPLAN-2798](https://demoseurope.youtrack.cloud/issue/DPLAN-2798)

This PR adjusts the behavior of the action menu so that it can be properly used with a keyboard according to accessibility guidelines. You can now use enter and space to open it and tab/ shift + tab to navigate inside it. The actionmenu was added to the header flyout of diplanbau, -rog and -fest in the linked PRs.

### Linked PRs

rog: [200](https://github.com/demos-europe/demosplan-project-diplanrog/pull/200)
fest: [143](https://github.com/demos-europe/demosplan-project-diplanfest/pull/143)
bau: [313](https://github.com/demos-europe/demosplan-project-diplanbau/pull/313)
