### PR TITLE
feat(refs DPLAN-15846, #AB30421): Add new Phosphor warning icon

### DIFF
--- a/src/components/DpIcon/util/iconConfig.ts
+++ b/src/components/DpIcon/util/iconConfig.ts
@@ -44,6 +44,7 @@ import {
   PhUsersThree,
   PhWarning,
   PhWarningDiamond,
+  PhWarningCircle,
   PhX,
   PhXCircle
 } from '@phosphor-icons/vue'
@@ -89,6 +90,7 @@ const mappedIcons: Record<PhosphorIconName | AliasedPhosphorIconName, Component>
   'user': PhUser,
   'users-three': PhUsersThree,
   'warning': PhWarning,
+  'warning-circle': PhWarningCircle,
   'x': PhX,
   'x-circle': PhXCircle,
   'arrows-clockwise': PhArrowsClockwise, // Alias: refresh

--- a/types/icons.ts
+++ b/types/icons.ts
@@ -73,6 +73,7 @@ export type PhosphorIconName =
   | 'user'
   | 'users-three'
   | 'warning'
+  | 'warning-circle'
   | 'x'
   | 'x-circle'
 


### PR DESCRIPTION
Related ticket: [DPLAN-15846](https://demoseurope.youtrack.cloud/issue/DPLAN-15846/ADO-30421-Veraltete-Layer-automatisch-erkennen-und-Nutzer-informieren)

This PR adds a mapping for a Phosphor warning-icon (exclamation mark in a circle).