### PR TITLE
B dplan 16159 fix search field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
-### Changed
-- ([#1321](https://github.com/demos-europe/demosplan-ui/pull/1321)) BREAKING: Remove DpFormRow ([@salisdemos](https://github.com/salisdemos))
+### Added
+- ([#1324](https://github.com/demos-europe/demosplan-ui/pull/1324)) DpFlyout: add position prop to control flyout positioning ([@meissnerdemos](https://github.com/meissnerdemos))
+
+### Fixed
+- ([#1324](https://github.com/demos-europe/demosplan-ui/pull/1324)) DpResettableInput: fix slot detection logic for fragments and text nodes ([@meissnerdemos](https://github.com/meissnerdemos))
 
 ### Changed
+- ([#1321](https://github.com/demos-europe/demosplan-ui/pull/1321)) BREAKING: Remove DpFormRow ([@salisdemos](https://github.com/salisdemos))
 - ([#1318](https://github.com/demos-europe/demosplan-ui/pull/1318)) DpEditableList: ensure Vue 3 v-model works correctly under compat mode ([@sakutademos](https://github.com/sakutademos)
 
 

--- a/src/components/DpFlyout/DpFlyout.vue
+++ b/src/components/DpFlyout/DpFlyout.vue
@@ -2,11 +2,11 @@
   <span
     ref="target"
     v-on-click-outside="close"
-    class="dp-flyout relative"
-    :class="{
+    class="dp-flyout"
+    :class="[{
       'is-expanded': isExpanded,
       'bg-surface-medium rounded-md': variant === 'dark'
-    }"
+    }, position]"
     data-cy="flyoutTrigger">
     <button
       :disabled="disabled"
@@ -80,6 +80,13 @@ export default {
       required: false,
       type: Boolean,
       default: true
+    },
+
+    position: {
+      required: false,
+      type: String,
+      default: 'relative',
+      validator: (prop) => ['relative', 'absolute'].includes(prop)
     },
 
     variant: {

--- a/src/components/DpResettableInput/DpResettableInput.vue
+++ b/src/components/DpResettableInput/DpResettableInput.vue
@@ -124,8 +124,14 @@ export default {
       let classes = this.buttonVariant === 'small' ? 'o-form__control-search-reset--small' : 'o-form__control-search-reset'
       const slotContent = this.$slots.default && this.$slots.default().filter(node => {
         if (node.type === Comment) return false
-        if (node.type === Text && !node.children.trim()) return false
-        return node.type !== Fragment
+        if (node.type === Text && (!node.children || !node.children.trim())) return false
+        if (node.type === Fragment) {
+          return node.children && node.children.some(child =>
+            child.type !== Comment &&
+            (child.type !== Text || (child.children && child.children.trim()))
+          )
+        }
+        return true
       })
       classes = slotContent && slotContent.length > 0 ? `${classes} grouped` : classes
 


### PR DESCRIPTION
### Ticket
[DPLAN-16159](https://demoseurope.youtrack.cloud/issue/DPLAN-16159)

This PR adds a prop to control whether the DpFlyout trigger has position: relative or absolute and fixes the logic for detection whether DpResettableInput has meaningful slot content. Returning 'false' for fragments was incorrect since these can contain meaningful nodes in Vue.

Related PR in Core: [4968](https://github.com/demos-europe/demosplan-core/pull/4968)