### PR TITLE
fix(DPLAN-16037): restore Vue 3 v-model for DpInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+- ([#1319](https://github.com/demos-europe/demosplan-ui/pull/1319)) DpEditableList: ensure Vue 3 v-model works correctly under compat mode ([@sakutademos](https://github.com/sakutademos)
+
+
 ## v0.4.22 - 2025-07-15
 
 ### Added

--- a/src/components/DpInput/DpInput.vue
+++ b/src/components/DpInput/DpInput.vue
@@ -299,18 +299,17 @@ const containerClasses = computed(() => {
 
 const labelHint = computed(() => {
   const hint: string[] = props.label.hint ? [props.label.hint] : []
-  const length = props.modelValue.length
 
   if (props.maxlength && !props.minlength) {
-    hint.push(maxlengthHint(length, props.maxlength))
+    hint.push(maxlengthHint(props.modelValue.length, props.maxlength))
   } else if (props.minlength && !props.maxlength) {
-    hint.push(minlengthHint(length, props.minlength))
+    hint.push(minlengthHint(props.modelValue.length, props.minlength))
   } else if (props.maxlength && props.minlength) {
     if (props.maxlength === props.minlength) {
-      hint.push(exactlengthHint(length, props.maxlength))
+      hint.push(exactlengthHint(props.modelValue.length, props.maxlength))
     } else {
-      hint.push(maxlengthHint(length, props.maxlength))
-      hint.push(minlengthHint(length, props.minlength))
+      hint.push(maxlengthHint(props.modelValue.length, props.maxlength))
+      hint.push(minlengthHint(props.modelValue.length, props.minlength))
     }
   }
 

--- a/src/components/DpInput/DpInput.vue
+++ b/src/components/DpInput/DpInput.vue
@@ -30,10 +30,10 @@
       :required="required"
       :autocomplete="autocomplete !== '' ? autocomplete : null"
       :size="(size && size > 0) ? size : null"
-      :value="value"
+      :value="modelValue"
       @blur="emit('blur', $event.target.value)"
       @focus="emit('focus')"
-      @input="(event) => { emit('update:modelValue', event.target.value); emit('input', event.target.value) }"
+      @input="onInput"
       @keydown.enter="handleEnter">
   </div>
 </template>
@@ -150,6 +150,12 @@ const props = defineProps({
     default: null
   },
 
+  modelValue: {
+    type: String,
+    required: false,
+    default: ''
+  },
+
   name: {
     type: String,
     required: false,
@@ -222,12 +228,6 @@ const props = defineProps({
     default: 'text'
   },
 
-  value: {
-    type: String,
-    required: false,
-    default: ''
-  },
-
   /**
    * Full width by default; set to 'auto' to have no width defined.
    * @deprecated Apply width to the parent element of DpInput.
@@ -240,6 +240,18 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['blur', 'enter', 'focus', 'input', 'update:modelValue'])
+
+/**
+ *  In Vue-2-compat mode (@vue/compat), v-model still uses value/input.
+ *  To enable Vue 3’s modelValue/update:modelValue behavior here,
+ *  explicitly declare it via the model option:
+ */
+defineOptions({
+  model: {
+    prop: 'modelValue',
+    event: 'update:modelValue'
+  }
+})
 
 const classes = computed(() => {
   let _classes: string[] = [
@@ -287,24 +299,30 @@ const containerClasses = computed(() => {
 
 const labelHint = computed(() => {
   const hint: string[] = props.label.hint ? [props.label.hint] : []
+  const length = props.modelValue.length
 
   if (props.maxlength && !props.minlength) {
-    hint.push(maxlengthHint(props.value.length, props.maxlength))
+    hint.push(maxlengthHint(length, props.maxlength))
   } else if (props.minlength && !props.maxlength) {
-    hint.push(minlengthHint(props.value.length, props.minlength))
+    hint.push(minlengthHint(length, props.minlength))
   } else if (props.maxlength && props.minlength) {
     if (props.maxlength === props.minlength) {
-      hint.push(exactlengthHint(props.value.length, props.maxlength))
+      hint.push(exactlengthHint(length, props.maxlength))
     } else {
-      hint.push(maxlengthHint(props.value.length, props.maxlength))
-      hint.push(minlengthHint(props.value.length, props.minlength))
+      hint.push(maxlengthHint(length, props.maxlength))
+      hint.push(minlengthHint(length, props.minlength))
     }
   }
 
   return hint
 })
 
-const handleEnter = (event: Event) => {
+const onInput = (event: Event) => {
+  const value = (event.target as HTMLInputElement).value
+  emit('update:modelValue', value)
+  emit('input', value)
+}
+const handleEnter = (event: KeyboardEvent) => {
   if (props.preventDefaultOnEnter) {
     event.preventDefault()
   }


### PR DESCRIPTION
**Ticket:** [DPLAN-16037](https://demoseurope.youtrack.cloud/issue/DPLAN-16037) Nicht möglich um Berechtigte Absenderadressen für den E-Mail Import zu editieren oder löschen

**Description:**  In Vue 3 `v-model` on custom components no longer uses the native `value/input` API, it binds to a `modelValue` prop and emits `update:modelValue`. This change explicitly declares that mapping (using `defineOptions` in `<script setup>`) so that v-model works correctly on our custom inputs under compat mode.