### PR TITLE
fix(refs dplan-16160): Remove default submit behaviour and adjust styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 ## UNRELEASED
 
 ### Changed
+- ([#1318](https://github.com/demos-europe/demosplan-ui/pull/1318)) DpEditableList: ensure Vue 3 v-model works correctly under compat mode ([@sakutademos](https://github.com/sakutademos)
 - ([#1321](https://github.com/demos-europe/demosplan-ui/pull/1321)) BREAKING: Remove DpFormRow ([@salisdemos](https://github.com/salisdemos))
 - ([#1323](https://github.com/demos-europe/demosplan-ui/pull/1323)) DpAccordion: Remove default submit behaviour and adjust styles ([@rafelddemos](https://github.com/rafelddemos))
-
-### Changed
-- ([#1318](https://github.com/demos-europe/demosplan-ui/pull/1318)) DpEditableList: ensure Vue 3 v-model works correctly under compat mode ([@sakutademos](https://github.com/sakutademos)
 
 
 ## v0.5.3 - 2025-07-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 - ([#1324](https://github.com/demos-europe/demosplan-ui/pull/1324)) DpResettableInput: fix slot detection logic for fragments and text nodes ([@meissnerdemos](https://github.com/meissnerdemos))
 
 ### Changed
+- ([#1323](https://github.com/demos-europe/demosplan-ui/pull/1323)) DpAccordion: Remove default submit behaviour and adjust styles ([@rafelddemos](https://github.com/rafelddemos))
 - ([#1321](https://github.com/demos-europe/demosplan-ui/pull/1321)) BREAKING: Remove DpFormRow ([@salisdemos](https://github.com/salisdemos))
 - ([#1318](https://github.com/demos-europe/demosplan-ui/pull/1318)) DpEditableList: ensure Vue 3 v-model works correctly under compat mode ([@sakutademos](https://github.com/sakutademos)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ### Changed
 - ([#1321](https://github.com/demos-europe/demosplan-ui/pull/1321)) BREAKING: Remove DpFormRow ([@salisdemos](https://github.com/salisdemos))
+- ([#1323](https://github.com/demos-europe/demosplan-ui/pull/1323)) DpAccordion: Remove default submit behaviour and adjust styles ([@rafelddemos](https://github.com/rafelddemos))
 
 ### Changed
 - ([#1318](https://github.com/demos-europe/demosplan-ui/pull/1318)) DpEditableList: ensure Vue 3 v-model works correctly under compat mode ([@sakutademos](https://github.com/sakutademos)

--- a/src/components/DpAccordion/DpAccordion.vue
+++ b/src/components/DpAccordion/DpAccordion.vue
@@ -24,7 +24,6 @@
 </template>
 
 <script>
-import DpIcon from '~/components/DpIcon'
 import DpTransitionExpand from '~/components/DpTransitionExpand'
 
 export default {

--- a/src/components/DpAccordion/DpAccordion.vue
+++ b/src/components/DpAccordion/DpAccordion.vue
@@ -7,10 +7,11 @@
       :data-cy="dataCy"
       type="button"
       @click="() => toggle()">
-      <dp-icon
+      <i
+        :class="{ 'fa-caret-right': !isVisible, 'fa-caret-down': isVisible }"
         aria-hidden="true"
-        :icon="isVisible ? 'caret-up' : 'caret-down'"
-        :size="iconSize" />
+        class="w-2 fa"
+      />
       <span :class="titleClasses">{{ title }}</span>
     </button>
     <dp-transition-expand>

--- a/src/components/DpAccordion/DpAccordion.vue
+++ b/src/components/DpAccordion/DpAccordion.vue
@@ -7,11 +7,11 @@
       :data-cy="dataCy"
       type="button"
       @click="() => toggle()">
-      <span :class="titleClasses">{{ title }}</span>
       <dp-icon
         aria-hidden="true"
         :icon="isVisible ? 'caret-up' : 'caret-down'"
         :size="iconSize" />
+      <span :class="titleClasses">{{ title }}</span>
     </button>
     <dp-transition-expand>
       <div v-show="isVisible">

--- a/src/components/DpAccordion/DpAccordion.vue
+++ b/src/components/DpAccordion/DpAccordion.vue
@@ -31,7 +31,6 @@ export default {
   name: 'DpAccordion',
 
   components: {
-    DpIcon,
     DpTransitionExpand
   },
 
@@ -85,9 +84,6 @@ export default {
         this.fontWeight === 'bold' ? 'weight--bold' : 'weight--normal'
       ]
     },
-    iconSize () {
-      return this.compressed ? 'medium' : 'large'
-    }
   },
 
   watch: {

--- a/src/components/DpAccordion/DpAccordion.vue
+++ b/src/components/DpAccordion/DpAccordion.vue
@@ -4,7 +4,8 @@
       v-if="title !== ''"
       :aria-expanded="isVisible.toString()"
       :data-cy="dataCy"
-      class="flex items-center justify-between w-full text-default hover:text-interactive hover:cursor-pointer active:text-interactive-hover border-b border-neutral pb-2"
+      class="flex items-center justify-between w-full text-default hover:text-interactive hover:cursor-pointer active:text-interactive-hover"
+      :class="{ 'border-b border-neutral pb-2': showBorder }"
       type="button"
       @click="() => toggle()">
       <span :class="titleClasses">{{ title }}</span>
@@ -61,12 +62,18 @@ export default {
       default: false
     },
 
+    showBorder: {
+      type: Boolean,
+      required: false,
+      default: true
+    },
+
     // Text displayed in toggle trigger
     title: {
       type: String,
       required: false,
       default: ''
-    }
+    },
   },
 
   emits: ['item:toggle'],

--- a/src/components/DpAccordion/DpAccordion.vue
+++ b/src/components/DpAccordion/DpAccordion.vue
@@ -4,7 +4,7 @@
       v-if="title !== ''"
       :aria-expanded="isVisible.toString()"
       :data-cy="dataCy"
-      class="flex items-center gap-1 text-interactive hover:cursor-pointer hover:text-interactive-hover"
+      class="flex items-center gap-2 text-interactive hover:text-interactive-hover hover:cursor-pointer"
       type="button"
       @click="() => toggle()">
       <span :class="titleClasses">{{ title }}</span>

--- a/src/components/DpAccordion/DpAccordion.vue
+++ b/src/components/DpAccordion/DpAccordion.vue
@@ -4,7 +4,7 @@
       v-if="title !== ''"
       :aria-expanded="isVisible.toString()"
       :data-cy="dataCy"
-      class="flex items-center gap-2 text-interactive hover:text-interactive-hover hover:cursor-pointer"
+      class="flex items-center justify-between w-full text-default hover:text-interactive hover:cursor-pointer active:text-interactive-hover"
       type="button"
       @click="() => toggle()">
       <span :class="titleClasses">{{ title }}</span>

--- a/src/components/DpAccordion/DpAccordion.vue
+++ b/src/components/DpAccordion/DpAccordion.vue
@@ -4,7 +4,7 @@
       v-if="title !== ''"
       :aria-expanded="isVisible.toString()"
       :data-cy="dataCy"
-      class="flex items-center justify-between w-full text-default hover:text-interactive hover:cursor-pointer active:text-interactive-hover"
+      class="flex items-center justify-between w-full text-default hover:text-interactive hover:cursor-pointer active:text-interactive-hover border-b border-neutral pb-2"
       type="button"
       @click="() => toggle()">
       <span :class="titleClasses">{{ title }}</span>

--- a/src/components/DpAccordion/DpAccordion.vue
+++ b/src/components/DpAccordion/DpAccordion.vue
@@ -5,6 +5,7 @@
       :aria-expanded="isVisible.toString()"
       class="flex items-center justify-between w-full hover:text-interactive hover:cursor-pointer active:text-interactive-hover"
       :data-cy="dataCy"
+      type="button"
       @click="() => toggle()">
       <span :class="titleClasses">{{ title }}</span>
       <dp-icon

--- a/src/components/DpAccordion/DpAccordion.vue
+++ b/src/components/DpAccordion/DpAccordion.vue
@@ -3,7 +3,7 @@
     <button
       v-if="title !== ''"
       :aria-expanded="isVisible.toString()"
-      class="flex items-center justify-between w-full hover:text-interactive hover:cursor-pointer active:text-interactive-hover"
+      class="flex items-center gap-1 text-interactive hover:cursor-pointer hover:text-interactive-hover"
       :data-cy="dataCy"
       type="button"
       @click="() => toggle()">

--- a/src/components/DpAccordion/DpAccordion.vue
+++ b/src/components/DpAccordion/DpAccordion.vue
@@ -7,12 +7,11 @@
       class="flex items-center gap-1 text-interactive hover:cursor-pointer hover:text-interactive-hover"
       type="button"
       @click="() => toggle()">
-      <i
-        :class="{ 'fa-caret-right': !isVisible, 'fa-caret-down': isVisible }"
-        aria-hidden="true"
-        class="w-2 fa"
-      />
       <span :class="titleClasses">{{ title }}</span>
+      <dp-icon
+        aria-hidden="true"
+        :icon="isVisible ? 'caret-up' : 'caret-down'"
+        :size="iconSize" />
     </button>
     <dp-transition-expand>
       <div v-show="isVisible">
@@ -24,12 +23,14 @@
 </template>
 
 <script>
+import DpIcon from '~/components/DpIcon'
 import DpTransitionExpand from '~/components/DpTransitionExpand'
 
 export default {
   name: 'DpAccordion',
 
   components: {
+    DpIcon,
     DpTransitionExpand
   },
 
@@ -83,6 +84,10 @@ export default {
         this.fontWeight === 'bold' ? 'weight--bold' : 'weight--normal'
       ]
     },
+
+    iconSize () {
+      return this.compressed ? 'medium' : 'large'
+    }
   },
 
   watch: {

--- a/src/components/DpAccordion/DpAccordion.vue
+++ b/src/components/DpAccordion/DpAccordion.vue
@@ -3,8 +3,8 @@
     <button
       v-if="title !== ''"
       :aria-expanded="isVisible.toString()"
-      class="flex items-center gap-1 text-interactive hover:cursor-pointer hover:text-interactive-hover"
       :data-cy="dataCy"
+      class="flex items-center gap-1 text-interactive hover:cursor-pointer hover:text-interactive-hover"
       type="button"
       @click="() => toggle()">
       <i


### PR DESCRIPTION
[DPLAN-16160](https://demoseurope.youtrack.cloud/issue/DPLAN-16160/Mitzeichnende-Toggle-ist-verrutscht-und-wenn-man-darauf-klickt-wird-das-STN-Formular-submitted)

This PR adjusts the changes made in the following PR:
https://github.com/demos-europe/demosplan-ui/pull/1269/files

- it re-adds the type of 'button' to remove the default submit behaviour when DpAccordion is inside a form
- adjusts Tailwind classes

Related PR in demosplan-core: https://github.com/demos-europe/demosplan-core/pull/4963
(Adds padding left in the side menu --> with the new position of the caret icon (after the text), the text in the side menu was too far left)