### PR TITLE
fix: set proper permissions for /app directory in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,9 @@ FROM node:20
 WORKDIR /app
 
 # Enable corepack and prepare Yarn
-RUN corepack enable && corepack prepare yarn@4.2.2 --activate
-
-# Set proper permissions for the working directory
-RUN chown -R node:node /app
+RUN corepack enable && corepack prepare yarn@4.2.2 --activate && \
+  # Set proper permissions for the working directory
+  chown -R node:node /app
 
 # Use default user ID
 USER node:1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ WORKDIR /app
 # Enable corepack and prepare Yarn
 RUN corepack enable && corepack prepare yarn@4.2.2 --activate
 
+# Set proper permissions for the working directory
+RUN chown -R node:node /app
+
 # Use default user ID
 USER node:1000
 


### PR DESCRIPTION
## Summary
- Fixes CI permission error when node user tries to write to package.json during yarn install
- Ensures the working directory is owned by node:node before switching to the node user

## Test plan
- [ ] Verify CI build passes without permission errors
- [ ] Confirm Docker container builds successfully
- [ ] Test yarn install works properly in container