### PR TITLE
fix(refs DPLAN-16159): add more prosemirror packages to resolutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+- ([#1328](https://github.com/demos-europe/demosplan-ui/pull/1328)) Add more prosemirror packages to resolutions to prevent dependency conflicts ([@meissnerdemos](https://github.com/meissnerdemos))
+
 ## v0.5.4 - 2025-07-29
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -145,7 +145,9 @@
   },
   "packageManager": "yarn@4.2.2",
   "resolutions": {
-    "prosemirror-model": "1.25.1",
-    "prosemirror-view": "1.40.0"
+    "prosemirror-model": "1.25.2",
+    "prosemirror-view": "1.40.1",
+    "prosemirror-state": "1.4.3",
+    "prosemirror-transform": "1.10.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15519,12 +15519,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prosemirror-model@npm:1.25.1":
-  version: 1.25.1
-  resolution: "prosemirror-model@npm:1.25.1"
+"prosemirror-model@npm:1.25.2":
+  version: 1.25.2
+  resolution: "prosemirror-model@npm:1.25.2"
   dependencies:
     orderedmap: "npm:^2.0.0"
-  checksum: 10c0/0974fec71f1d0fcfaa5c0350864dcdbfd95092a026460bbc96208c7b8d84f86444504cb746fd558009102a7debbde32c35d9d98da97382ad729ccaeaef729131
+  checksum: 10c0/d336a62e021a93711ad326c919e406709ff014caebb33806187b4d45f6860ffc19cf1124a8666164ab612a059125fe016574af546d992610a4daa416af45d97d
   languageName: node
   linkType: hard
 
@@ -15548,7 +15548,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prosemirror-state@npm:^1.0.0, prosemirror-state@npm:^1.2.2, prosemirror-state@npm:^1.4.3":
+"prosemirror-state@npm:1.4.3":
   version: 1.4.3
   resolution: "prosemirror-state@npm:1.4.3"
   dependencies:
@@ -15586,16 +15586,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prosemirror-transform@npm:^1.0.0, prosemirror-transform@npm:^1.1.0, prosemirror-transform@npm:^1.7.3":
-  version: 1.8.0
-  resolution: "prosemirror-transform@npm:1.8.0"
-  dependencies:
-    prosemirror-model: "npm:^1.0.0"
-  checksum: 10c0/20861fcb304cc68718e49be6c41f22505689e969507f1e9754bbdfedf98fc4059254a79e1659b930c13ca52c547d3449f1814263a7601aeea1c1c4dfedc80ac1
-  languageName: node
-  linkType: hard
-
-"prosemirror-transform@npm:^1.10.2, prosemirror-transform@npm:^1.10.3":
+"prosemirror-transform@npm:1.10.4":
   version: 1.10.4
   resolution: "prosemirror-transform@npm:1.10.4"
   dependencies:
@@ -15604,14 +15595,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prosemirror-view@npm:1.40.0":
-  version: 1.40.0
-  resolution: "prosemirror-view@npm:1.40.0"
+"prosemirror-view@npm:1.40.1":
+  version: 1.40.1
+  resolution: "prosemirror-view@npm:1.40.1"
   dependencies:
     prosemirror-model: "npm:^1.20.0"
     prosemirror-state: "npm:^1.0.0"
     prosemirror-transform: "npm:^1.1.0"
-  checksum: 10c0/9fde9b415b9beeeda823acc170871f420f8e8646be83d9af5b9b5c124419d9a4b5c1293d9536dd06910b6154a001401d79cdc57a902fb7a0ea19501966f8dfdd
+  checksum: 10c0/b63335343edc68a9dec8c9fddf145e493f0b541b0ce4847dd20c42f2068c5ac6c00762978389e3448bc575230914ab0882679f66077fd1d950e40c83b5e2831f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Ticket
[DPLAN-16207](https://demoseurope.youtrack.cloud/issue/DPLAN-16207)

This PR adds more prosemirror packages to the resolutions in the package.json. The error in the ticket was caused by different versions of prosemirror packages being imported, since some of them have other prosemirror packages as dependencies themselves, and it appears that not all versions are compatible with each other. The "resolutions" section of the package.json is referenced by yarn to resolve these version conflicts and ensure that only one version is imported. 

### How to test
1. Login as admin in a project that has segments and navigate to the 'Stellungnahmen aufteilen' section.
2. Start to create a segment, add a tag to it, and then abort the process with the abort button.
3. Test if there is any weird behavior now like being unable to make another segment (if there is, the bug is still there).
4. Also check the console for the error `Uncaught TypeError: style.eq is not a function`

### Related PR
#1294 Here a different error also involved conflicting prosemirror package versions.