### PR TITLE
Fix(dplan-16416): error - de is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+- ([#1344](https://github.com/demos-europe/demosplan-ui/pull/1344)) Add the de translations object to index.js, so it can be exported from demosplan-ui ([@sakutademos](https://github.com/sakutademos)
+
 ## v0.5.6 - 2025-08-11
 
 ### Fixed

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,5 @@
 import dataTableSearch from './DpDataTableExtended/DataTableSearch'
+import { de } from './shared/translations'
 import DpAccordion from './DpAccordion'
 import DpAnonymizeText from './DpAnonymizeText'
 import DpAutocomplete from './DpAutocomplete'
@@ -62,6 +63,7 @@ import DpVideoPlayer from './DpVideoPlayer'
 
 export {
   dataTableSearch,
+  de,
   DpAccordion,
   DpBadge,
   DpButton,

--- a/src/mixins/dpValidateMixin.js
+++ b/src/mixins/dpValidateMixin.js
@@ -68,10 +68,10 @@ export default {
           if (fieldsWithTopics.length) {
             const fieldsString = fieldsWithTopics.map(item => {
               return item.topicName ? `${item.fieldName} (${item.topicName})` : item.fieldName }).join(', ')
-            const errorMandatoryFields = de.error.mandatoryFields.intro + fieldsString + de.error.mandatoryFields.outro
+            const errorMandatoryFields = de?.error?.mandatoryFields?.intro + fieldsString + de?.error?.mandatoryFields?.outro
             dplan.notify.notify('error', errorMandatoryFields)
           } else {
-            dplan.notify.notify('error', de.error.mandatoryFields.default)
+            dplan.notify.notify('error', de?.error?.mandatoryFields?.default)
           }
         }
         const firstErrorElement = form.querySelector('.' + errorClass)

--- a/src/mixins/dpValidateMixin.js
+++ b/src/mixins/dpValidateMixin.js
@@ -68,10 +68,10 @@ export default {
           if (fieldsWithTopics.length) {
             const fieldsString = fieldsWithTopics.map(item => {
               return item.topicName ? `${item.fieldName} (${item.topicName})` : item.fieldName }).join(', ')
-            const errorMandatoryFields = de?.error?.mandatoryFields?.intro + fieldsString + de?.error?.mandatoryFields?.outro
+            const errorMandatoryFields = de.error.mandatoryFields?.intro + fieldsString + de.error.mandatoryFields?.outro
             dplan.notify.notify('error', errorMandatoryFields)
           } else {
-            dplan.notify.notify('error', de?.error?.mandatoryFields?.default)
+            dplan.notify.notify('error', de.error.mandatoryFields?.default)
           }
         }
         const firstErrorElement = form.querySelector('.' + errorClass)

--- a/src/mixins/dpValidateMixin.js
+++ b/src/mixins/dpValidateMixin.js
@@ -68,10 +68,10 @@ export default {
           if (fieldsWithTopics.length) {
             const fieldsString = fieldsWithTopics.map(item => {
               return item.topicName ? `${item.fieldName} (${item.topicName})` : item.fieldName }).join(', ')
-            const errorMandatoryFields = de.error.mandatoryFields?.intro + fieldsString + de.error.mandatoryFields?.outro
+            const errorMandatoryFields = de.error.mandatoryFields.intro + fieldsString + de.error.mandatoryFields.outro
             dplan.notify.notify('error', errorMandatoryFields)
           } else {
-            dplan.notify.notify('error', de.error.mandatoryFields?.default)
+            dplan.notify.notify('error', de.error.mandatoryFields.default)
           }
         }
         const firstErrorElement = form.querySelector('.' + errorClass)


### PR DESCRIPTION
**Ticket:** [DPLAN-16416](https://demoseurope.youtrack.cloud/issue/DPLAN-16416) Fehler wenn man eine PDF unter Antragsunterlagen hochladen probiert

**Description:**
This PR fixes an issue (`Uncaught TypeError: Cannot read properties of undefined (reading 'error') at Proxy.dpValidateAction`) in the addon. The problem occurs because the dpValidateMixin has been duplicated in the addon and requires access to the `de` object from the UI library.