### PR TITLE
test: Add tests for DpRadio

### DIFF
--- a/src/components/DpRadio/DpRadio.vue
+++ b/src/components/DpRadio/DpRadio.vue
@@ -11,7 +11,7 @@
       autocomplete="off"
       :checked="checked"
       :value="value"
-      :data-cy="dataCy !== '' ? dataCy : false"
+      :data-cy="dataCy !== '' ? dataCy : null"
       :data-dp-validate-error-fieldname="dataDpValidateErrorFieldname || label.text || null"
       @change="$emit('change', $event.target.checked)"><!--
  --><dp-label

--- a/tests/form/DpRadio.spec.js
+++ b/tests/form/DpRadio.spec.js
@@ -1,0 +1,132 @@
+import DpRadio from '~/components/DpRadio/DpRadio'
+import { runBooleanAttrTests } from './shared/Attributes'
+import { shallowMount } from '@vue/test-utils'
+
+describe('DpRadio', () => {
+  const wrapper = shallowMount(DpRadio, {
+    props: {
+      id: 'radioId'
+    }
+  })
+
+  const radio = wrapper.find('input[type="radio"]')
+  runBooleanAttrTests(wrapper, radio, 'required')
+  runBooleanAttrTests(wrapper, radio, 'disabled')
+  runBooleanAttrTests(wrapper, radio, 'readonly')
+
+  it('emits an event on change with the new `checked` state as argument', async () => {
+    const componentWrapper = shallowMount(DpRadio, {
+      props: {
+        id: 'radioId',
+        checked: false
+      }
+    })
+
+    const radioEl = await componentWrapper.find('input[type="radio"]')
+    await componentWrapper.setProps({ checked: true })
+    await radioEl.trigger('change')
+    await componentWrapper.setProps({ checked: false })
+    await radioEl.trigger('change')
+
+    expect(componentWrapper.emitted()).toHaveProperty('change')
+    expect(componentWrapper.emitted()['change'][0][0]).toBe(true)
+    // One Event adds two element to the events array, so we have to check the 3rd value
+    expect(componentWrapper.emitted()['change'][2][0]).toBe(false)
+  })
+
+  it('has the value of `value` prop as its value attribute', async () => {
+    const componentWrapper = shallowMount(DpRadio, {
+      props: {
+        id: 'radioId'
+      }
+    })
+
+    await componentWrapper.setProps({ value: 'radioValue' })
+
+    const radioEl = componentWrapper.find('input[type="radio"]')
+    expect(radioEl.attributes('value')).toEqual('radioValue')
+  })
+
+  it('has default value of "1" when no value prop is provided', () => {
+    const componentWrapper = shallowMount(DpRadio, {
+      props: {
+        id: 'radioId'
+      }
+    })
+
+    const radioEl = componentWrapper.find('input[type="radio"]')
+    expect(radioEl.attributes('value')).toEqual('1')
+  })
+
+  it('is checked when checked prop is true', async () => {
+    const componentWrapper = shallowMount(DpRadio, {
+      props: {
+        id: 'radioId',
+        checked: true
+      }
+    })
+
+    const radioEl = componentWrapper.find('input[type="radio"]')
+    expect(radioEl.element.checked).toBe(true)
+  })
+
+  it('is not checked when checked prop is false', async () => {
+    const componentWrapper = shallowMount(DpRadio, {
+      props: {
+        id: 'radioId',
+        checked: false
+      }
+    })
+
+    const radioEl = componentWrapper.find('input[type="radio"]')
+    expect(radioEl.element.checked).toBe(false)
+  })
+
+  it('has the name attribute when name prop is provided', async () => {
+    const componentWrapper = shallowMount(DpRadio, {
+      props: {
+        id: 'radioId',
+        name: 'radioGroup'
+      }
+    })
+
+    const radioEl = componentWrapper.find('input[type="radio"]')
+    expect(radioEl.attributes('name')).toEqual('radioGroup')
+  })
+
+  it('does not have name attribute when name prop is empty', async () => {
+    const componentWrapper = shallowMount(DpRadio, {
+      props: {
+        id: 'radioId',
+        name: ''
+      }
+    })
+
+    const radioEl = componentWrapper.find('input[type="radio"]')
+    expect(radioEl.attributes('name')).toBeUndefined()
+  })
+
+  it('has data-cy attribute when dataCy prop is provided', async () => {
+    const componentWrapper = shallowMount(DpRadio, {
+      props: {
+        id: 'radioId',
+        dataCy: 'radio-test'
+      }
+    })
+
+    const radioEl = componentWrapper.find('input[type="radio"]')
+    expect(radioEl.attributes('data-cy')).toEqual('radio-test')
+  })
+
+  it('does not have data-cy attribute when dataCy prop is empty', async () => {
+    const componentWrapper = shallowMount(DpRadio, {
+      props: {
+        id: 'radioId',
+        dataCy: ''
+      }
+    })
+
+    const radioEl = componentWrapper.find('input[type="radio"]')
+    expect(radioEl.attributes('data-cy')).toBeUndefined()
+  })
+})

--- a/tests/form/DpRadio.spec.js
+++ b/tests/form/DpRadio.spec.js
@@ -9,7 +9,7 @@ describe('DpRadio', () => {
     }
   })
 
-  const radio = wrapper.find('input[type="radio"]')
+  const radio = wrapper.get('input[type="radio"]')
   runBooleanAttrTests(wrapper, radio, 'required')
   runBooleanAttrTests(wrapper, radio, 'disabled')
   runBooleanAttrTests(wrapper, radio, 'readonly')
@@ -22,7 +22,7 @@ describe('DpRadio', () => {
       }
     })
 
-    const radioEl = await componentWrapper.find('input[type="radio"]')
+    const radioEl = await componentWrapper.get('input[type="radio"]')
     await componentWrapper.setProps({ checked: true })
     await radioEl.trigger('change')
     await componentWrapper.setProps({ checked: false })
@@ -34,6 +34,26 @@ describe('DpRadio', () => {
     expect(componentWrapper.emitted()['change'][2][0]).toBe(false)
   })
 
+  it('emits correct payload when user clicks the radio input', async () => {
+    const componentWrapper = shallowMount(DpRadio, {
+      props: {
+        id: 'radioId',
+        checked: false,
+        value: 'testValue'
+      }
+    })
+
+    const radioEl = componentWrapper.get('input[type="radio"]')
+
+    // Simulate user clicking the radio
+    radioEl.element.checked = true
+    await radioEl.trigger('change')
+
+    // Verify the event was emitted with the correct payload
+    expect(componentWrapper.emitted()).toHaveProperty('change')
+    expect(componentWrapper.emitted().change[0][0]).toBe(true)
+  })
+
   it('has the value of `value` prop as its value attribute', async () => {
     const componentWrapper = shallowMount(DpRadio, {
       props: {
@@ -43,7 +63,7 @@ describe('DpRadio', () => {
 
     await componentWrapper.setProps({ value: 'radioValue' })
 
-    const radioEl = componentWrapper.find('input[type="radio"]')
+    const radioEl = componentWrapper.get('input[type="radio"]')
     expect(radioEl.attributes('value')).toEqual('radioValue')
   })
 
@@ -54,7 +74,7 @@ describe('DpRadio', () => {
       }
     })
 
-    const radioEl = componentWrapper.find('input[type="radio"]')
+    const radioEl = componentWrapper.get('input[type="radio"]')
     expect(radioEl.attributes('value')).toEqual('1')
   })
 
@@ -66,7 +86,7 @@ describe('DpRadio', () => {
       }
     })
 
-    const radioEl = componentWrapper.find('input[type="radio"]')
+    const radioEl = componentWrapper.get('input[type="radio"]')
     expect(radioEl.element.checked).toBe(true)
   })
 
@@ -78,7 +98,7 @@ describe('DpRadio', () => {
       }
     })
 
-    const radioEl = componentWrapper.find('input[type="radio"]')
+    const radioEl = componentWrapper.get('input[type="radio"]')
     expect(radioEl.element.checked).toBe(false)
   })
 
@@ -90,7 +110,7 @@ describe('DpRadio', () => {
       }
     })
 
-    const radioEl = componentWrapper.find('input[type="radio"]')
+    const radioEl = componentWrapper.get('input[type="radio"]')
     expect(radioEl.attributes('name')).toEqual('radioGroup')
   })
 
@@ -102,7 +122,7 @@ describe('DpRadio', () => {
       }
     })
 
-    const radioEl = componentWrapper.find('input[type="radio"]')
+    const radioEl = componentWrapper.get('input[type="radio"]')
     expect(radioEl.attributes('name')).toBeUndefined()
   })
 
@@ -114,7 +134,7 @@ describe('DpRadio', () => {
       }
     })
 
-    const radioEl = componentWrapper.find('input[type="radio"]')
+    const radioEl = componentWrapper.get('input[type="radio"]')
     expect(radioEl.attributes('data-cy')).toEqual('radio-test')
   })
 
@@ -126,7 +146,7 @@ describe('DpRadio', () => {
       }
     })
 
-    const radioEl = componentWrapper.find('input[type="radio"]')
+    const radioEl = componentWrapper.get('input[type="radio"]')
     expect(radioEl.attributes('data-cy')).toBeUndefined()
   })
 })


### PR DESCRIPTION
This PR adds tests for the DpRadio component.

It also adjusts the data-cy value to 'null' instead of 'false', because the Attribute Coercion Behaviour changed with Vue3 --> attribute is no longer removed if the value is boolean false. Instead, it's set as attr="false". To remove the attribute, null or undefined has to be used. (https://v3-migration.vuejs.org/breaking-changes/attribute-coercion)