### PR TITLE
feat(refs DPLAN-14969, #AB23560): Allow non-error DpNotification MSGs to persist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Changed
+- ([#1330](https://github.com/demos-europe/demosplan-ui/pull/1330)) DpNotification: Allow non-error notifications to persist ([@rafelddemos](https://github.com/rafelddemos))
+
 ## v0.5.4 - 2025-07-29
 
 ### Added

--- a/src/components/DpNotification/DpNotification.vue
+++ b/src/components/DpNotification/DpNotification.vue
@@ -76,7 +76,7 @@ export default {
   },
 
   mounted () {
-    if (this.message.type !== 'error') {
+    if (this.message.type !== 'error' && !this.message.persist) {
       setTimeout(() => {
         this.hide()
       }, this.hideTimer)


### PR DESCRIPTION
[DPLAN-14969](https://demoseurope.youtrack.cloud/issue/DPLAN-14969/ADO-Issue-23560-Rechtzeitige-Ankundigung-Ausloggen-damit-gespeichert-werden-kann)

So far, only the notifications of type 'error' were not set to disappear after 20 seconds.
This PR expands the condition for the DpNotification setTimeout, so that other types of notifications (warning, info) can also be allowed to persist, if needed.
'message.persist' is implemented as optional (and defaults to 'false'), so that already existing implementations are not affected.

Related core-PRs: 
FE: https://github.com/demos-europe/demosplan-core/pull/4970
BE: https://github.com/demos-europe/demosplan-core/pull/4959
