### PR TITLE
fix(DPLAN-16037): restore Vue 3 v-model for DpInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Changed
 
+- ([#1318](https://github.com/demos-europe/demosplan-ui/pull/1318)) DpEditableList: ensure Vue 3 v-model works correctly under compat mode ([@sakutademos](https://github.com/sakutademos)
 - ([#1312](https://github.com/demos-europe/demosplan-ui/pull/1312)) Adjust tsConfig moduleResolution to bundler  ([@salisdemos](https://github.com/salisdemos))
 
 

--- a/src/components/DpInput/DpInput.vue
+++ b/src/components/DpInput/DpInput.vue
@@ -34,7 +34,7 @@
       @blur="emit('blur', $event.target.value)"
       @focus="emit('focus')"
       @input="onInput"
-      @keydown.enter="handleEnter" />
+      @keydown.enter="handleEnter">
   </div>
 </template>
 

--- a/src/components/DpInput/DpInput.vue
+++ b/src/components/DpInput/DpInput.vue
@@ -39,8 +39,8 @@
 </template>
 
 <script setup lang="ts">
-import {computed, ref} from 'vue'
 import { exactlengthHint, maxlengthHint, minlengthHint, prefixClass } from '~/utils'
+import { computed } from 'vue'
 import DpLabel from '~/components/DpLabel'
 
 const props = defineProps({

--- a/src/components/DpInput/DpInput.vue
+++ b/src/components/DpInput/DpInput.vue
@@ -299,18 +299,17 @@ const containerClasses = computed(() => {
 
 const labelHint = computed(() => {
   const hint: string[] = props.label.hint ? [props.label.hint] : []
-  const length = props.modelValue.length
 
   if (props.maxlength && !props.minlength) {
-    hint.push(maxlengthHint(length, props.maxlength))
+    hint.push(maxlengthHint(props.modelValue.length, props.maxlength))
   } else if (props.minlength && !props.maxlength) {
-    hint.push(minlengthHint(length, props.minlength))
+    hint.push(minlengthHint(props.modelValue.length, props.minlength))
   } else if (props.maxlength && props.minlength) {
     if (props.maxlength === props.minlength) {
-      hint.push(exactlengthHint(length, props.maxlength))
+      hint.push(exactlengthHint(props.modelValue.length, props.maxlength))
     } else {
-      hint.push(maxlengthHint(length, props.maxlength))
-      hint.push(minlengthHint(length, props.minlength))
+      hint.push(maxlengthHint(props.modelValue.length, props.maxlength))
+      hint.push(minlengthHint(props.modelValue.length, props.minlength))
     }
   }
 


### PR DESCRIPTION
Ticket: [DPLAN-16037](https://demoseurope.youtrack.cloud/issue/DPLAN-16037) Nicht möglich um Berechtigte Absenderadressen für den E-Mail Import zu editieren oder löschen

**Description:**  In Vue 3 `v-model` on custom components no longer uses the native `value/input` API, it binds to a `modelValue` prop and emits `update:modelValue`. This change explicitly declares that mapping (using `defineOptions` in `<script setup>`) so that v-model works correctly on our custom inputs under compat mode.