### PR TITLE
fix(refs DPLAN-16172): use tailwind classes to apply correct styling

### DIFF
--- a/src/components/DpInput/DpInput.vue
+++ b/src/components/DpInput/DpInput.vue
@@ -275,7 +275,7 @@ const classes = computed(() => {
   }
 
   if (props.readonly || props.disabled) {
-    _classes.push('bg-surface-light border-none cursor-default')
+    _classes.push('bg-surface-light border border-input-disabled cursor-default')
   } else {
     _classes.push('text-input bg-surface border border-input cursor-text')
   }

--- a/src/components/DpSelect/DpSelect.vue
+++ b/src/components/DpSelect/DpSelect.vue
@@ -15,7 +15,7 @@
       :required="required"
       :name="name !== '' ? name : null"
       class="o-form__control-select"
-      :class="[disabled ? ' bg-color--grey-light-2' : '', classes]"
+      :class="[disabled ? ' border border-input-disabled bg-surface-light cursor-default' : 'border border-input', classes]"
       :disabled="disabled"
       @change="update">
       <option

--- a/src/components/DpTextArea/DpTextArea.vue
+++ b/src/components/DpTextArea/DpTextArea.vue
@@ -10,7 +10,7 @@
       v-model="currentValue"
       :name="name"
       class="o-form__control-textarea"
-      :class="{ 'grow': growToParent, 'h-7': reducedHeight }"
+      :class="[{ 'grow': growToParent, 'h-7': reducedHeight }, disabled ? 'border border-input-disabled' : 'border border-input']"
       :data-dp-validate-if="dataDpValidateIf ? true : null"
       :data-dp-validate-error-fieldname="dataDpValidateErrorFieldname || label || null"
       :data-cy="dataCy"


### PR DESCRIPTION
The stylings for form components as defined in our design system are reflected in our tailwind classes, so we should use them (before, styling was defined in demosplan custom classes). if we want to override these styles in a project, we need to override the css var(s) associated with the tailwind class (--dp-border-color-input-disabled in this case) in the project (color) settings.