### PR TITLE
fix: make linting work again

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,5 @@
 // For more info, see https://github.com/storybookjs/eslint-plugin-storybook#configuration-flat-config-format
-import storybook from "eslint-plugin-storybook";
+const storybook = require("eslint-plugin-storybook")
 
 const globals = require('globals')
 const eslintJs = require('@eslint/js')
@@ -23,13 +23,23 @@ async function getConfig () {
         '**/.yarn/**',
         '**/tokens/dist/**',
         '**/dist/**',
-        '**/.storybook/**'
+        '**/.storybook/**',
+        '*.config.js',
+        'babel.config.js',
+        'jest.config.js',
+        'webpack.config.js',
+        'vite.config.mjs',
+        'jest/**',
+        'scripts/**'
       ]
     },
     {
       files: ["**/*.js", "**/*.ts", "**/*.vue"],
       languageOptions: {
-        globals: globals.browser,
+        globals: {
+          ...globals.browser,
+          ...globals.node
+        },
         parser: vueEslintParser,
         parserOptions: {
           parser: tsEslint.parser
@@ -99,6 +109,16 @@ async function getConfig () {
         }],
         'vue/multi-word-component-names': 'warn',
         'vuejs-accessibility/label-has-for': 'warn'
+      }
+    },
+    {
+      files: ["**/*.spec.js", "**/*.test.js", "tests/**/*.js"],
+      languageOptions: {
+        globals: {
+          ...globals.browser,
+          ...globals.node,
+          ...globals.jest
+        }
       }
     }
   ]

--- a/src/components/DpCheckboxGroup/DpCheckboxGroup.vue
+++ b/src/components/DpCheckboxGroup/DpCheckboxGroup.vue
@@ -75,7 +75,7 @@ export default {
   },
 
   watch: {
-      selectedOptions () {
+    selectedOptions () {
       this.selected = this.selectedOptions
     }
   },

--- a/src/components/DpEditableList/DpEditableList.vue
+++ b/src/components/DpEditableList/DpEditableList.vue
@@ -119,18 +119,18 @@ export default {
     },
   },
 
+  data () {
+    return {
+      isFormVisible: false,
+      currentlyUpdating: ''
+    }
+  },
+
   watch: {
     closeOnSuccess (newVal) {
       if (newVal) {
         this.resetForm()
       }
-    }
-  },
-
-  data () {
-    return {
-      isFormVisible: false,
-      currentlyUpdating: ''
     }
   },
 

--- a/src/components/DpEditor/libs/tiptapExtensions.js
+++ b/src/components/DpEditor/libs/tiptapExtensions.js
@@ -7,8 +7,10 @@ import History from '@tiptap/extension-history'
 import Italic from '@tiptap/extension-italic'
 import Link from '@tiptap/extension-link'
 import ListItem from '@tiptap/extension-list-item'
-// THIS IS A WORKAROUND.
-// In our setup per default the cjs-file is used. That file for some reason has a problem to resolve an internal dependency (Suggestion) properly.
+/*
+ * THIS IS A WORKAROUND.
+ * In our setup per default the cjs-file is used. That file for some reason has a problem to resolve an internal dependency (Suggestion) properly.
+ */
 import { Mention } from '../../../../node_modules/@tiptap/extension-mention/dist/index.js'
 import OrderedList from '@tiptap/extension-ordered-list'
 import Paragraph from '@tiptap/extension-paragraph'

--- a/src/components/DpIcon/util/iconConfig.ts
+++ b/src/components/DpIcon/util/iconConfig.ts
@@ -43,8 +43,8 @@ import {
   PhUser,
   PhUsersThree,
   PhWarning,
-  PhWarningDiamond,
   PhWarningCircle,
+  PhWarningDiamond,
   PhX,
   PhXCircle
 } from '@phosphor-icons/vue'

--- a/src/components/DpInput/DpInput.vue
+++ b/src/components/DpInput/DpInput.vue
@@ -239,6 +239,8 @@ const props = defineProps({
   }
 })
 
+const emit = defineEmits(['blur', 'enter', 'focus', 'input', 'update:modelValue'])
+
 /**
  *  In Vue-2-compat mode (@vue/compat), v-model still uses value/input.
  *  To enable Vue 3’s modelValue/update:modelValue behavior here,
@@ -250,8 +252,6 @@ defineOptions({
     event: 'update:modelValue'
   }
 })
-
-const emit = defineEmits(['blur', 'enter', 'focus', 'input', 'update:modelValue'])
 
 const classes = computed(() => {
   let _classes: string[] = [

--- a/src/components/DpTreeList/DpTreeList.vue
+++ b/src/components/DpTreeList/DpTreeList.vue
@@ -13,8 +13,7 @@
           v-model="allElementsSelected"
           name="checkAll"
           check-all
-          :style="checkboxIndentationStyle"
-        />
+          :style="checkboxIndentationStyle" />
         <div class="grow color--grey">
           <!--
             @slot Content displayed at the top of the tree list. Typically used for column headers or global actions.
@@ -27,8 +26,7 @@
           data-cy="treeListNodeToggle"
           :value="allElementsExpanded"
           toggle-all
-          @input="toggleAll"
-        />
+          @input="toggleAll" />
       </div>
     </div>
 
@@ -75,8 +73,7 @@
           -->
           <slot
             :name="slot"
-            v-bind="scope"
-          />
+            v-bind="scope" />
         </template>
       </dp-tree-list-node>
     </component>

--- a/src/components/DpTreeList/DpTreeListNode.vue
+++ b/src/components/DpTreeList/DpTreeListNode.vue
@@ -10,16 +10,14 @@
         :class="dragHandle">
         <dp-icon
           class="c-treelist__drag-handle-icon"
-          icon="drag-handle"
-        />
+          icon="drag-handle" />
       </div>
       <dp-tree-list-checkbox
         v-if="isSelectable"
         :checked="isNodeSelected"
         :name="checkboxIdentifier"
         :string-value="nodeId"
-        @check="handleSelectionToggle"
-      />
+        @check="handleSelectionToggle" />
       <div
         class="flex grow items-start"
         :style="indentationStyle">
@@ -28,8 +26,7 @@
           v-model="isExpanded"
           class="c-treelist__folder text--left u-pv-0_25"
           :class="{ 'pointer-events-none': 0 === children.length }"
-          :icon-class-prop="iconClassFolder"
-        />
+          :icon-class-prop="iconClassFolder" />
         <div class="grow u-pl-0 u-p-0_25">
           <slot
             v-if="isBranch"
@@ -37,15 +34,13 @@
             :node-element="node"
             :node-children="children"
             :node-id="nodeId"
-            :parent-id="parentId"
-          />
+            :parent-id="parentId" />
           <slot
             v-if="isLeaf"
             name="leaf"
             :node-element="node"
             :node-id="nodeId"
-            :parent-id="parentId"
-          />
+            :parent-id="parentId" />
         </div>
       </div>
       <dp-tree-list-toggle
@@ -54,12 +49,10 @@
         v-tooltip="!hasToggle ? translations.noElementsExisting : ''"
         data-cy="treeListChildToggle"
         class="self-start"
-        :disabled="!hasToggle"
-      />
+        :disabled="!hasToggle" />
       <div
         v-else
-        class="min-w-4"
-      />
+        class="min-w-4" />
     </div>
     <component
       :is="draggable ? 'dp-draggable' : 'div'"
@@ -102,8 +95,7 @@
           v-slot:[slot]="scope">
           <slot
             v-bind="scope"
-            :name="slot"
-          />
+            :name="slot" />
         </template>
       </dp-tree-list-node>
     </component>

--- a/src/components/DpTreeList/utils/SelectionManager.js
+++ b/src/components/DpTreeList/utils/SelectionManager.js
@@ -19,13 +19,13 @@ export class SelectionManager {
     }
 
     // High-performance data structures
-    this.nodePath = new Map() // nodeId -> path array
-    this.nodeParentId = new Map() // nodeId -> parentId
-    this.nodeChildren = new Map() // nodeId -> Set of childIds
+    this.nodePath = new Map() // NodeId -> path array
+    this.nodeParentId = new Map() // NodeId -> parentId
+    this.nodeChildren = new Map() // NodeId -> Set of childIds
     this.selectedNodes = new Set() // Set of selected nodeIds
     this.explicitlySelected = new Set() // Nodes explicitly selected by user
-    this.nodeType = new Map() // nodeId -> 'branch' | 'leaf'
-    this.nodeObject = new Map() // nodeId -> full node object reference
+    this.nodeType = new Map() // NodeId -> 'branch' | 'leaf'
+    this.nodeObject = new Map() // NodeId -> full node object reference
 
     // Selection counting for performance optimization
     this.totalSelectableCount = 0 // Total nodes that CAN be selected

--- a/tests/form/DpAutocomplete.spec.js
+++ b/tests/form/DpAutocomplete.spec.js
@@ -83,8 +83,10 @@ describe('DpAutocomplete', () => {
 
     expect(wrapper.vm.isOptionsListVisible).toBe(true)
 
-    // The component renders all options and filters inside v-for directive
-    // So checking for all role="option" elements instead of just 'Apple'
+    /*
+     * The component renders all options and filters inside v-for directive
+     * So checking for all role="option" elements instead of just 'Apple'
+     */
     expect(wrapper.findAll('[role="option"]').length).toBe(3) // All options are rendered
   })
 
@@ -96,8 +98,10 @@ describe('DpAutocomplete', () => {
     // Skip DOM-based testing and test the component's filtering logic directly
     wrapper.vm.currentQuery = 'a'
 
-    // Manually check if 'Apple' and 'Banana' would be filtered using similar logic
-    // as the component (case insensitive match)
+    /*
+     * Manually check if 'Apple' and 'Banana' would be filtered using similar logic
+     * as the component (case insensitive match)
+     */
     const aMatchingOptions = defaultProps.options.filter(opt =>
       opt.name.toLowerCase().includes('a')
     )


### PR DESCRIPTION
Running `yarn lint .` no longer worked, it was throwing an error.

The main fix was to change the storybook import in eslint.config.js.
In addition, some more directories and files are excluded from linting, while test files are added.

And finally, I ran `yarn lint . --fix`, which now leaves us at
```
✖ 249 problems (186 errors, 63 warnings)
```