### PR TITLE
chore: enable new eslint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -56,15 +56,12 @@ async function getConfig () {
           'ignoreConsecutiveComments': true,
           'ignoreInlineComments': true
         }],
+        'comma-dangle': ['error', 'always-multiline'],
         'generator-star-spacing': 'off',
         'multiline-comment-style': 'error',
         'sort-imports': ['error', { 'ignoreCase': true }],
         '@/object-curly-spacing': ['error', 'always'],
         '@/indent': ['error', 2],
-        'vue/html-closing-bracket-newline': ['error', {
-          'singleline': 'never',
-          'multiline': 'never'
-        }],
         'vue/object-curly-spacing': ['error', 'always'],
         'vue/order-in-components': ['error', {
           'order': [

--- a/src/components/DpAccordion/DpAccordion.vue
+++ b/src/components/DpAccordion/DpAccordion.vue
@@ -7,12 +7,14 @@
       class="flex items-center justify-between w-full text-default hover:text-interactive hover:cursor-pointer active:text-interactive-hover"
       :class="{ 'border-b border-neutral pb-2': showBorder }"
       type="button"
-      @click="() => toggle()">
+      @click="() => toggle()"
+    >
       <span :class="titleClasses">{{ title }}</span>
       <dp-icon
         aria-hidden="true"
         :icon="isVisible ? 'caret-up' : 'caret-down'"
-        :size="iconSize" />
+        :size="iconSize"
+      />
     </button>
     <dp-transition-expand>
       <div v-show="isVisible">
@@ -32,47 +34,47 @@ export default {
 
   components: {
     DpIcon,
-    DpTransitionExpand
+    DpTransitionExpand,
   },
 
   props: {
     dataCy: {
       type: String,
       required: false,
-      default: 'accordionToggle'
+      default: 'accordionToggle',
     },
 
     fontWeight: {
       type: String,
       required: false,
       default: 'bold',
-      validate: prop => ['normal', 'bold'].includes(prop)
+      validate: prop => ['normal', 'bold'].includes(prop),
     },
 
     // Reduce font-size of the title
     compressed: {
       type: Boolean,
-      default: false
+      default: false,
     },
 
     // Needed if you want to toggle the accordion from outside
     isOpen: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     showBorder: {
       type: Boolean,
       required: false,
-      default: true
+      default: true,
     },
 
     // Text displayed in toggle trigger
     title: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
   },
 
@@ -80,7 +82,7 @@ export default {
 
   data () {
     return {
-      isVisible: this.isOpen
+      isVisible: this.isOpen,
     }
   },
 
@@ -88,26 +90,26 @@ export default {
     titleClasses () {
       return [
         this.compressed ? 'text-base' : 'text-lg',
-        this.fontWeight === 'bold' ? 'weight--bold' : 'weight--normal'
+        this.fontWeight === 'bold' ? 'weight--bold' : 'weight--normal',
       ]
     },
 
     iconSize () {
       return this.compressed ? 'medium' : 'large'
-    }
+    },
   },
 
   watch: {
     isOpen () {
       this.isVisible = this.isOpen
-    }
+    },
   },
 
   methods: {
     toggle (state) {
       this.isVisible = (typeof state === 'undefined') ? !this.isVisible : state
       this.$emit('item:toggle', this.isVisible)
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpAnonymizeText/DpAnonymizeText.vue
+++ b/src/components/DpAnonymizeText/DpAnonymizeText.vue
@@ -3,18 +3,21 @@
     <bubble-menu
       v-if="editor"
       :editor="editor"
-      :options="menuOptions">
+      :options="menuOptions"
+    >
       <div class="editor-menububble__wrapper is-active bottom-0">
         <button
           v-if="editor.isActive('anonymize')"
           class="editor-menububble__button whitespace-nowrap"
-          @click="editor.chain().focus().toggleUnanonymize().run()">
+          @click="editor.chain().focus().toggleUnanonymize().run()"
+        >
           {{ translations.unanonymize }}
         </button>
         <button
           v-else
           class="editor-menububble__button whitespace-nowrap"
-          @click="editor.chain().focus().toggleAnonymize().run()">
+          @click="editor.chain().focus().toggleAnonymize().run()"
+        >
           {{ translations.anonymize }}
         </button>
       </div>
@@ -26,7 +29,8 @@
       autocapitalize="off"
       spellcheck="false"
       class="editor-content"
-      :editor="editor" />
+      :editor="editor"
+    />
   </div>
 </template>
 
@@ -35,7 +39,7 @@ import {
   Anonymize,
   Obscure,
   PreventEditing,
-  UnAnonymize
+  UnAnonymize,
 } from '../DpEditor/libs/customExtensions'
 import {
   Bold,
@@ -50,7 +54,7 @@ import {
   OrderedList,
   Paragraph,
   Text,
-  Underline
+  Underline,
 } from '../DpEditor/libs/tiptapExtensions'
 import {
   Editor, // Wrapper for prosemirror state
@@ -65,14 +69,14 @@ export default {
 
   components: {
     BubbleMenu,
-    EditorContent
+    EditorContent,
   },
 
   props: {
     value: {
       type: String,
-      required: true
-    }
+      required: true,
+    },
   },
 
   data () {
@@ -80,12 +84,12 @@ export default {
       editor: null,
       menuOptions: {
         middleware: [offset(6)],
-        placement: 'top'
+        placement: 'top',
       },
       translations: {
         anonymize: de.anonymization.mark,
-        unanonymize: de.anonymization.unmark
-      }
+        unanonymize: de.anonymization.unmark,
+      },
     }
   },
 
@@ -108,7 +112,7 @@ export default {
       // Update text
       this.editor.commands.setContent(currentValue)
       this.$emit('change', currentValue)
-    }
+    },
   },
 
   mounted () {
@@ -134,12 +138,12 @@ export default {
         PreventEditing,
         Text,
         UnAnonymize,
-        Underline
+        Underline,
       ],
       onUpdate: () => {
         this.setValue()
-      }
+      },
     })
-  }
+  },
 }
 </script>

--- a/src/components/DpAutocomplete/DpAutocomplete.vue
+++ b/src/components/DpAutocomplete/DpAutocomplete.vue
@@ -5,7 +5,8 @@
       v-if="searchButton"
       id="autocomplete-label"
       for="input-box"
-      class="mb-1 md:hidden">
+      class="mb-1 md:hidden"
+    >
       {{ placeholder }}
     </label>
     <!-- Search container -->
@@ -22,7 +23,8 @@
       role="combobox"
       :style="boxHeightStyle"
       tabindex="0"
-      @mousedown.stop.prevent="focusInput">
+      @mousedown.stop.prevent="focusInput"
+    >
       <!-- Placeholder, if search button is used only displayed on lap-up screens -->
       <label
         id="autocomplete-label"
@@ -32,14 +34,16 @@
           'flex': !searchButton,
           'hidden md:flex': searchButton,
           'md:absolute md:pointer-events-none sr-only': !isPlaceholderVisible
-        }">
+        }"
+      >
         {{ placeholder }}
       </label>
       <!-- Placeholder for small screens if search button is used -->
       <template v-if="searchButton">
         <span
           :class="{ 'hidden': !isPlaceholderVisible }"
-          class="md:hidden h-full w-[80%] px-1 py-[2px] text-gray-400 flex items-center m-0">
+          class="md:hidden h-full w-[80%] px-1 py-[2px] text-gray-400 flex items-center m-0"
+        >
           {{ de.search.searching }}
         </span>
       </template>
@@ -60,7 +64,8 @@
         :style="boxHeightStyle"
         @mousedown.stop.prevent="focusInput"
         @keydown.stop="runSpecialKeys"
-        @focusout="isInputFocused = false" />
+        @focusout="isInputFocused = false"
+      />
       <dp-button
         v-if="(searchButton && !isPlaceholderVisible) || isPlaceholderVisible"
         class="md:hidden search h-[34px] w-[34px] justify-center rounded-r-md rounded-l-none border-2 !border-l-1 z-[5] -ml-px -mr-px"
@@ -69,12 +74,14 @@
         icon="search"
         :text="de.search.searching"
         variant="outline"
-        @click="triggerSearch" />
+        @click="triggerSearch"
+      />
       <div
         v-show="isInputFocused"
         :style="boxHeightStyle"
         class="w-auto max-w-full py-[2px] text-gray-300 overflow-hidden whitespace-pre flex items-center"
-        aria-hidden="true">
+        aria-hidden="true"
+      >
         {{ completion }}
       </div>
     </div>
@@ -85,7 +92,8 @@
         v-if="isOptionsListVisible"
         id="options-list"
         role="listbox"
-        class="absolute w-full border-x border-b border-neutral p-2 bg-surface z-10 shadow-md mt-[1px]">
+        class="absolute w-full border-x border-b border-neutral p-2 bg-surface z-10 shadow-md mt-[1px]"
+      >
         <li
           v-for="(option, idx) in props.options"
           :key="option[label] + idx"
@@ -94,16 +102,19 @@
           role="option"
           :aria-selected="idx === listPosition"
           tabindex="0"
-          @mousedown.stop.prevent="selectCurrentOption(option as Record<string, unknown>)">
+          @mousedown.stop.prevent="selectCurrentOption(option as Record<string, unknown>)"
+        >
           <slot
             name="option"
-            :option="option">
+            :option="option"
+          >
             {{ option[label] }}
           </slot>
         </li>
         <li
           v-if="props.options.length === 0"
-          class="text-gray-500 px-2 py-1">
+          class="text-gray-500 px-2 py-1"
+        >
           {{ noResultsText }}
         </li>
       </ol>
@@ -130,7 +141,7 @@ const props = defineProps({
   height: {
     type: String,
     required: false,
-    default: '28px'
+    default: '28px',
   },
 
   /**
@@ -139,7 +150,7 @@ const props = defineProps({
   label: {
     type: String,
     required: false,
-    default: 'label'
+    default: 'label',
   },
 
   /**
@@ -148,7 +159,7 @@ const props = defineProps({
   minChars: {
     type: Number,
     required: false,
-    default: 3
+    default: 3,
   },
 
   /**
@@ -157,7 +168,7 @@ const props = defineProps({
   modelValue: {
     type: String,
     required: false,
-    default: ''
+    default: '',
   },
 
   /**
@@ -166,7 +177,7 @@ const props = defineProps({
   noResultsText: {
     type: String,
     required: false,
-    default: de.autocompleteNoResults
+    default: de.autocompleteNoResults,
   },
 
   /**
@@ -175,7 +186,7 @@ const props = defineProps({
   options: {
     type: Array,
     required: false,
-    default: () => ([])
+    default: () => ([]),
   },
 
   /**
@@ -184,7 +195,7 @@ const props = defineProps({
   placeholder: {
     type: String,
     required: false,
-    default: de.placeholderAutoSuggest
+    default: de.placeholderAutoSuggest,
   },
 
   /**
@@ -192,14 +203,14 @@ const props = defineProps({
    */
   routeGenerator: {
     type: Function,
-    required: true
+    required: true,
   },
 
   searchButton: {
     type: Boolean,
     required: false,
-    default: false
-  }
+    default: false,
+  },
 })
 
 const emit = defineEmits([
@@ -207,7 +218,7 @@ const emit = defineEmits([
   'search-changed',
   'selected',
   'search',
-  'searched'
+  'searched',
 ])
 
 const input = ref<HTMLElement | null>(null)
@@ -390,7 +401,7 @@ async function fetchOptions(searchString: string) {
       url: route,
       params: {},
       headers: {},
-      data: {}
+      data: {},
     })
 
     // Only emit results that match the current search -> prevents race conditions
@@ -410,7 +421,7 @@ const observer = new MutationObserver((mutations) => {
     mutation.type === 'characterData' ||
     // Nodes added or removed
     mutation.addedNodes.length > 0 ||
-    mutation.removedNodes.length > 0
+    mutation.removedNodes.length > 0,
   )
 
   if (hasContentChanged) {
@@ -423,7 +434,7 @@ onMounted(() => {
   observer.observe(input.value, {
     childList: true,
     characterData: true,
-    subtree: true
+    subtree: true,
   })
 })
 

--- a/src/components/DpBadge/DpBadge.vue
+++ b/src/components/DpBadge/DpBadge.vue
@@ -1,7 +1,8 @@
 <template>
   <span
     :class="`rounded-md ${colorClasses} ${sizeClasses} badge`"
-    v-text="text" />
+    v-text="text"
+  />
 </template>
 
 <script>
@@ -13,20 +14,20 @@ export default {
       type: String,
       required: false,
       default: 'default',
-      validator: (prop) => ['confirm', 'default', 'error', 'info', 'warning'].includes(prop)
+      validator: (prop) => ['confirm', 'default', 'error', 'info', 'warning'].includes(prop),
     },
 
     size: {
       type: String,
       required: false,
       default: 'medium',
-      validator: (prop) => ['smaller', 'small', 'medium', 'large'].includes(prop)
+      validator: (prop) => ['smaller', 'small', 'medium', 'large'].includes(prop),
     },
 
     text: {
       required: true,
-      type: String
-    }
+      type: String,
+    },
   },
 
   computed: {
@@ -36,7 +37,7 @@ export default {
         confirm: 'text-message-success bg-message-success',
         info: 'text-message-info bg-message-info',
         warning: 'text-message-warning bg-message-warning',
-        error: 'text-message-severe bg-message-severe'
+        error: 'text-message-severe bg-message-severe',
       }
 
       return cssClassMap[this.color]
@@ -47,11 +48,11 @@ export default {
         smaller: 'text-xxs px-0.5',
         small: 'text-xs py-0.5 px-1.5',
         medium: 'text-sm py-1.5 px-2',
-        large: 'text-base py-2 px-3'
+        large: 'text-base py-2 px-3',
       }
 
       return cssClassMap[this.size]
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpBulkEditHeader/DpBulkEditHeader.vue
+++ b/src/components/DpBulkEditHeader/DpBulkEditHeader.vue
@@ -1,7 +1,8 @@
 <template>
   <div
     role="menu"
-    class="flex items-center gap-2 p-2 bg-selected">
+    class="flex items-center gap-2 p-2 bg-selected"
+  >
     <span>
       {{ selectedItemsText }}
     </span>
@@ -11,7 +12,8 @@
       color="secondary"
       data-cy="resetSelection"
       :text="deselect"
-      @click="$emit('reset-selection')" />
+      @click="$emit('reset-selection')"
+    />
   </div>
 </template>
 
@@ -23,22 +25,22 @@ export default {
   name: 'DpBulkEditHeader',
 
   components: {
-    DpButton
+    DpButton,
   },
 
   props: {
     selectedItemsText: {
       type: String,
-      required: true
-    }
+      required: true,
+    },
   },
 
   emits: ['reset-selection'],
 
   data () {
     return {
-      deselect: de.operations.deselect.all
+      deselect: de.operations.deselect.all,
     }
-  }
+  },
 }
 </script>

--- a/src/components/DpButton/DpButton.vue
+++ b/src/components/DpButton/DpButton.vue
@@ -12,20 +12,24 @@
     @blur="emit('blur', $event)"
     @click="emit('click', $event)"
     @focus="emit('focus', $event)"
-    @mousedown="emit('mousedown', $event)">
+    @mousedown="emit('mousedown', $event)"
+  >
     <dp-icon
       v-if="icon"
       aria-hidden="true"
       :icon="icon"
-      :size="iconSize" />
+      :size="iconSize"
+    />
     <span
       v-if="!hideText"
-      v-text="text" />
+      v-text="text"
+    />
     <dp-icon
       v-if="iconAfter"
       aria-hidden="true"
       :icon="iconAfter"
-      :size="iconSize" />
+      :size="iconSize"
+    />
   </component>
 </template>
 
@@ -48,7 +52,7 @@ const props = defineProps({
   busy: {
     type: [Boolean, null],
     required: false,
-    default: null
+    default: null,
   },
 
   /**
@@ -58,13 +62,13 @@ const props = defineProps({
     type: String as PropType<ButtonColor>,
     required: false,
     default: 'primary',
-    validator: (prop: ButtonColor) => ['primary', 'secondary', 'warning'].includes(prop)
+    validator: (prop: ButtonColor) => ['primary', 'secondary', 'warning'].includes(prop),
   },
 
   disabled: {
     type: [Boolean, null],
     required: false,
-    default: null
+    default: null,
   },
 
   /**
@@ -74,7 +78,7 @@ const props = defineProps({
   hideText: {
     type: Boolean,
     required: false,
-    default: false
+    default: false,
   },
 
   /**
@@ -84,7 +88,7 @@ const props = defineProps({
   href: {
     type: String,
     required: false,
-    default: '#'
+    default: '#',
   },
 
   /**
@@ -93,7 +97,7 @@ const props = defineProps({
   icon: {
     type: String as PropType<IconName>,
     required: false,
-    default: ''
+    default: '',
   },
 
   /**
@@ -103,7 +107,7 @@ const props = defineProps({
     type: String as PropType<IconSize>,
     required: false,
     default: 'small',
-    validator: (prop: IconSize) => Object.keys(ICON_SIZES).includes(prop)
+    validator: (prop: IconSize) => Object.keys(ICON_SIZES).includes(prop),
   },
 
   /**
@@ -112,7 +116,7 @@ const props = defineProps({
   iconAfter: {
     type: String as PropType<IconName>,
     required: false,
-    default: ''
+    default: '',
   },
 
   /**
@@ -121,7 +125,7 @@ const props = defineProps({
   rounded: {
     type: Boolean,
     required: false,
-    default: false
+    default: false,
   },
 
   /**
@@ -130,7 +134,7 @@ const props = defineProps({
   text: {
     type: String,
     required: false,
-    default: 'save'
+    default: 'save',
   },
 
   /**
@@ -142,7 +146,7 @@ const props = defineProps({
     type: String as PropType<ButtonType>,
     required: false,
     default: 'button',
-    validator: (prop: ButtonType): boolean  => ['button', 'reset', 'submit'].includes(prop)
+    validator: (prop: ButtonType): boolean  => ['button', 'reset', 'submit'].includes(prop),
   },
 
   /**
@@ -153,15 +157,15 @@ const props = defineProps({
     type: String as PropType<ButtonVariant>,
     required: false,
     default: 'solid',
-    validator: (prop: ButtonVariant) => ['solid', 'outline', 'subtle'].includes(prop)
-  }
+    validator: (prop: ButtonVariant) => ['solid', 'outline', 'subtle'].includes(prop),
+  },
 })
 
 const emit = defineEmits([
   'blur',
   'click',
   'focus',
-  'mousedown'
+  'mousedown',
 ])
 
 const iconOnly = computed(() => (props.icon || props.iconAfter) && props.hideText)
@@ -172,7 +176,7 @@ const classes = computed(() => [
   ...spacingClasses.value,
   props.busy && 'bg-busy animate-busy pointer-events-none',
   props.disabled && 'opacity-40 pointer-events-none',
-  props.rounded ? 'rounded-full' : 'rounded-button'
+  props.rounded ? 'rounded-full' : 'rounded-button',
 ])
 
 const colorClasses = computed(() => {
@@ -222,7 +226,7 @@ const spacingClasses = computed(() => {
   }
   return [
     'space-x-1',
-    padding
+    padding,
   ]
 })
 
@@ -285,7 +289,7 @@ const allColorClasses = {
       hover:border-interactive-subtle-hover\
       focus:border-interactive-subtle-hover\
       focus-visible:border-interactive-subtle-hover\
-      active:border-interactive-subtle-active `
+      active:border-interactive-subtle-active `,
   },
   secondary: {
     solidOutlineSubtle: ' outline-4 outline-offset-0 outline-transparent focus-visible:outline-[#595959]/50 ',
@@ -312,7 +316,7 @@ const allColorClasses = {
       hover:border-interactive-secondary-subtle-hover\
       focus:border-interactive-secondary-subtle-hover\
       focus-visible:border-interactive-secondary-subtle-hover\
-      active:border-interactive-secondary-subtle-active `
+      active:border-interactive-secondary-subtle-active `,
   },
   warning: {
     solidOutlineSubtle: ' outline-4 outline-offset-0 outline-transparent focus-visible:outline-[#B20000]/50 ',
@@ -339,7 +343,7 @@ const allColorClasses = {
       hover:border-interactive-warning-subtle-hover\
       focus:border-interactive-warning-subtle-hover\
       focus-visible:border-interactive-warning-subtle-hover\
-      active:border-interactive-warning-subtle-active `
-  }
+      active:border-interactive-warning-subtle-active `,
+  },
 }
 </script>

--- a/src/components/DpButtonIcon/DpButtonIcon.vue
+++ b/src/components/DpButtonIcon/DpButtonIcon.vue
@@ -5,10 +5,12 @@
       delay: { show: 1000, hide: 200 }
     }"
     class="btn--icon"
-    @click="$emit('click')">
+    @click="$emit('click')"
+  >
     <i
       :class="`fa ${icon}`"
-      aria-hidden="true" />
+      aria-hidden="true"
+    />
     <span class="sr-only">{{ text }}</span>
   </button>
 </template>
@@ -24,19 +26,19 @@ export default {
   name: 'DpButtonIcon',
 
   directives: {
-    tooltip: Tooltip
+    tooltip: Tooltip,
   },
 
   props: {
     icon: {
       type: String,
-      required: true
+      required: true,
     },
 
     text: {
       type: String,
-      required: true
-    }
-  }
+      required: true,
+    },
+  },
 }
 </script>

--- a/src/components/DpButtonRow/DpButtonRow.vue
+++ b/src/components/DpButtonRow/DpButtonRow.vue
@@ -1,7 +1,8 @@
 <template>
   <div
     :class="[align, $attrs.class]"
-    class="space-x-2">
+    class="space-x-2"
+  >
     <dp-button
       v-if="primary"
       :busy="busy ? true : null"
@@ -9,7 +10,8 @@
       :disabled="isDisabledPrimary"
       :text="primaryText"
       :variant="variant"
-      @click.prevent="$emit('primary-action')" />
+      @click.prevent="$emit('primary-action')"
+    />
     <dp-button
       v-if="secondary"
       color="secondary"
@@ -18,7 +20,8 @@
       :href="href"
       :text="secondaryText"
       :variant="variant"
-      @click.prevent="$emit('secondary-action')" />
+      @click.prevent="$emit('secondary-action')"
+    />
     <slot />
   </div>
 </template>
@@ -31,7 +34,7 @@ export default {
   name: 'DpButtonRow',
 
   components: {
-    DpButton
+    DpButton,
   },
 
   props: {
@@ -42,7 +45,7 @@ export default {
       type: String,
       required: false,
       default: 'right',
-      validator: (prop) => ['right', 'left'].includes(prop)
+      validator: (prop) => ['right', 'left'].includes(prop),
     },
 
     /**
@@ -51,13 +54,13 @@ export default {
     busy: {
       type: [Boolean, null],
       required: false,
-      default: null
+      default: null,
     },
 
     dataCy: {
       type: String,
       required: false,
-      default: 'buttonRow'
+      default: 'buttonRow',
     },
 
     /**
@@ -71,7 +74,7 @@ export default {
     disabled: {
       type: [Boolean, Object],
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -81,7 +84,7 @@ export default {
     href: {
       type: String,
       required: false,
-      default: '#'
+      default: '#',
     },
 
     /**
@@ -90,7 +93,7 @@ export default {
     primary: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -99,7 +102,7 @@ export default {
     primaryText: {
       type: String,
       required: false,
-      default: de.operations.save
+      default: de.operations.save,
     },
 
     /**
@@ -108,7 +111,7 @@ export default {
     secondary: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -117,7 +120,7 @@ export default {
     secondaryText: {
       type: String,
       required: false,
-      default: de.operations.abort
+      default: de.operations.abort,
     },
 
     /**
@@ -128,13 +131,13 @@ export default {
       required: false,
       type: String,
       default: 'solid',
-      validator: (prop) => ['solid', 'outline', 'subtle'].includes(prop)
-    }
+      validator: (prop) => ['solid', 'outline', 'subtle'].includes(prop),
+    },
   },
 
   emits: [
     'primary-action',
-    'secondary-action'
+    'secondary-action',
   ],
 
   computed: {
@@ -148,7 +151,7 @@ export default {
 
     isDisabledSecondary () {
       return this.disabled === true || (this.disabled.secondary || false)
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpCard/DpCard.vue
+++ b/src/components/DpCard/DpCard.vue
@@ -2,13 +2,15 @@
   <div class="rounded-lg shadow-sm px-4 py-3">
     <h4
       v-if="heading !== ''"
-      class="flex gap-1 items-center text-base mb-2">
+      class="flex gap-1 items-center text-base mb-2"
+    >
       <span>
         {{ heading }}
       </span>
       <dp-contextual-help
         v-if="headingTooltip !== ''"
-        :text="headingTooltip" />
+        :text="headingTooltip"
+      />
     </h4>
     <slot />
   </div>
@@ -21,7 +23,7 @@ export default {
   name: 'DpCard',
 
   components: {
-    DpContextualHelp
+    DpContextualHelp,
   },
 
   props: {
@@ -31,7 +33,7 @@ export default {
     heading: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -40,8 +42,8 @@ export default {
     headingTooltip: {
       type: String,
       required: false,
-      default: ''
-    }
-  }
+      default: '',
+    },
+  },
 }
 </script>

--- a/src/components/DpCheckbox/DpCheckbox.vue
+++ b/src/components/DpCheckbox/DpCheckbox.vue
@@ -15,7 +15,8 @@
       :data-dp-validate-error-fieldname="dataDpValidateErrorFieldname || label.text || null"
       true-value="1"
       false-value="0"
-      @change="$emit('change', $event.target.checked)">
+      @change="$emit('change', $event.target.checked)"
+    >
     <dp-label
       v-if="label.text !== ''"
       :class="prefixClass('o-form__label')"
@@ -25,7 +26,8 @@
         for: id,
         required: required,
         ...label,
-      }" />
+      }"
+    />
   </div>
 </template>
 
@@ -37,44 +39,44 @@ export default {
   name: 'DpCheckbox',
 
   components: {
-    DpLabel
+    DpLabel,
   },
 
   mixins: [prefixClassMixin],
 
   model: {
     prop: 'checked',
-    event: 'change'
+    event: 'change',
   },
 
   props: {
     checked: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     dataCy: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     dataDpValidateErrorFieldname: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     disabled: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     id: {
       type: String,
-      required: true
+      required: true,
     },
 
     label: {
@@ -82,32 +84,32 @@ export default {
       default: () => ({}),
       validator: (prop) => {
         return Object.keys(prop).every(key => ['bold', 'hint', 'text', 'tooltip'].includes(key))
-      }
+      },
     },
 
     name: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     readonly: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     required: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     valueToSend: {
       type: String,
       required: false,
-      default: '1'
-    }
-  }
+      default: '1',
+    },
+  },
 }
 </script>

--- a/src/components/DpCheckboxGroup/DpCheckboxGroup.vue
+++ b/src/components/DpCheckboxGroup/DpCheckboxGroup.vue
@@ -4,7 +4,8 @@
       v-if="label !== ''"
       v-cleanhtml="label"
       class="font-size-medium is-label"
-      :class="inline ? 'float-left' : 'u-mb-0_25'" />
+      :class="inline ? 'float-left' : 'u-mb-0_25'"
+    />
     <dp-checkbox
       v-for="(option, idx) in options"
       :id="option.id"
@@ -16,7 +17,8 @@
       }"
       :name="option.name || ''"
       :data-cy="dataCy !== '' ? `${dataCy}:${option.id}` : null"
-      @change="(val) => $emit('update', { ...selected, [option.id]: val })" />
+      @change="(val) => $emit('update', { ...selected, [option.id]: val })"
+    />
   </fieldset>
 </template>
 
@@ -28,56 +30,56 @@ export default {
   name: 'DpCheckboxGroup',
 
   components: {
-    DpCheckbox
+    DpCheckbox,
   },
 
   directives: {
-    cleanhtml: CleanHtml
+    cleanhtml: CleanHtml,
   },
 
   props: {
     dataCy: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     options: {
       type: Array,
-      required: true
+      required: true,
     },
 
     label: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     inline: {
       type: Boolean,
-      default: false
+      default: false,
     },
 
     selectedOptions: {
       type: Object,
-      default: () => ({})
-    }
+      default: () => ({}),
+    },
   },
 
   emits: [
-    'update'
+    'update',
   ],
 
   data () {
     return {
-      selected: {}
+      selected: {},
     }
   },
 
   watch: {
     selectedOptions () {
       this.selected = this.selectedOptions
-    }
+    },
   },
 
   methods: {
@@ -85,11 +87,11 @@ export default {
       this.options.forEach(option => {
         this.selected[option.id] = this.selectedOptions[option.id] ?? false
       })
-    }
+    },
   },
 
   mounted () {
     this.setSelected()
-  }
+  },
 }
 </script>

--- a/src/components/DpColumnSelector/DpColumnSelector.vue
+++ b/src/components/DpColumnSelector/DpColumnSelector.vue
@@ -2,12 +2,14 @@
   <dp-flyout
     :has-menu="false"
     :data-cy="dataCy"
-    @close="trackSelection">
+    @close="trackSelection"
+  >
     <template v-slot:trigger>
       <span v-text="triggerText" />
       <i
         class="fa fa-caret-down u-ml-0_25"
-        aria-hidden="true" />
+        aria-hidden="true"
+      />
     </template>
     <div class="space-stack-xs u-pv-0_25">
       <dp-checkbox
@@ -19,7 +21,8 @@
         :label="{
           text: label
         }"
-        @change="broadcastSelection(value, !selectedColumns.has(value))" />
+        @change="broadcastSelection(value, !selectedColumns.has(value))"
+      />
     </div>
   </dp-flyout>
 </template>
@@ -35,39 +38,39 @@ export default {
 
   components: {
     DpCheckbox,
-    DpFlyout
+    DpFlyout,
   },
 
   props: {
     dataCy: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     selectableColumns: {
       type: Array,
       required: false,
-      default: () => ([])
+      default: () => ([]),
     },
 
     initialSelection: {
       type: Array,
       required: false,
-      default: () => ([])
+      default: () => ([]),
     },
 
     localStorageKey: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     useLocalStorage: {
       type: Boolean,
       required: false,
-      default: false
-    }
+      default: false,
+    },
   },
 
   emits: ['selection-changed'],
@@ -75,7 +78,7 @@ export default {
   data () {
     return {
       selectedColumns: new Set(),
-      triggerText: de.table.colsSelect
+      triggerText: de.table.colsSelect,
     }
   },
 
@@ -119,11 +122,11 @@ export default {
       if (hasOwnProp(window, '_paq')) {
         window._paq.push(['trackEvent', 'Column Selection', `View: ${this.localStorageKey}`, `Selected: ${this.selectedColumns.join(', ')}`])
       }
-    }
+    },
   },
 
   mounted () {
     this.initializeColumnSelection()
-  }
+  },
 }
 </script>

--- a/src/components/DpConfirmDialog/DpConfirmDialog.vue
+++ b/src/components/DpConfirmDialog/DpConfirmDialog.vue
@@ -4,10 +4,12 @@
     content-classes="w-2/3 xl:w-1/3"
     :data-cy="`confirmDialog:${dataCy}`"
     aria-describedby="dialogDescription"
-    @modal:toggled="onModalToggled">
+    @modal:toggled="onModalToggled"
+  >
     <p
       id="dialogDescription"
-      class="font-normal break-words mb-3">
+      class="font-normal break-words mb-3"
+    >
       {{ message }}
     </p>
     <dp-button-row
@@ -15,7 +17,8 @@
       :primary-text="confirmButtonText"
       secondary
       @primary-action="handleConfirm(true)"
-      @secondary-action="handleConfirm(false)" />
+      @secondary-action="handleConfirm(false)"
+    />
   </dp-modal>
 </template>
 
@@ -29,27 +32,27 @@ export default {
 
   components: {
     DpButtonRow,
-    DpModal
+    DpModal,
   },
 
   props: {
     dataCy: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     message: {
       type: String,
       required: false,
-      default: de.confirmDialog.confirm
-    }
+      default: de.confirmDialog.confirm,
+    },
   },
 
   data () {
     return {
       confirmButtonText: de.operations.confirm,
-      resolvePromise: null as ((result: boolean) => void) | null
+      resolvePromise: null as ((result: boolean) => void) | null,
     }
   },
   methods: {
@@ -75,7 +78,7 @@ export default {
       return new Promise(resolve => {
         this.resolvePromise = resolve
       })
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpContextualHelp/DpContextualHelp.vue
+++ b/src/components/DpContextualHelp/DpContextualHelp.vue
@@ -4,7 +4,8 @@
     :aria-label="ariaLabel"
     :icon="icon"
     :size="size"
-    class="inline-block" />
+    class="inline-block"
+  />
 </template>
 
 <script setup lang="ts">
@@ -22,7 +23,7 @@ const props = defineProps({
   icon: {
     type: String as PropType<IconName>,
     required: false,
-    default: 'question'
+    default: 'question',
   },
 
   /**
@@ -32,7 +33,7 @@ const props = defineProps({
     type: String as PropType<IconSize>,
     required: false,
     default: 'medium',
-    validator: (prop: IconSize) => Object.keys(ICON_SIZES).includes(prop)
+    validator: (prop: IconSize) => Object.keys(ICON_SIZES).includes(prop),
   },
 
   /**
@@ -43,7 +44,7 @@ const props = defineProps({
   text: {
     type: String,
     required: false,
-    default: ''
+    default: '',
   },
   /**
    * For available options check https://floating-vue.starpad.dev/api/#directive-options
@@ -52,8 +53,8 @@ const props = defineProps({
   tooltipOptions: {
     type: Object,
     required: false,
-    default: () => ({})
-  }
+    default: () => ({}),
+  },
 })
 
 const vTooltip = Tooltip

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -3,16 +3,19 @@
     <table
       ref="tableEl"
       :data-cy="`${dataCy}:table`"
-      :class="tableClass">
+      :class="tableClass"
+    >
       <caption
         class="sr-only"
-        v-text="tableDescription" />
+        v-text="tableDescription"
+      />
       <colgroup v-if="headerFields.filter((field) => field.colClass).length > 0">
         <col v-if="isDraggable">
         <col v-if="isSelectable">
         <col
           v-for="field in headerFields"
-          :class="field.colClass">
+          :class="field.colClass"
+        >
         <col v-if="hasFlyout">
         <col v-if="isExpandable">
         <col v-if="isTruncatable">
@@ -34,13 +37,16 @@
           :translations="headerTranslations"
           @toggle-expand-all="toggleExpandAll"
           @toggle-select-all="toggleSelectAll"
-          @toggle-wrap-all="toggleWrapAll">
+          @toggle-wrap-all="toggleWrapAll"
+        >
           <template
             v-for="field in headerFields"
-            v-slot:[`header-${field.field}`]="field">
+            v-slot:[`header-${field.field}`]="field"
+          >
             <slot
               :name="`header-${field.field}`"
-              v-bind="field" />
+              v-bind="field"
+            />
           </template>
         </dp-table-header>
       </thead>
@@ -48,7 +54,8 @@
       <!-- not draggable -->
       <tbody
         v-if="!isDraggable && !isLoading"
-        :data-cy="`${dataCy}:tbody`">
+        :data-cy="`${dataCy}:tbody`"
+      >
         <template v-for="(item, idx) in items">
           <dp-table-row
             :ref="`tableRows[${idx}]`"
@@ -72,33 +79,40 @@
             :wrapped="wrappedElements[item[trackBy]] || false"
             @toggle-expand="toggleExpand"
             @toggle-select="toggleSelect"
-            @toggle-wrap="toggleWrap">
+            @toggle-wrap="toggleWrap"
+          >
             <template
               v-for="field in fields"
-              v-slot:[field]="item">
+              v-slot:[field]="item"
+            >
               <slot
                 :name="field"
-                v-bind="item" />
+                v-bind="item"
+              />
             </template>
             <template v-slot:flyout="item">
               <slot
                 name="flyout"
-                v-bind="item" />
+                v-bind="item"
+              />
             </template>
           </dp-table-row>
 
           <!-- DpTableRowExpanded -->
           <tr
             v-if="expandedElements[item[trackBy]] || false"
-            :class="{ 'is-expanded-content': expandedElements[item[trackBy]] }">
+            :class="{ 'is-expanded-content': expandedElements[item[trackBy]] }"
+          >
             <td
               :class="{ 'opacity-70': isLoading }"
               :colspan="colCount"
               @mouseenter="addHoveredClass(idx)"
-              @mouseleave="removeHoveredClass(idx)">
+              @mouseleave="removeHoveredClass(idx)"
+            >
               <slot
                 name="expandedContent"
-                v-bind="item" />
+                v-bind="item"
+              />
             </td>
           </tr>
         </template>
@@ -111,10 +125,12 @@
         handle="c-data-table__drag-handle"
         ghost-class="sortable-ghost"
         chosen-class="sortable-chosen"
-        @end="(event, item) => $emit('changed-order', event, item)">
+        @end="(event, item) => $emit('changed-order', event, item)"
+      >
         <template
           v-for="(item, idx) in items"
-          :key="item[trackBy]">
+          :key="item[trackBy]"
+        >
           <dp-table-row
             :checked="elementSelections[item[trackBy]] || false"
             :expanded="expandedElements[item[trackBy]] || false"
@@ -137,19 +153,23 @@
             :wrapped="wrappedElements[item[trackBy]] || false"
             @toggle-expand="toggleExpand"
             @toggle-select="toggleSelect"
-            @toggle-wrap="toggleWrap">
+            @toggle-wrap="toggleWrap"
+          >
             <template
               v-for="(field, idx) in fields"
               v-slot:[field]="item"
-              :key="idx">
+              :key="idx"
+            >
               <slot
                 :name="field"
-                v-bind="item" />
+                v-bind="item"
+              />
             </template>
             <template v-slot:flyout="item">
               <slot
                 name="flyout"
-                v-bind="item" />
+                v-bind="item"
+              />
             </template>
           </dp-table-row>
         </template>
@@ -162,18 +182,21 @@
           v-if="searchTermSet"
           :colspan="colCount"
           class="u-pt"
-          v-html="noResults" />
+          v-html="noResults"
+        />
 
         <!-- noEntriesItem -->
         <td
           v-else
           :colspan="colCount"
-          class="u-pt">
+          class="u-pt"
+        >
           <dp-loading
             v-if="isLoading"
             is-loading
             class="u-mt"
-            :colspan="colCount" />
+            :colspan="colCount"
+          />
           <template v-else>
             {{ mergedTranslations.tableNoElements }}
           </template>
@@ -200,11 +223,11 @@ export default {
     DpTableRow,
     DpTableHeader,
     DpLoading,
-    DpDraggable
+    DpDraggable,
   },
 
   directives: {
-    cleanhtml: CleanHtml
+    cleanhtml: CleanHtml,
   },
 
   mixins: [sessionStorageMixin],
@@ -213,21 +236,21 @@ export default {
     dataCy: {
       type: String,
       required: false,
-      default: 'dateTable'
+      default: 'dateTable',
     },
 
     // Adds flyout menu
     hasFlyout: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     // The first table row (consisting of column headers) is being fixed to the top of the outer table element.
     hasStickyHeader: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -240,19 +263,19 @@ export default {
      */
     headerFields: {
       type: Array,
-      required: true
+      required: true,
     },
 
     initSelectedItems: {
       type: Array,
       required: false,
-      default: () => []
+      default: () => [],
     },
 
     isDraggable: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -262,13 +285,13 @@ export default {
     isExpandable: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     isLoading: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -277,7 +300,7 @@ export default {
     isResizable: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -286,7 +309,7 @@ export default {
     isSelectable: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -295,7 +318,7 @@ export default {
     isSelectableName: {
       type: String,
       required: false,
-      default: null
+      default: null,
     },
 
     /**
@@ -309,12 +332,12 @@ export default {
     isTruncatable: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     items: {
       type: Array,
-      required: true
+      required: true,
     },
 
     /**
@@ -325,7 +348,7 @@ export default {
     multiPageAllSelected: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -335,7 +358,7 @@ export default {
     lockCheckboxBy: {
       type: String,
       required: false,
-      default: null
+      default: null,
     },
 
     /**
@@ -345,7 +368,7 @@ export default {
     multiPageSelectionItemsToggled: {
       type: Number,
       required: false,
-      default: 0
+      default: 0,
     },
 
     /**
@@ -355,51 +378,51 @@ export default {
     multiPageSelectionItemsTotal: {
       type: Number,
       required: false,
-      default: 0
+      default: 0,
     },
 
     searchString: {
       type: [String, null],
       required: false,
-      default: null
+      default: null,
     },
 
     // This allows item selection to be forced from outside. It will override any internal selection state.
     shouldBeSelectedItems: {
       type: Object,
       required: false,
-      default: () => ({})
+      default: () => ({}),
     },
 
     tableClass: {
       type: String,
       required: false,
-      default: 'c-data-table'
+      default: 'c-data-table',
     },
 
     tableDescription: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     trackBy: {
       type: String,
-      required: true
+      required: true,
     },
 
     translations: {
       type: Object,
       required: false,
-      default: () => ({})
-    }
+      default: () => ({}),
+    },
   },
 
   emits: [
     'changed-order',
     'items-selected',
     'items-toggled',
-    'selectAll'
+    'selectAll',
   ],
 
   data () {
@@ -415,7 +438,7 @@ export default {
         lockedForSelection: de.item.lockedForSelection,
         searchNoResults: (searchTerm) =>  de.search.noResults({ searchTerm: searchTerm }),
         tableLoadingData: de.loadingData,
-        tableNoElements: de.noEntriesAvailable
+        tableNoElements: de.noEntriesAvailable,
       },
       elementSelections: {},
       expandedElements: {},
@@ -428,9 +451,9 @@ export default {
         this.isSelectable,
         this.hasFlyout,
         this.isExpandable,
-        this.isTruncatable
+        this.isTruncatable,
       ],
-      wrappedElements: {}
+      wrappedElements: {},
     }
   },
 
@@ -490,7 +513,7 @@ export default {
 
     selectableItems () {
       return this.lockCheckboxBy ? this.items.filter(item => !item[this.lockCheckboxBy]) : this.items
-    }
+    },
   },
 
   watch: {
@@ -505,12 +528,12 @@ export default {
           })
         }
       },
-      deep: false // HeaderFields are always replaces as a whole and therefor deep watch is not necessary
+      deep: false, // HeaderFields are always replaces as a whole and therefor deep watch is not necessary
     },
 
     shouldBeSelectedItems () {
       this.forceElementSelections(this.shouldBeSelectedItems)
-    }
+    },
   },
 
   methods: {
@@ -612,7 +635,7 @@ export default {
       return elements.reduce((acc, el) => {
         return {
           ...acc,
-          ...{ [el[this.trackBy]]: status }
+          ...{ [el[this.trackBy]]: status },
         }
       }, this.elementSelections)
     },
@@ -625,7 +648,7 @@ export default {
       this.expandedElements = this.items.reduce((acc, item) => {
         return {
           ...acc,
-          ...{ [item[this.trackBy]]: status }
+          ...{ [item[this.trackBy]]: status },
         }
       }, {})
       this.allExpanded = status
@@ -659,12 +682,12 @@ export default {
       this.wrappedElements = this.items.reduce((acc, item) => {
         return {
           ...acc,
-          ...{ [item[this.trackBy]]: status }
+          ...{ [item[this.trackBy]]: status },
         }
       }, {})
 
       this.allWrapped = status
-    }
+    },
   },
 
   created () {
@@ -725,6 +748,6 @@ export default {
     this.forceElementSelections(this.shouldBeSelectedItems)
 
     this.headerCellCount = this.headerFields.length
-  }
+  },
 }
 </script>

--- a/src/components/DpDataTable/DpResizableColumn.vue
+++ b/src/components/DpDataTable/DpResizableColumn.vue
@@ -5,12 +5,14 @@
     class="c-data-table__resizable break-words"
     :class="{ 'u-pr-0' : isLast }"
     :data-col-field="headerField.field"
-    :data-col-idx="idx">
+    :data-col-idx="idx"
+  >
     <slot />
     <dp-resize-handle
       v-if="!isLast"
       :display-icon="isResizableColumn"
-      @mousedown="e => initResize(e, idx)" />
+      @mousedown="e => initResize(e, idx)"
+    />
   </th>
 </template>
 
@@ -23,7 +25,7 @@ export default {
   name: 'DpResizableColumn',
 
   components: {
-    DpResizeHandle
+    DpResizeHandle,
   },
 
   mixins: [sessionStorageMixin],
@@ -31,24 +33,24 @@ export default {
   props: {
     idx: {
       required: true,
-      type: Number
+      type: Number,
     },
 
     headerField: {
       type: Object,
-      required: true
+      required: true,
     },
 
     isLast: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     nextHeader: {
       type: Object,
       required: false,
-      default: null
+      default: null,
     },
   },
 
@@ -61,14 +63,14 @@ export default {
       dragStart: false,
       resize: '',
       resizeWidth: '',
-      nextWidth: ''
+      nextWidth: '',
     }
   },
 
   computed: {
     isResizableColumn () {
       return hasOwnProp(this.headerField, 'resizeable') ? this.headerField.resizeable : true
-    }
+    },
   },
 
   methods: {
@@ -110,7 +112,7 @@ export default {
       document.querySelector('body').removeEventListener('mousemove', this.namedFunc)
       document.querySelector('body').removeEventListener('mouseup', this.stopResize)
       document.querySelector('body').classList.remove('resizing')
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpDataTable/DpResizeHandle.vue
+++ b/src/components/DpDataTable/DpResizeHandle.vue
@@ -1,14 +1,17 @@
 <template>
   <div
     class="c-data-table__resize-handle"
-    @mousedown.stop.prevent="(e) => $emit('mousedown', e)">
+    @mousedown.stop.prevent="(e) => $emit('mousedown', e)"
+  >
     <template v-if="displayIcon">
       <i
         class="fa fa-angle-left resize-handle__icon"
-        aria-hidden="true" />
+        aria-hidden="true"
+      />
       <i
         class="fa fa-angle-right resize-handle__icon"
-        aria-hidden="true" />
+        aria-hidden="true"
+      />
     </template>
   </div>
 </template>
@@ -21,8 +24,8 @@ export default {
     displayIcon: {
       required: false,
       type: Boolean,
-      default: true
-    }
-  }
+      default: true,
+    },
+  },
 }
 </script>

--- a/src/components/DpDataTable/DpTableHeader.vue
+++ b/src/components/DpDataTable/DpTableHeader.vue
@@ -2,21 +2,25 @@
   <tr
     ref="tableHeader"
     :data-cy="dataCy !== '' ? dataCy : false"
-    :class="{ 'c-data-table__sticky-header': isSticky }">
+    :class="{ 'c-data-table__sticky-header': isSticky }"
+  >
     <th
       v-if="isDraggable"
       :data-col-field="isResizable ? 'dragHandle' : null"
       scope="col"
-      class="c-data-table__cell--narrow">
+      class="c-data-table__cell--narrow"
+    >
       <dp-icon
         class="c-data-table__drag-handle"
-        icon="drag-handle" />
+        icon="drag-handle"
+      />
     </th>
     <th
       v-if="isSelectable"
       :data-col-field="isResizable ? 'select' : null"
       scope="col"
-      class="c-data-table__cell--narrow">
+      class="c-data-table__cell--narrow"
+    >
       <input
         ref="selectAll"
         :aria-label="translations.headerSelectHint"
@@ -24,7 +28,8 @@
         type="checkbox"
         data-cy="selectAll"
         :checked="checked"
-        @click="toggleSelectAll()">
+        @click="toggleSelectAll()"
+      >
     </th>
     <template v-for="(hf, idx) in headerFields">
       <component
@@ -32,44 +37,53 @@
         :is-last="headerFields.length === idx ? true : null"
         :header-field="hf"
         :next-header="headerFields[idx + 1]"
-        :idx="idx">
+        :idx="idx"
+      >
         <slot
           v-if="$slots[`header-${hf.field}`] && $slots[`header-${hf.field}`](hf)[0].children?.length > 0"
           :name="`header-${hf.field}`"
-          v-bind="hf">
+          v-bind="hf"
+        >
           <div :class="{ 'c-data-table__resizable--truncated': isTruncatable }">
             <span
               v-if="hf.label"
-              v-text="hf.label" />
+              v-text="hf.label"
+            />
           </div>
         </slot>
         <span
           v-else-if="hf.label"
-          v-text="hf.label" />
+          v-text="hf.label"
+        />
       </component>
     </template>
     <th
       v-if="hasFlyout"
       :data-col-field="isResizable ? 'flyout' : null"
-      scope="col" />
+      scope="col"
+    />
     <th
       v-if="isExpandable"
       scope="col"
       class="c-data-table__cell--narrow"
-      @click="toggleExpandAll()">
+      @click="toggleExpandAll()"
+    >
       <dp-wrap-trigger
         data-cy="isExpandableWrapTrigger"
-        :title="translations.headerExpandHint" />
+        :title="translations.headerExpandHint"
+      />
     </th>
     <th
       v-if="isTruncatable"
       :data-col-field="isResizable ? 'wrap' : null"
       scope="col"
       class="c-data-table__cell--narrow"
-      @click="toggleWrapAll()">
+      @click="toggleWrapAll()"
+    >
       <dp-wrap-trigger
         data-cy="isTruncatableWrapTrigger"
-        :title="translations.headerExpandHint" />
+        :title="translations.headerExpandHint"
+      />
     </th>
   </tr>
 </template>
@@ -85,82 +99,82 @@ export default {
   components: {
     DpIcon,
     DpResizableColumn,
-    DpWrapTrigger
+    DpWrapTrigger,
   },
 
   props: {
     checked: {
       type: Boolean,
-      required: true
+      required: true,
     },
 
     dataCy: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     hasFlyout: {
       type: Boolean,
-      required: true
+      required: true,
     },
 
     headerFields: {
       type: Array,
-      required: true
+      required: true,
     },
 
     indeterminate: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     isDraggable: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     isExpandable: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     isResizable: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     isSelectable: {
       type: Boolean,
-      required: true
+      required: true,
     },
 
     isSticky: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     isTruncatable: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     translations: {
       type: Object,
-      required: true
-    }
+      required: true,
+    },
   },
 
   watch: {
     indeterminate () {
       this.setIndeterminate()
-    }
+    },
   },
 
   methods: {
@@ -180,11 +194,11 @@ export default {
 
     toggleWrapAll () {
       this.$emit('toggle-wrap-all')
-    }
+    },
   },
 
   beforeUpdate() {
     this.setIndeterminate()
-  }
+  },
 }
 </script>

--- a/src/components/DpDataTable/DpTableRow.vue
+++ b/src/components/DpDataTable/DpTableRow.vue
@@ -2,23 +2,28 @@
   <tr
     class="row"
     :data-cy="dataCy !== '' ? dataCy : false"
-    :class="[{ 'opacity-70': isLoading }, { 'is-expanded-row': expanded }]">
+    :class="[{ 'opacity-70': isLoading }, { 'is-expanded-row': expanded }]"
+  >
     <td
       v-if="isDraggable"
-      class="c-data-table__cell--narrow">
+      class="c-data-table__cell--narrow"
+    >
       <dp-icon
         icon="drag-handle"
-        class="c-data-table__drag-handle" />
+        class="c-data-table__drag-handle"
+      />
     </td>
 
     <td
       v-if="isSelectable"
-      class="c-data-table__cell--narrow">
+      class="c-data-table__cell--narrow"
+    >
       <dp-icon
         v-if="isLocked"
         v-tooltip="isLockedMessage"
         class="align-middle color--grey-light"
-        icon="lock" />
+        icon="lock"
+      />
       <input
         v-else
         type="checkbox"
@@ -27,14 +32,16 @@
         :name="isSelectableName || null"
         :value="isSelectableName ? item[trackBy] : null"
         :checked="checked"
-        @click="toggleSelect(item[trackBy])">
+        @click="toggleSelect(item[trackBy])"
+      >
     </td>
 
     <td
       v-for="(field, idx) in fields"
       :key="`${field}:${idx}`"
       :class="[{ 'c-data-table__resizable': isTruncatable }, { 'break-words': isResizable }]"
-      :data-col-idx="`${idx}`">
+      :data-col-idx="`${idx}`"
+    >
       <div
         :class="[
           isTruncatable ?? 'break-words',
@@ -44,23 +51,28 @@
               : 'c-data-table__resizable--truncated'
             : ''
         ]"
-        :style="isTruncatable ?? elementStyle(field)">
+        :style="isTruncatable ?? elementStyle(field)"
+      >
         <slot
           v-if="$slots[field](item)[0].children.length > 0"
           :name="field"
-          v-bind="item" />
+          v-bind="item"
+        />
         <span
           v-else
-          v-cleanhtml="highlighted(field)" />
+          v-cleanhtml="highlighted(field)"
+        />
       </div>
     </td>
 
     <td
       v-if="hasFlyout"
-      class="overflow-visible min-w-[50px]">
+      class="overflow-visible min-w-[50px]"
+    >
       <slot
         name="flyout"
-        v-bind="item" />
+        v-bind="item"
+      />
     </td>
 
     <td
@@ -68,10 +80,12 @@
       class="c-data-table__cell--narrow overflow-hidden min-w-[50px]"
       :class="{ 'is-open': expanded }"
       :title="expanded ? translations.ariaCollapse : translations.ariaExpand"
-      @click="toggleExpand(item[trackBy])">
+      @click="toggleExpand(item[trackBy])"
+    >
       <dp-wrap-trigger
         :data-cy="`isExpandableWrapTrigger:${$attrs.index}`"
-        :expanded="expanded" />
+        :expanded="expanded"
+      />
     </td>
 
     <td
@@ -79,10 +93,12 @@
       class="c-data-table__cell--narrow overflow-hidden min-w-[50px]"
       :class="{ 'is-open': wrapped }"
       :title="wrapped ? translations.ariaCollapse : translations.ariaExpand"
-      @click="toggleWrap(item[trackBy])">
+      @click="toggleWrap(item[trackBy])"
+    >
       <dp-wrap-trigger
         :data-cy="`isTruncatableWrapTrigger:${$attrs.index}`"
-        :expanded="wrapped" />
+        :expanded="wrapped"
+      />
     </td>
   </tr>
 </template>
@@ -99,23 +115,23 @@ export default {
 
   components: {
     DpIcon,
-    DpWrapTrigger
+    DpWrapTrigger,
   },
 
   directives: {
-    cleanhtml: CleanHtml
+    cleanhtml: CleanHtml,
   },
 
   props: {
     checked: {
       type: Boolean,
-      required: true
+      required: true,
     },
 
     dataCy: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -124,12 +140,12 @@ export default {
     expanded: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     hasFlyout: {
       type: Boolean,
-      required: true
+      required: true,
     },
 
     /**
@@ -142,35 +158,35 @@ export default {
      */
     headerFields: {
       type: Array,
-      required: true
+      required: true,
     },
 
     fields: {
       type: Array,
-      required: true
+      required: true,
     },
 
     item: {
       type: Object,
-      required: true
+      required: true,
     },
 
     isDraggable: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     isExpandable: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     isLoading: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -179,7 +195,7 @@ export default {
     isLocked: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -188,40 +204,40 @@ export default {
     isLockedMessage: {
       type: String,
       required: false,
-      default: null
+      default: null,
     },
 
     isResizable: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     isSelectable: {
       type: Boolean,
-      required: true
+      required: true,
     },
 
     isSelectableName: {
       type: String,
       required: false,
-      default: null
+      default: null,
     },
 
     isTruncatable: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     searchTerm: {
       type: RegExp,
-      required: true
+      required: true,
     },
 
     trackBy: {
       type: String,
-      required: true
+      required: true,
     },
 
     /**
@@ -231,16 +247,16 @@ export default {
     wrapped: {
       type: Boolean,
       required: false,
-      default: false
-    }
+      default: false,
+    },
   },
 
   data () {
     return {
       translations: {
         ariaCollapse: de.aria.collapse.element,
-        ariaExpand: de.aria.expand.element
-      }
+        ariaExpand: de.aria.expand.element,
+      },
     }
   },
 
@@ -276,7 +292,7 @@ export default {
 
         return style
       }
-    }
+    },
   },
 
   methods: {
@@ -290,7 +306,7 @@ export default {
 
     toggleExpand (id) {
       this.$emit('toggle-expand', id)
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpDataTable/DpWrapTrigger.vue
+++ b/src/components/DpDataTable/DpWrapTrigger.vue
@@ -1,12 +1,14 @@
 <template>
   <button
     class="c-data-table__wrap-trigger o-link--default btn--blank"
-    :data-cy="dataCy !== '' ? dataCy : false">
+    :data-cy="dataCy !== '' ? dataCy : false"
+  >
     <dp-icon
       aria-hidden="true"
       :aria-label="ariaLabel"
       :icon="icon"
-      size="small" />
+      size="small"
+    />
   </button>
 </template>
 
@@ -18,21 +20,21 @@ export default {
   name: 'DpWrapTrigger',
 
   components: {
-    DpIcon
+    DpIcon,
   },
 
   props: {
     dataCy: {
       type: String,
       required: false,
-      default: 'wrapTriggerIcon'
+      default: 'wrapTriggerIcon',
     },
 
     expanded: {
       type: Boolean,
       required: false,
-      default: false
-    }
+      default: false,
+    },
   },
 
   computed: {
@@ -42,7 +44,7 @@ export default {
 
     icon () {
       return this.expanded ? 'caret-up' : 'caret-down'
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpDataTableExtended/DpDataTableExtended.vue
+++ b/src/components/DpDataTableExtended/DpDataTableExtended.vue
@@ -6,7 +6,8 @@
           <!-- Search field -->
           <label
             class="inline"
-            for="search">
+            for="search"
+          >
             {{ defaultTranslations.search }}
           </label>
           <input
@@ -16,7 +17,8 @@
             name="search"
             class="o-form__control-input"
             data-cy="dataTableExtended:search"
-            @input="updateFields(null)">
+            @input="updateFields(null)"
+          >
 
           <!-- pager -->
           <dp-sliding-pagination
@@ -24,13 +26,15 @@
             class="inline-block u-ml-0_5 u-mt-0_125"
             :current="currentPage"
             :total="totalPages"
-            @page-change="handlePageChange" />
+            @page-change="handlePageChange"
+          />
           <dp-select-page-item-count
             class="inline-block u-mt-0_125 u-ml-0_5"
             :page-count-options="itemsPerPageOptions"
             :current-item-count="itemsPerPage"
             :label-text="defaultTranslations.showEntries"
-            @changed-count="setPageItemCount" />
+            @changed-count="setPageItemCount"
+          />
         </div>
       </div>
     </dp-sticky-element>
@@ -39,26 +43,32 @@
       v-bind="$props"
       :items="onPageItems"
       :should-be-selected-items="currentlySelectedItems"
-      @items-selected="emitSelectedItems">
+      @items-selected="emitSelectedItems"
+    >
       <template
         v-for="(el, i) in sortableFilteredFields"
-        v-slot:[`header-${el.field}`]="el">
+        v-slot:[`header-${el.field}`]="el"
+      >
         <slot
           :name="`header-${el.field}`"
-          v-bind="sortableFilteredFields[i]">
+          v-bind="sortableFilteredFields[i]"
+        >
           <div
             :key="el.field"
-            class="o-hellip--nowrap relative u-pr-0_75">
+            class="o-hellip--nowrap relative u-pr-0_75"
+          >
             <button
               :aria-label="defaultTranslations.colsSort + ': ' + el.label"
               :title="defaultTranslations.colsSort + ': ' + el.label"
               class="btn--blank u-top-0 u-right-0 absolute"
               type="button"
-              @click="setOrder(el.field)">
+              @click="setOrder(el.field)"
+            >
               <i
                 aria-hidden="true"
                 class="fa"
-                :class="sortIconClass(el.field)" />
+                :class="sortIconClass(el.field)"
+              />
             </button>
             {{ el.label }}
           </div>
@@ -66,11 +76,13 @@
       </template>
       <template
         v-for="el in [...filteredFields, { field: 'expandedContent' }, { field: 'flyout' }]"
-        v-slot:[el.field]="item">
+        v-slot:[el.field]="item"
+      >
         <!-- table cells (TDs) -->
         <slot
           :name="el.field"
-          v-bind="item" />
+          v-bind="item"
+        />
       </template>
     </dp-data-table>
 
@@ -98,7 +110,7 @@ export default {
     DpDataTable,
     DpSelectPageItemCount,
     DpSlidingPagination,
-    DpStickyElement
+    DpStickyElement,
   },
 
   mixins: [tableSelectAllItems],
@@ -113,13 +125,13 @@ export default {
           return hasOwnProp(data, 'key') && hasOwnProp(data, 'direction')
         }
         return data === null
-      }
+      },
     },
 
     hasFlyout: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -128,55 +140,55 @@ export default {
     headerFields: {
       type: Array,
       required: true,
-      default: () => []
+      default: () => [],
     },
 
     initItemsPerPage: {
       type: Number,
       required: false,
-      default: 50
+      default: 50,
     },
 
     isExpandable: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     isLoading: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     isResizable: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     isSelectable: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     isSortable: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     isTruncatable: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     itemsPerPageOptions: {
       type: Array,
       required: false,
-      default: () => [10, 50, 100, 200]
+      default: () => [10, 50, 100, 200],
     },
 
     /**
@@ -186,7 +198,7 @@ export default {
     lockCheckboxBy: {
       type: String,
       required: false,
-      default: null
+      default: null,
     },
 
     /**
@@ -196,20 +208,20 @@ export default {
     tableItems: {
       type: Array,
       required: false,
-      default: () => []
+      default: () => [],
     },
 
     trackBy: {
       type: String,
       required: false,
-      default: 'id'
+      default: 'id',
     },
 
     translations: {
       type: Object,
       required: false,
-      default: () => ({})
-    }
+      default: () => ({}),
+    },
   },
 
   data () {
@@ -218,7 +230,7 @@ export default {
       defaultTranslations: {
         colsSort: de.table.colsSort,
         search: de.search.text,
-        showEntries: de.pager.showEntries
+        showEntries: de.pager.showEntries,
       },
       filteredItems: [],
       filters: this.headerFields.reduce((obj, item) => {
@@ -228,7 +240,7 @@ export default {
       isHighlighted: '',
       itemsPerPage: this.initItemsPerPage,
       searchString: '',
-      sortOrder: (this.defaultSortOrder !== null) ? this.defaultSortOrder : (this.headerFields.length > 0) ? { key: this.headerFields[0].field, direction: -1 } : null
+      sortOrder: (this.defaultSortOrder !== null) ? this.defaultSortOrder : (this.headerFields.length > 0) ? { key: this.headerFields[0].field, direction: -1 } : null,
     }
   },
 
@@ -258,7 +270,7 @@ export default {
 
     totalPages () {
       return this.filteredItems.length > 0 ? Math.ceil(this.filteredItems.length / this.itemsPerPage) : 1
-    }
+    },
   },
 
   watch: {
@@ -266,8 +278,8 @@ export default {
       handler () {
         this.updateFields()
       },
-      deep: true
-    }
+      deep: true,
+    },
   },
 
   methods: {
@@ -338,11 +350,11 @@ export default {
         sortedList = dataTableSearch(this.searchString, sortedList, this.headerFields.map(el => el.field))
       }
       this.filteredItems = sortedList
-    }
+    },
   },
 
   mounted () {
     this.updateFields()
-  }
+  },
 }
 </script>

--- a/src/components/DpDataTableExtended/DpSelectPageItemCount.vue
+++ b/src/components/DpDataTableExtended/DpSelectPageItemCount.vue
@@ -4,18 +4,21 @@
       :id="selectId"
       class="o-form__control-select w-auto u-mr-0_25"
       data-cy="selectPageMenu"
-      @change="e => $emit('changed-count', parseInt(e.target.value))">
+      @change="e => $emit('changed-count', parseInt(e.target.value))"
+    >
       <option
         v-for="option in pageCountOptions"
         :data-cy="`selectPageItem:${option}`"
         :value="option"
-        :selected="option === currentItemCount">
+        :selected="option === currentItemCount"
+      >
         {{ option }}
       </option>
     </select>
     <label
       :for="selectId"
-      class="inline u-mb-0">
+      class="inline u-mb-0"
+    >
       {{ labelText }}
     </label>
   </div>
@@ -30,24 +33,24 @@ export default {
   props: {
     currentItemCount: {
       type: Number,
-      required: true
+      required: true,
     },
 
     labelText: {
       type: String,
-      required: true
+      required: true,
     },
 
     pageCountOptions: {
       type: Array,
-      required: true
-    }
+      required: true,
+    },
   },
 
   data () {
     return {
-      selectId: uuid()
+      selectId: uuid(),
     }
-  }
+  },
 }
 </script>

--- a/src/components/DpDateRangePicker/DpDateRangePicker.vue
+++ b/src/components/DpDateRangePicker/DpDateRangePicker.vue
@@ -12,7 +12,8 @@
       :value="startValue"
       :required="required || (endDate !== '' && endDate < currentDate)"
       :data-cy="`${dataCy}:startDate`"
-      @input="handleInputStartDate" />
+      @input="handleInputStartDate"
+    />
     <span>-</span>
     <dp-datepicker
       :id="endId"
@@ -26,7 +27,8 @@
       :value="endValue"
       :required="required"
       :data-cy="`${dataCy}:endDate`"
-      @input="handleInputEndDate" />
+      @input="handleInputEndDate"
+    />
   </div>
 </template>
 
@@ -38,123 +40,123 @@ export default {
   name: 'DpDateRangePicker',
 
   components: {
-    DpDatepicker
+    DpDatepicker,
   },
 
   props: {
     calendarsAfter: {
       type: Number,
       required: false,
-      default: 0
+      default: 0,
     },
 
     calendarsBefore: {
       type: Number,
       required: false,
-      default: 0
+      default: 0,
     },
 
     dataCy: {
       type: String,
       required: false,
-      default: 'dateRangePicker'
+      default: 'dateRangePicker',
     },
 
     dataDpValidateErrorFieldname: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     endDisabled: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     endId: {
       type: String,
-      required: true
+      required: true,
     },
 
     endName: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     endValue: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     enforcePlausibleDates: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     maxDate: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     minDate: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     placeholder: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     required: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     startDisabled: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     startId: {
       type: String,
-      required: true
+      required: true,
     },
 
     startName: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     startValue: {
       type: String,
       required: false,
-      default: ''
-    }
+      default: '',
+    },
   },
 
   data () {
     return {
       endDate: this.endValue,
       maxStartDate: this.enforcePlausibleDates ? this.endValue : '',
-      minEndDate: this.enforcePlausibleDates ? this.startValue : ''
+      minEndDate: this.enforcePlausibleDates ? this.startValue : '',
     }
   },
 
   computed: {
     currentDate () {
       return formatDate()
-    }
+    },
   },
 
   watch: {
@@ -164,7 +166,7 @@ export default {
 
     endValue (newVal) {
       this.maxStartDate = this.enforcePlausibleDates ? newVal : ''
-    }
+    },
   },
 
   methods: {
@@ -185,7 +187,7 @@ export default {
 
     updateMinEndDate (value) {
       this.minEndDate = this.enforcePlausibleDates && value ? value : ''
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpDatepicker/DpDatepicker.vue
+++ b/src/components/DpDatepicker/DpDatepicker.vue
@@ -2,7 +2,8 @@
   <div
     :id="id"
     :data-cy="dataCy"
-    @input.stop.prevent="emitUpdate" />
+    @input.stop.prevent="emitUpdate"
+  />
 </template>
 
 <script>
@@ -16,31 +17,31 @@ export default {
     calendarsAfter: {
       type: Number,
       required: false,
-      default: 0
+      default: 0,
     },
 
     calendarsBefore: {
       type: Number,
       required: false,
-      default: 0
+      default: 0,
     },
 
     dataCy: {
       type: String,
       required: false,
-      default: 'datepicker'
+      default: 'datepicker',
     },
 
     dataDpValidateErrorFieldname: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     disabled: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -48,7 +49,7 @@ export default {
      */
     id: {
       type: String,
-      required: true
+      required: true,
     },
 
     /**
@@ -57,7 +58,7 @@ export default {
     maxDate: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -66,25 +67,25 @@ export default {
     minDate: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     name: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     placeholder: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     required: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -93,8 +94,8 @@ export default {
     value: {
       type: String,
       required: false,
-      default: ''
-    }
+      default: '',
+    },
   },
 
   data () {
@@ -105,8 +106,8 @@ export default {
         locale: 'DE-de',
         dateFormat: 'dd.mm.yyyy',
         id: this.id,
-        inputClass: 'o-form__control-input w-full'
-      }
+        inputClass: 'o-form__control-input w-full',
+      },
     }
   },
 
@@ -144,7 +145,7 @@ export default {
 
     disabled: function () {
       this.datepicker = this.datepicker.updateDatepicker({ disabled: this.disabled })
-    }
+    },
   },
 
   methods: {
@@ -164,7 +165,7 @@ export default {
       this.$emit('input', valueToEmit)
       this.$root.$emit('dp-datepicker', { id: this.id, value: valueToEmit })
       this.addErrorFieldnameAttribute()
-    }
+    },
   },
 
   mounted () {
@@ -176,11 +177,11 @@ export default {
       ...this.name !== '' ? { inputName: this.name } : {},
       ...{ required: this.required },
       ...{ disabled: this.disabled },
-      ...this.localConfig
+      ...this.localConfig,
     }
     this.datepicker = Datepicker(config)
     this.value !== '' && this.datepicker.setDate(this.value)
     this.addErrorFieldnameAttribute()
-  }
+  },
 }
 </script>

--- a/src/components/DpDatetimePicker/DpDatetimePicker.vue
+++ b/src/components/DpDatetimePicker/DpDatetimePicker.vue
@@ -5,7 +5,8 @@
       :for="`datePicker:${id}`"
       :hint="hint"
       :required="required"
-      :text="label" />
+      :text="label"
+    />
     <div class="o-form__control-wrapper o-form__group">
       <dp-datepicker
         :id="`datePicker:${id}`"
@@ -17,7 +18,8 @@
         :max-date="maxDate"
         :min-date="minDate"
         :required="required"
-        @input="$emit('input', currentDatetime)" />
+        @input="$emit('input', currentDatetime)"
+      />
       <dp-time-picker
         :id="`timePicker:${id}`"
         v-model="time"
@@ -25,13 +27,15 @@
         :data-cy="`${dataCy}:time`"
         :disabled="disabled"
         :min-value="minTime"
-        @input="$emit('input', currentDatetime)" />
+        @input="$emit('input', currentDatetime)"
+      />
       <input
         v-if="hiddenInput && name"
         type="hidden"
         :disabled="disabled"
         :name="name"
-        :value="currentDatetime">
+        :value="currentDatetime"
+      >
     </div>
   </div>
 </template>
@@ -53,20 +57,20 @@ export default {
     DpLabel: defineAsyncComponent(async () => {
       return await import('../DpLabel/DpLabel')
     }),
-    DpTimePicker
+    DpTimePicker,
   },
 
   props: {
     dataCy: {
       type: String,
       required: false,
-      default: 'dateTimePicker'
+      default: 'dateTimePicker',
     },
 
     disabled: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -76,13 +80,13 @@ export default {
     hiddenInput: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     hint: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /*
@@ -90,7 +94,7 @@ export default {
      */
     id: {
       type: String,
-      required: true
+      required: true,
     },
 
     /*
@@ -101,7 +105,7 @@ export default {
     label: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /*
@@ -111,7 +115,7 @@ export default {
     maxDate: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /*
@@ -121,27 +125,27 @@ export default {
     minDate: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     // Used in conjunction with `hiddenInput` to render a hidden input field with this name.
     name: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     required: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     // Expects ISO datetime
     value: {
       type: String,
-      required: true
-    }
+      required: true,
+    },
   },
 
   emits: ['input'],
@@ -149,7 +153,7 @@ export default {
   data () {
     return {
       date: '',
-      time: '00:00'
+      time: '00:00',
     }
   },
 
@@ -169,13 +173,13 @@ export default {
      */
     minTime () {
       return this.isCurrentDateSelected ? new Date().toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' }) : ''
-    }
+    },
   },
 
   watch: {
     value: function (newVal) {
       this.setDatetime(newVal)
-    }
+    },
   },
 
   methods: {
@@ -185,11 +189,11 @@ export default {
         this.date = parsedDateTime.format('DD.MM.YYYY')
         this.time = parsedDateTime.format('HH:mm')
       }
-    }
+    },
   },
 
   mounted () {
     this.setDatetime(this.value)
-  }
+  },
 }
 </script>

--- a/src/components/DpDetails/DpDetails.vue
+++ b/src/components/DpDetails/DpDetails.vue
@@ -2,17 +2,20 @@
   <details
     class="o-details space-stack-xs"
     :data-cy="`${dataCy}:detailsWrapper`"
-    role="group">
+    role="group"
+  >
     <summary
       :aria-expanded="isOpen"
       class="o-details__trigger o-link--default cursor-pointer inline-block"
       :data-cy="`${dataCy}:detailsSummary`"
       role="button"
-      @click="isOpen = !isOpen">
+      @click="isOpen = !isOpen"
+    >
       <i
         class="fa w-2 text--center"
         :class="{ 'fa-caret-down': isOpen, 'fa-caret-right': !isOpen }"
-        aria-hidden="true" />
+        aria-hidden="true"
+      />
       <strong v-cleanhtml="summary" />
     </summary>
     <div :data-cy="`${dataCy}:detailsContent`">
@@ -28,14 +31,14 @@ export default {
   name: 'DpDetails',
 
   directives: {
-    cleanhtml: CleanHtml
+    cleanhtml: CleanHtml,
   },
 
   props: {
     dataCy: {
       type: String,
       required: false,
-      default: 'element'
+      default: 'element',
     },
 
     /**
@@ -44,14 +47,14 @@ export default {
     summary: {
       type: String,
       required: false,
-      default: ''
-    }
+      default: '',
+    },
   },
 
   data () {
     return {
-      isOpen: false
+      isOpen: false,
     }
-  }
+  },
 }
 </script>

--- a/src/components/DpDraggable/DpDraggable.vue
+++ b/src/components/DpDraggable/DpDraggable.vue
@@ -2,7 +2,8 @@
   <component
     :is="draggableTag"
     :id="groupId"
-    ref="wrapper">
+    ref="wrapper"
+  >
     <slot />
   </component>
 </template>
@@ -17,7 +18,7 @@ const props = defineProps({
    */
   contentData: {
     type: Array,
-    required: true
+    required: true,
   },
 
   /*
@@ -26,7 +27,7 @@ const props = defineProps({
   dragAcrossBranches: {
     type: Boolean,
     required: false,
-    default: true
+    default: true,
   },
 
   /*
@@ -35,7 +36,7 @@ const props = defineProps({
   isDraggable: {
     type: Boolean,
     required: false,
-    default: true
+    default: true,
   },
 
   /*
@@ -44,7 +45,7 @@ const props = defineProps({
   draggableTag: {
     type: String,
     required: false,
-    default: 'div'
+    default: 'div',
   },
 
   /*
@@ -53,7 +54,7 @@ const props = defineProps({
   groupId: {
     type: String,
     required: false,
-    default: 'noIdGiven'
+    default: 'noIdGiven',
   },
 
   /*
@@ -64,7 +65,7 @@ const props = defineProps({
   handleChange: {
     type: Function,
     required: false,
-    default: () => undefined
+    default: () => undefined,
   },
 
   /*
@@ -73,7 +74,7 @@ const props = defineProps({
   handleDrag: {
     type: Function,
     required: false,
-    default: () => undefined
+    default: () => undefined,
   },
 
   /*
@@ -82,7 +83,7 @@ const props = defineProps({
   nodeId: {
     type: String,
     required: false,
-    default: null
+    default: null,
   },
 
   /*
@@ -92,20 +93,20 @@ const props = defineProps({
   onMove: {
     type: Function,
     required: false,
-    default: () => true
+    default: () => true,
   },
 
   opts: {
     type: Object,
     required: false,
-    default: () => ({})
-  }
+    default: () => ({}),
+  },
 })
 const emit = defineEmits(
   [
     'add',
-    'end'
-  ]
+    'end',
+  ],
 )
 const wrapper = ref<HTMLElement | null>(null)
 const list = ref([])
@@ -134,8 +135,8 @@ const { option: changeSortableOption } = useSortable(
       props.onMove(e, isAllowedTarget, props.groupId)
     },
     onStart: (e: Event) => props.handleDrag('start', e),
-    ...props.opts
-  }
+    ...props.opts,
+  },
 )
 
 watch(() => props.isDraggable, () => {

--- a/src/components/DpEditableList/DpEditableList.vue
+++ b/src/components/DpEditableList/DpEditableList.vue
@@ -2,19 +2,23 @@
   <div>
     <ul
       v-if="Object.keys(entries).length > 0"
-      class="u-mb-0_75">
+      class="u-mb-0_75"
+    >
       <li
         v-for="(entry, index) in entries"
         :key="index"
-        :data-cy="`${dataCy}:entryItem`">
+        :data-cy="`${dataCy}:entryItem`"
+      >
         <!--both v-bind below are important and should not be removed (one is for the source data to be passed from parent component, second is for when the source data (entries) is an object)-->
         <slot
           name="list"
           v-bind="entry"
           :entry="entry"
-          :index="index" />
+          :index="index"
+        />
         <span
-          v-if="hasPermissionToEdit">
+          v-if="hasPermissionToEdit"
+        >
           <dp-button
             class="ml-1"
             :data-cy="`${dataCy}:updateEntry`"
@@ -22,7 +26,8 @@
             icon="edit"
             :text="translationKeys.update"
             variant="subtle"
-            @click.prevent="showUpdateForm(index)" />
+            @click.prevent="showUpdateForm(index)"
+          />
           <dp-button
             class="ml-1"
             :data-cy="`${dataCy}:deleteEntry`"
@@ -30,13 +35,15 @@
             icon="delete"
             :text="translationKeys.delete"
             variant="subtle"
-            @click.prevent="deleteEntry(index)" />
+            @click.prevent="deleteEntry(index)"
+          />
         </span>
       </li>
     </ul>
     <div
       v-else
-      class="color--grey u-mb-0_5">
+      class="color--grey u-mb-0_5"
+    >
       {{ translationKeys.noEntries }}
     </div>
 
@@ -49,13 +56,15 @@
         class="btn btn--primary"
         :data-cy="currentlyUpdating !== '' ? `${dataCy}:saveEntry` : `${dataCy}:addEntry`"
         :text="currentlyUpdating !== '' ? translationKeys.update : translationKeys.add"
-        @click.prevent="saveEntry" />
+        @click.prevent="saveEntry"
+      />
 
       <dp-button
         class="btn btn--secondary u-ml-0_5"
         :data-cy="`${dataCy}:abort`"
         :text="translationKeys.abort"
-        @click.prevent="resetForm" />
+        @click.prevent="resetForm"
+      />
     </div>
 
     <dp-button
@@ -63,7 +72,8 @@
       class="btn btn--primary"
       :data-cy="`${dataCy}:showInput`"
       :text="translationKeys.new"
-      @click.prevent="showNewForm" />
+      @click.prevent="showNewForm"
+    />
   </div>
 </template>
 
@@ -75,26 +85,26 @@ export default {
   name: 'DpEditableList',
 
   components: {
-    DpButton
+    DpButton,
   },
 
   props: {
     closeOnSuccess: {
       required: false,
       type: Boolean,
-      default: false
+      default: false,
     },
 
     dataCy: {
       type: String,
       required: false,
-      default: 'editableList'
+      default: 'editableList',
     },
 
     entries: {
       required: true,
       type: [Array, Object],
-      default: () => { return [] }
+      default: () => { return [] },
     },
 
     translationKeys: {
@@ -107,22 +117,22 @@ export default {
           abort: de.operations.abort,
           update: de.operations.update,
           noEntries: de.operations.none,
-          delete: de.operations.delete
+          delete: de.operations.delete,
         }
-      }
+      },
     },
 
     hasPermissionToEdit: {
       required: false,
       type: Boolean,
-      default: true
+      default: true,
     },
   },
 
   data () {
     return {
       isFormVisible: false,
-      currentlyUpdating: ''
+      currentlyUpdating: '',
     }
   },
 
@@ -131,7 +141,7 @@ export default {
       if (newVal) {
         this.resetForm()
       }
-    }
+    },
   },
 
   methods: {
@@ -166,7 +176,7 @@ export default {
       this.toggleFormVisibility(false)
       this.currentlyUpdating = ''
       this.$emit('delete', index)
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpEditor/DpEditor.vue
+++ b/src/components/DpEditor/DpEditor.vue
@@ -3,11 +3,13 @@
     <div
       v-if="maxlength !== 0"
       v-cleanhtml="counterText"
-      :class="prefixClass('lbl__hint')" />
+      :class="prefixClass('lbl__hint')"
+    />
     <dp-link-modal
       v-if="toolbar.linkButton"
       ref="linkModal"
-      @insert="insertUrl" />
+      @insert="insertUrl"
+    />
     <dp-upload-modal
       v-if="toolbar.imageButton && tusEndpoint"
       ref="uploadModal"
@@ -16,15 +18,18 @@
       :tus-endpoint="tusEndpoint"
       @insert-image="insertImage"
       @add-alt="addAltTextToImage"
-      @close="resetImageId" />
+      @close="resetImageId"
+    />
     <slot
       name="modal"
       :append-text="appendText"
-      :handle-insert-text="handleInsertText" />
+      :handle-insert-text="handleInsertText"
+    />
 
     <div
       v-if="editor"
-      :class="prefixClass('row tiptap')">
+      :class="prefixClass('row tiptap')"
+    >
       <div :class="prefixClass('col')">
         <div :class="[isFullscreen ? 'fullscreen': '', prefixClass('editor')]">
           <div :class="[readonly ? prefixClass('readonly'): '', prefixClass('menubar')]">
@@ -36,10 +41,12 @@
               data-cy="editor:cut"
               :disabled="readonly"
               type="button"
-              @click="cut">
+              @click="cut"
+            >
               <i
                 :class="prefixClass('fa fa-scissors')"
-                aria-hidden="true" />
+                aria-hidden="true"
+              />
             </button>
             &#10072;
             <!-- Undo -->
@@ -50,10 +57,12 @@
               data-cy="editor:undo"
               :disabled="readonly"
               type="button"
-              @click="editor.chain().focus().undo().run()">
+              @click="editor.chain().focus().undo().run()"
+            >
               <i
                 :class="prefixClass('fa fa-reply')"
-                aria-hidden="true" />
+                aria-hidden="true"
+              />
             </button>
             <!-- Redo -->
             <button
@@ -63,10 +72,12 @@
               data-cy="editor:redo"
               :disabled="readonly"
               type="button"
-              @click="editor.chain().focus().redo().run()">
+              @click="editor.chain().focus().redo().run()"
+            >
               <i
                 :class="prefixClass('fa fa-share')"
-                aria-hidden="true" />
+                aria-hidden="true"
+              />
             </button>
             <template v-if="toolbar.textDecoration">
               &#10072;
@@ -79,10 +90,12 @@
                 data-cy="editor:bold"
                 :disabled="readonly"
                 type="button"
-                @click="editor.chain().focus().toggleBold().run()">
+                @click="editor.chain().focus().toggleBold().run()"
+              >
                 <i
                   :class="prefixClass('fa fa-bold')"
-                  aria-hidden="true" />
+                  aria-hidden="true"
+                />
               </button>
 
               <!-- Italic -->
@@ -93,10 +106,12 @@
                 data-cy="editor:italic"
                 :disabled="readonly"
                 type="button"
-                @click="editor.chain().focus().toggleItalic().run()">
+                @click="editor.chain().focus().toggleItalic().run()"
+              >
                 <i
                   :class="prefixClass('fa fa-italic')"
-                  aria-hidden="true" />
+                  aria-hidden="true"
+                />
               </button>
               <!-- Underline -->
               <button
@@ -106,10 +121,12 @@
                 data-cy="editor:underline"
                 :disabled="readonly"
                 type="button"
-                @click="editor.chain().focus().toggleUnderline().run()">
+                @click="editor.chain().focus().toggleUnderline().run()"
+              >
                 <i
                   :class="prefixClass('fa fa-underline')"
-                  aria-hidden="true" />
+                  aria-hidden="true"
+                />
               </button>
             </template>
             <!-- Strike through -->
@@ -121,28 +138,34 @@
               data-cy="editor:strikethrough"
               :disabled="readonly"
               type="button"
-              @click="editor.chain().focus().toggleStrike().run()">
+              @click="editor.chain().focus().toggleStrike().run()"
+            >
               <i
                 :class="prefixClass('fa fa-strikethrough')"
-                aria-hidden="true" />
+                aria-hidden="true"
+              />
             </button>
             <div
               v-if="toolbar.insertAndDelete"
-              :class="prefixClass('inline-block relative')">
+              :class="prefixClass('inline-block relative')"
+            >
               <button
                 :class="[editor.isActive('insert') || editor.isActive('delete') ? prefixClass('is-active') : '', prefixClass('menubar__button')]"
                 :disabled="readonly"
                 type="button"
                 @click.stop="toggleSubMenu('diffMenu', !diffMenu.isOpen)"
-                @keydown.tab.shift.exact="toggleSubMenu('diffMenu', false)">
+                @keydown.tab.shift.exact="toggleSubMenu('diffMenu', false)"
+              >
                 <dp-icon
                   class="inline-block mr-0.5"
-                  icon="highlighter" />
+                  icon="highlighter"
+                />
                 <i :class="prefixClass('fa fa-caret-down')" />
               </button>
               <div
                 v-if="diffMenu.isOpen"
-                :class="prefixClass('button_submenu')">
+                :class="prefixClass('button_submenu')"
+              >
                 <button
                   v-for="(button, idx) in diffMenu.buttons"
                   :key="`diffMenu_${idx}`"
@@ -151,7 +174,8 @@
                   :disabled="readonly"
                   @keydown.tab.exact="() => { idx === diffMenu.buttons.length -1 ? toggleSubMenu('diffMenu', false) : null }"
                   @keydown.tab.shift.exact="() => { idx === 0 ? toggleSubMenu('diffMenu', false) : null }"
-                  @click.stop="executeSubMenuButtonAction(button, 'diffMenu', true)">
+                  @click.stop="executeSubMenuButtonAction(button, 'diffMenu', true)"
+                >
                   {{ button.label }}
                 </button>
               </div>
@@ -159,7 +183,8 @@
             </div>
             <div
               v-else-if="toolbar.mark /* display the Button without fold out, if ony 'mark' is enabled */"
-              :class="prefixClass('inline-block relative')">
+              :class="prefixClass('inline-block relative')"
+            >
               <button
                 v-for="(button, idx) in diffMenu.buttons"
                 :key="`diffMenu_${idx}`"
@@ -170,10 +195,12 @@
                 :aria-label="button.label"
                 @keydown.tab.exact="() => { idx === diffMenu.buttons.length -1 ? toggleSubMenu('diffMenu', false) : null }"
                 @keydown.tab.shift.exact="() => { idx === 0 ? toggleSubMenu('diffMenu', false) : null }"
-                @click.stop="executeSubMenuButtonAction(button, 'diffMenu', true)">
+                @click.stop="executeSubMenuButtonAction(button, 'diffMenu', true)"
+              >
                 <dp-icon
                   class="inline-block"
-                  icon="highlighter" />
+                  icon="highlighter"
+                />
               </button>
             </div>
             <!-- lists -->
@@ -185,7 +212,8 @@
                 type="button"
                 :aria-label="translations.unorderedList"
                 :disabled="readonly"
-                @click="editor.chain().focus().toggleBulletList().run()">
+                @click="editor.chain().focus().toggleBulletList().run()"
+              >
                 <i :class="prefixClass('fa fa-list-ul')" />
               </button>
               <!-- Ordered List -->
@@ -195,7 +223,8 @@
                 type="button"
                 :aria-label="translations.orderedList"
                 :disabled="readonly"
-                @click="editor.chain().focus().toggleOrderedList().run()">
+                @click="editor.chain().focus().toggleOrderedList().run()"
+              >
                 <i :class="prefixClass('fa fa-list-ol')" />
               </button>
               &#10072;
@@ -211,7 +240,8 @@
                 :class="[editor.isActive('heading', { level: heading }) ? prefixClass('is-active') : '', prefixClass('menubar__button')]"
                 :disabled="readonly"
                 type="button"
-                @click="editor.chain().focus().toggleHeading({ level: heading }).run()">
+                @click="editor.chain().focus().toggleHeading({ level: heading }).run()"
+              >
                 {{ `H${heading}` }}
               </button>
               &#10072;
@@ -223,10 +253,12 @@
               :class="[editor.isActive('obscure') ? prefixClass('is-active') : '', prefixClass('menubar__button')]"
               type="button"
               :disabled="readonly"
-              @click="editor.chain().focus().toggleObscure().run()">
+              @click="editor.chain().focus().toggleObscure().run()"
+            >
               <i
                 :class="prefixClass('fa fa-pencil-square')"
-                aria-hidden="true" />
+                aria-hidden="true"
+              />
             </button>
             <!--Add links-->
             <button
@@ -234,7 +266,8 @@
               v-tooltip="translations.link.editOrInsert"
               :class="prefixClass('menubar__button')"
               type="button"
-              @click.stop="showLinkPrompt(editor.commands.toggleLink, editor.getAttributes('customLink'))">
+              @click.stop="showLinkPrompt(editor.commands.toggleLink, editor.getAttributes('customLink'))"
+            >
               <i :class="prefixClass('fa fa-link')" />
             </button>
             <!-- Insert images-->
@@ -244,25 +277,29 @@
               :class="prefixClass('menubar__button')"
               type="button"
               :disabled="readonly"
-              @click.stop="openUploadModal(null)">
+              @click.stop="openUploadModal(null)"
+            >
               <i :class="prefixClass('fa fa-picture-o')" />
             </button>
             <!-- Insert and edit tables -->
             <div
               v-if="toolbar.table"
-              :class="prefixClass('inline-block relative')">
+              :class="prefixClass('inline-block relative')"
+            >
               <button
                 :class="[tableMenu.isOpen ? prefixClass('is-active') : '', prefixClass('menubar__button')]"
                 type="button"
                 :disabled="readonly"
                 @click.stop="toggleSubMenu('tableMenu', !tableMenu.isOpen)"
-                @keydown.tab.shift.exact="toggleSubMenu('tableMenu', false)">
+                @keydown.tab.shift.exact="toggleSubMenu('tableMenu', false)"
+              >
                 <i :class="prefixClass('fa fa-table mr-0.5')" />
                 <i :class="prefixClass('fa fa-caret-down')" />
               </button>
               <div
                 v-if="tableMenu.isOpen"
-                :class="prefixClass('button_submenu')">
+                :class="prefixClass('button_submenu')"
+              >
                 <button
                   v-for="(button, idx) in tableMenu.buttons"
                   :key="`tableMenu_${idx}`"
@@ -270,7 +307,8 @@
                   :disabled="readonly"
                   @keydown.tab.exact="() => { idx === tableMenu.buttons.length -1 ? toggleSubMenu('tableMenu', false) : null }"
                   @keydown.tab.shift.exact="() => { idx === 0 ? toggleSubMenu('tableMenu', false) : null }"
-                  @click.stop="executeSubMenuButtonAction(button, 'tableMenu')">
+                  @click.stop="executeSubMenuButtonAction(button, 'tableMenu')"
+                >
                   {{ button.label }}
                 </button>
               </div>
@@ -282,10 +320,12 @@
               :class="[isFullscreen ? prefixClass('is-active') : '', prefixClass('menubar__button float-right')]"
               type="button"
               :aria-label="translations.fullscreen"
-              @click="fullscreen">
+              @click="fullscreen"
+            >
               <i
                 :class="prefixClass('fa fa-arrows-alt')"
-                aria-hidden="true" />
+                aria-hidden="true"
+              />
             </button>
             <slot name="button" />
           </div>
@@ -293,7 +333,8 @@
             v-if="editor"
             :data-cy="`editor${editorId}`"
             :editor="editor"
-            :class="prefixClass('editor__content overflow-hidden')" />
+            :class="prefixClass('editor__content overflow-hidden')"
+          />
           <!-- this hidden input is needed if we use this component without the inline-editing-wrapper TiptapEditText.vue,
           so we can save the text entered in the textarea via a form element -->
           <input
@@ -305,13 +346,15 @@
             :name="hiddenInput"
             :class="[required ? prefixClass('is-required') : '', prefixClass('tiptap__input--hidden')]"
             :data-dp-validate-maxlength="maxlength"
-            :value="hiddenInputValue">
+            :value="hiddenInputValue"
+          >
           <i
             v-if="!isFullscreen"
             aria-hidden="true"
             :class="prefixClass('fa fa-angle-down resizeVertical')"
             draggable="true"
-            @mousedown="resizeVertically" />
+            @mousedown="resizeVertically"
+          />
         </div>
       </div>
     </div>
@@ -338,7 +381,7 @@ import {
   TableHeader,
   TableRow,
   Text,
-  Underline
+  Underline,
 } from './libs/tiptapExtensions'
 import { CleanHtml, Tooltip } from '~/directives'
 import {
@@ -353,7 +396,7 @@ import {
   CustomLink,
   CustomMark,
   InsertAtCursorPos,
-  Obscure
+  Obscure,
 } from './libs/customExtensions'
 import DpIcon from '../DpIcon/DpIcon'
 import DpLinkModal from './DpLinkModal'
@@ -373,12 +416,12 @@ export default {
     EditorContent,
     DpLinkModal,
     DpResizableImage,
-    DpUploadModal
+    DpUploadModal,
   },
 
   directives: {
     cleanhtml: CleanHtml,
-    tooltip: Tooltip
+    tooltip: Tooltip,
   },
 
   mixins: [prefixClassMixin],
@@ -390,19 +433,19 @@ export default {
     basicAuth: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     dataDpValidateErrorFieldname: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     dataDpValidateIf: {
       type: String,
       default: '',
-      required: false
+      required: false,
     },
 
     /**
@@ -411,7 +454,7 @@ export default {
     editorId: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -420,7 +463,7 @@ export default {
     tusEndpoint: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -430,13 +473,13 @@ export default {
     hiddenInput: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     required: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -459,12 +502,12 @@ export default {
     toolbarItems: {
       required: false,
       type: Object,
-      default: () => ({})
+      default: () => ({}),
     },
 
     maxlength: {
       type: [Number, null],
-      default: null
+      default: null,
     },
 
     /**
@@ -473,13 +516,13 @@ export default {
     obscure: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     readonly: {
       required: false,
       default: false,
-      type: Boolean
+      type: Boolean,
     },
 
     /**
@@ -492,9 +535,9 @@ export default {
       default: () => ({}),
       validator: (prop) => {
         return Object.keys(prop).every(key => [
-          'getFileByHash'
+          'getFileByHash',
         ].includes(key))
-      }
+      },
     },
 
     /**
@@ -507,9 +550,9 @@ export default {
           matcher: {
             char: '@|$|#', // A single char that should trigger a suggestion
             allowSpaces: true || false,
-            startOfLine: true || false
+            startOfLine: true || false,
           },
-          suggestions: [{ id: 'a unique id', name: 'a string that should be displayed when inserting the suggestion' }]
+          suggestions: [{ id: 'a unique id', name: 'a string that should be displayed when inserting the suggestion' }],
         }
         return Array.isArray(value) && value.filter(suggestionGroup => {
           let isValid = suggestionGroup.matcher && suggestionGroup.suggestions
@@ -523,13 +566,13 @@ export default {
         }).length === value.length
       },
       required: false,
-      default: () => ([])
+      default: () => ([]),
     },
 
     value: {
       type: String,
-      required: true
-    }
+      required: true,
+    },
   },
 
   data () {
@@ -537,7 +580,7 @@ export default {
       currentValue: '',
       diffMenu: {
         isOpen: false,
-        buttons: []
+        buttons: [],
       },
       imageId: null,
       editor: null,
@@ -554,50 +597,50 @@ export default {
           {
             label: de.editor.table.create,
             command: () => this.editor.commands.insertTable({ rowsCount: 3, colsCount: 3, withHeaderRow: false }),
-            name: 'createTable'
+            name: 'createTable',
           },
           {
             label: de.editor.table.delete,
             command: () => this.editor.commands.deleteTable(),
-            name: 'deleteTable'
+            name: 'deleteTable',
           },
           {
             label: de.editor.table.addColumnBefore,
             command: () => this.editor.commands.addColumnBefore(),
-            name: 'addColumnBefore'
+            name: 'addColumnBefore',
           },
           {
             label: de.editor.table.addColumnAfter,
             command: () => this.editor.commands.addColumnAfter(),
-            name: 'addColumnAfter'
+            name: 'addColumnAfter',
 
           },
           {
             label: de.editor.table.deleteColumn,
             command: () => this.editor.commands.deleteColumn(),
-            name: 'deleteColumn'
+            name: 'deleteColumn',
           },
           {
             label: de.editor.table.addRowBefore,
             command: () => this.editor.commands.addRowBefore(),
-            name: 'addRowBefore'
+            name: 'addRowBefore',
           },
           {
             label: de.editor.table.addRowAfter,
             command: () => this.editor.commands.addRowAfter(),
-            name: 'addRowAfter'
+            name: 'addRowAfter',
           },
           {
             label: de.editor.table.deleteRow,
             command: () => this.editor.commands.deleteRow(),
-            name: 'deleteRow'
+            name: 'deleteRow',
           },
           {
             label: de.editor.table.toggleCellMerge,
             command: () => this.editor.commands.mergeOrSplit(),
-            name: 'toggleCellMerge'
-          }
-        ]
+            name: 'toggleCellMerge',
+          },
+        ],
       },
       toolbar: Object.assign({
         /**
@@ -645,14 +688,14 @@ export default {
          * Set to true if you want table-insert button
          */
         table: false,
-        textDecoration: true
+        textDecoration: true,
       }, this.toolbarItems),
       translations: {
         ...de.editor,
         headingLevel: (level) => de.editor.headingLevel({ level }),
         insertImage: de.image.insert,
-        obscureTitle: de.obscure.title
-      }
+        obscureTitle: de.obscure.title,
+      },
     }
   },
 
@@ -668,7 +711,7 @@ export default {
 
     obscureEnabled () {
       return this.toolbar.obscure
-    }
+    },
   },
 
   watch: {
@@ -685,7 +728,7 @@ export default {
      */
     readonly () {
       this.editor.setOptions({ editable: !this.readonly })
-    }
+    },
   },
 
   methods: {
@@ -723,7 +766,7 @@ export default {
         History,
         HardBreak,
         Heading.configure({ levels: this.toolbar.headings }),
-        InsertAtCursorPos
+        InsertAtCursorPos,
       ]
 
       if (this.suggestions.length > 0) {
@@ -739,17 +782,17 @@ export default {
                   'data-id': node.attrs.id,
                   'data-label': node.attrs.label,
                   'data-suggestion-id': node.attrs.id,
-                  'data-type': self.name
+                  'data-type': self.name,
                 }, HTMLAttributes),
                 self.options.renderText({
                   options: {
-                    suggestion: { char: suggestion.matcher.char }
+                    suggestion: { char: suggestion.matcher.char },
                   },
                   node,
                 }),
               ]
             },
-            suggestion: buildSuggestion(suggestion)
+            suggestion: buildSuggestion(suggestion),
           }))
         })
       }
@@ -778,7 +821,7 @@ export default {
 
       if (this.toolbar.table) {
         extensions.push(Table.configure({
-          resizable: true
+          resizable: true,
         }))
         extensions.push(TableHeader)
         extensions.push(TableCell)
@@ -793,13 +836,13 @@ export default {
           {
             label: de.editor.mark.insert,
             command: () => this.editor.chain().focus().toggleInsert().run(),
-            name: 'insert'
+            name: 'insert',
           },
           {
             label: de.editor.mark.delete,
             command: () => this.editor.chain().focus().toggleDelete().run(),
-            name: 'delete'
-          }
+            name: 'delete',
+          },
         ]
       }
 
@@ -809,7 +852,7 @@ export default {
         this.diffMenu.buttons.unshift({
           label: de.editor.mark.element,
           command: () => this.editor.chain().focus().toggleMarkText().run(),
-          name: 'mark'
+          name: 'mark',
         })
       }
 
@@ -920,10 +963,10 @@ export default {
               type: 'customLink',
               attrs: {
                 href: linkUrl,
-                target: newTab ? '_blank' : null
-              }
-            }
-          ]
+                target: newTab ? '_blank' : null,
+              },
+            },
+          ],
         })
       }
     },
@@ -1061,7 +1104,7 @@ export default {
         }
         document.addEventListener('click', closeMenu)
       }
-    }
+    },
   },
 
   created () {
@@ -1082,7 +1125,7 @@ export default {
       },
       editorProps: {
         attributes: {
-          role: 'textbox'
+          role: 'textbox',
         },
 
         handleDrop: (_view, _event, _slice, moved) => {
@@ -1118,14 +1161,14 @@ export default {
           returnContent = this.transformObscureTag(returnContent)
 
           return returnContent
-        }
+        },
       },
 
       onInit: ({ view }) => {
         this.currentValue = this.transformObscureTag(this.editor.getHTML())
 
         view._props.handleScrollToSelection = customHandleScrollToSelection
-      }
+      },
     })
 
     this.$root.$on('open-image-alt-modal', ({ event, imgId, editorId }) => {
@@ -1158,7 +1201,7 @@ export default {
         this.$el.closest('form').removeEventListener('reset', this.resetEditor)
       }
     }
-  }
+  },
 }
 
 // Custom handling of scrolling after paste
@@ -1167,7 +1210,7 @@ function windowRect (win) {
     left: 0,
     right: win.innerWidth,
     top: 0,
-    bottom: win.innerHeight
+    bottom: win.innerHeight,
   }
 }
 function getSide (value, side) {

--- a/src/components/DpEditor/DpLinkModal.vue
+++ b/src/components/DpEditor/DpLinkModal.vue
@@ -3,7 +3,8 @@
     ref="linkModal"
     content-classes="u-1-of-3"
     data-dp-validate="linkModal"
-    @modal:toggled="setVisible">
+    @modal:toggled="setVisible"
+  >
     <h3>
       {{ hasLink ? translations.linkEdit : translations.linkInsert }}
     </h3>
@@ -14,7 +15,8 @@
         :label="{
           text: translations.linkText
         }"
-        :required="isVisible" />
+        :required="isVisible"
+      />
       <dp-input
         id="link_url"
         v-model="url"
@@ -24,13 +26,15 @@
         }"
         :pattern="isVisible === true ? '(^https?://.*|^//.*|^mailto:.*)' : null"
         :required="isVisible"
-        type="url" />
+        type="url"
+      />
       <dp-checkbox
         id="newTab"
         v-model="newTab"
         :label="{
           text: translations.newTab
-        }" />
+        }"
+      />
       <dp-button-row
         class="u-mt"
         primary
@@ -38,7 +42,8 @@
         secondary
         :secondary-text="translations.remove"
         @primary-action="dpValidateAction('linkModal', () => emitAndClose('insert'), false)"
-        @secondary-action="emitAndClose('remove')" />
+        @secondary-action="emitAndClose('remove')"
+      />
     </div>
   </dp-modal>
 </template>
@@ -58,7 +63,7 @@ export default {
     DpButtonRow,
     DpCheckbox,
     DpInput,
-    DpModal
+    DpModal,
   },
 
   mixins: [dpValidateMixin],
@@ -77,16 +82,16 @@ export default {
         linkText: de.link.text,
         remove: de.operations.remove,
         newTab: de.tab.openNew,
-        url: de.url
+        url: de.url,
       },
-      url: ''
+      url: '',
     }
   },
 
   computed: {
     hasLink () {
       return this.initUrl !== ''
-    }
+    },
   },
 
   methods: {
@@ -111,7 +116,7 @@ export default {
         this.text = ''
         this.newTab = false
       }
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpEditor/DpResizableImage.vue
+++ b/src/components/DpEditor/DpResizableImage.vue
@@ -3,14 +3,16 @@
     ref="imagewrapper"
     as="span"
     class="resizable-image"
-    tabindex="1">
+    tabindex="1"
+  >
     <img
       ref="image"
       :alt="node.attrs.alt"
       data-cy="editor:resizableImage"
       :src="node.attrs.src"
       :title="imageTitle"
-      @click.ctrl="$root.$emit('open-image-alt-modal', { event: $event, imgId: id, editorId: editor.options.id })">
+      @click.ctrl="$root.$emit('open-image-alt-modal', { event: $event, imgId: id, editorId: editor.options.id })"
+    >
   </node-view-wrapper>
 </template>
 
@@ -23,7 +25,7 @@ export default {
   name: 'DpResizableImage',
 
   components: {
-    NodeViewWrapper
+    NodeViewWrapper,
   },
 
   props: nodeViewProps,
@@ -33,7 +35,7 @@ export default {
       id: uuid(),
       imageTitle: de.image.alt.editHint,
       observer: null,
-      ratioFactor: 1
+      ratioFactor: 1,
     }
   },
 
@@ -79,7 +81,7 @@ export default {
           this.initResizeObserver()
         }, 200)
       }
-    }
+    },
   },
 
   mounted () {
@@ -101,6 +103,6 @@ export default {
     if (this.observer) {
       this.observer.disconnect()
     }
-  }
+  },
 }
 </script>

--- a/src/components/DpEditor/DpUploadModal.vue
+++ b/src/components/DpEditor/DpUploadModal.vue
@@ -3,20 +3,24 @@
     ref="uploadModal"
     content-classes="w-fit"
     data-cy="editor:uploadModal"
-    @modal:toggled="(isOpen) => { if (!isOpen) reset() }">
+    @modal:toggled="(isOpen) => { if (!isOpen) reset() }"
+  >
     <h3
       v-if="editAltTextOnly"
-      class="u-mb">
+      class="u-mb"
+    >
       {{ translations.editImage }}
     </h3>
     <h3
       v-else
-      class="mb-2">
+      class="mb-2"
+    >
       {{ translations.insertImage }}
     </h3>
     <div
       v-if="!editAltTextOnly"
-      class="mb-2">
+      class="mb-2"
+    >
       <dp-upload-files
         id="imageFile"
         ref="uploader"
@@ -27,13 +31,15 @@
         :max-number-of-files="1"
         :translations="{ dropHereOr: translations.uploadImage('20MB') }"
         :tus-endpoint="tusEndpoint"
-        @upload-success="setFile" />
+        @upload-success="setFile"
+      />
     </div>
     <div v-else>
       <img
         :alt="altText"
         class="mb-4"
-        :src="imgSrc">
+        :src="imgSrc"
+      >
     </div>
     <dp-input
       id="altText"
@@ -43,19 +49,22 @@
       :label="{
         hint: translations.altTextHint,
         text: translations.altText,
-      }" />
+      }"
+    />
     <div class="u-mt text-right w-full space-inline-s">
       <button
         class="btn btn--primary"
         data-cy="uploadModal:save"
         type="button"
         @click="emitAndClose"
-        v-text="editAltTextOnly ? translations.save : translations.insert" />
+        v-text="editAltTextOnly ? translations.save : translations.insert"
+      />
       <button
         class="btn btn--secondary"
         data-cy="uploadModal:abort"
         type="button"
-        @click="closeAndReset()">
+        @click="closeAndReset()"
+      >
         {{ translations.abort }}
       </button>
     </div>
@@ -74,7 +83,7 @@ export default {
   components: {
     DpInput,
     DpModal,
-    DpUploadFiles
+    DpUploadFiles,
   },
 
   props: {
@@ -84,12 +93,12 @@ export default {
     basicAuth: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     getFileByHash: {
       type: Function,
-      required: true
+      required: true,
     },
 
     /**
@@ -97,14 +106,14 @@ export default {
      */
     tusEndpoint: {
       type: String,
-      required: true
-    }
+      required: true,
+    },
   },
 
   emits: [
     'add-alt',
     'close',
-    'insert-image'
+    'insert-image',
   ],
 
   data () {
@@ -121,8 +130,8 @@ export default {
         insert: de.operations.insert,
         insertImage: de.image.insert,
         save: de.operations.save,
-        uploadImage: de.upload.select.image
-      }
+        uploadImage: de.upload.select.image,
+      },
     }
   },
 
@@ -163,7 +172,7 @@ export default {
       }
 
       this.$refs.uploadModal.toggle()
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpEditor/MentionList.vue
+++ b/src/components/DpEditor/MentionList.vue
@@ -6,7 +6,8 @@
         :key="item.id"
         class="o-list__item suggestion__list-item u-ph-0_5 u-pv-0_25"
         :class="{ 'suggestion__list-item--is-active': index === selectedIndex }"
-        @click="selectItem(index)">
+        @click="selectItem(index)"
+      >
         <button class="btn--blank">
           {{ item.label }}
         </button>
@@ -14,7 +15,8 @@
     </template>
     <li
       v-else
-      class="o-list__item suggestion__list-item">
+      class="o-list__item suggestion__list-item"
+    >
       No result
     </li>
   </ul>
@@ -47,7 +49,7 @@ export default {
       handler () {
         this.selectedIndex = 0
       },
-      deep: true
+      deep: true,
     },
   },
 
@@ -92,7 +94,7 @@ export default {
       if (item) {
         this.command(item)
       }
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpEditor/libs/Decoration.js
+++ b/src/components/DpEditor/libs/Decoration.js
@@ -34,10 +34,10 @@ const placeholderPlugin = new Plugin({
         set = addHandle(tr, set, action.move.pos, action.move.id)
       }
       return set
-    }
+    },
   },
   props: {
-    decorations (state) { return this.getState(state) }
+    decorations (state) { return this.getState(state) },
   },
   filterTransaction (tr, state) {
     const action = tr.getMeta(this)
@@ -51,7 +51,7 @@ const placeholderPlugin = new Plugin({
       tr.setSelection(new TextSelection(state.doc.resolve(action.move.initialPos), state.doc.resolve(action.move.pos)))
     }
     return true
-  }
+  },
 })
 
 export { placeholderPlugin }

--- a/src/components/DpEditor/libs/customExtensions.js
+++ b/src/components/DpEditor/libs/customExtensions.js
@@ -21,5 +21,5 @@ export {
   InsertAtCursorPos,
   Obscure,
   UnAnonymize,
-  PreventEditing
+  PreventEditing,
 }

--- a/src/components/DpEditor/libs/editorAnonymize.js
+++ b/src/components/DpEditor/libs/editorAnonymize.js
@@ -17,8 +17,8 @@ export default Mark.create({
   addAttributes () {
     return {
       title: {
-        default: null
-      }
+        default: null,
+      },
     }
   },
 
@@ -26,20 +26,20 @@ export default Mark.create({
     return {
       HTMLAttributes: {
         title: null,
-      }
+      },
     }
   },
 
   parseHTML () {
     return [{
-      tag: 'span.anonymize-me'
+      tag: 'span.anonymize-me',
     }]
   },
 
   renderHTML: ({ HTMLAttributes, options }) => {
     return ['span', mergeAttributes(
       HTMLAttributes,
-      { class: 'anonymize-me' }
+      { class: 'anonymize-me' },
     ), 0]
   },
 
@@ -47,7 +47,7 @@ export default Mark.create({
     return {
       toggleAnonymize: () => ({ commands }) => {
         return commands.toggleMark(this.name)
-      }
+      },
     }
-  }
+  },
 })

--- a/src/components/DpEditor/libs/editorBuildSuggestion.js
+++ b/src/components/DpEditor/libs/editorBuildSuggestion.js
@@ -36,7 +36,7 @@ export default ({ suggestions, matcher }) => ({
           theme: 'dark',
           placement: 'top-start',
           inertia: true,
-          duration: [400, 200]
+          duration: [400, 200],
         })
       },
 

--- a/src/components/DpEditor/libs/editorCustomDelete.js
+++ b/src/components/DpEditor/libs/editorCustomDelete.js
@@ -29,5 +29,5 @@ export default Mark.create({
         return commands.unsetMark(this.name)
       },
     }
-  }
+  },
 })

--- a/src/components/DpEditor/libs/editorCustomImage.js
+++ b/src/components/DpEditor/libs/editorCustomImage.js
@@ -23,7 +23,7 @@ export default Node.create({
       HTMLAttributes: {
         style: 'width: ',
         class: null,
-      }
+      },
     }
   },
 
@@ -34,8 +34,8 @@ export default Node.create({
         keepOnSplit: false,
         parseHTML: element => element.getAttribute('alt'),
         renderHTML: attributes => ({
-          'alt': attributes.alt
-        })
+          'alt': attributes.alt,
+        }),
       },
 
       height: {
@@ -45,8 +45,8 @@ export default Node.create({
           return element.height || element.style.height
         },
         renderHTML: attributes => ({
-          'height': attributes.height
-        })
+          'height': attributes.height,
+        }),
       },
 
       src: {
@@ -54,8 +54,8 @@ export default Node.create({
         keepOnSplit: false,
         parseHTML: element => element.getAttribute('src'),
         renderHTML: attributes => ({
-          'src': attributes.src
-        })
+          'src': attributes.src,
+        }),
       },
 
       title: {
@@ -63,8 +63,8 @@ export default Node.create({
         keepOnSplit: false,
         parseHTML: element => element.getAttribute('title'),
         renderHTML: attributes => ({
-          'title': attributes.title
-        })
+          'title': attributes.title,
+        }),
       },
 
       width: {
@@ -73,10 +73,10 @@ export default Node.create({
         parseHTML: element => element.width || element.style.width,
         renderHTML: attributes => {
           return {
-            'width': attributes.width
+            'width': attributes.width,
           }
-        }
-      }
+        },
+      },
     }
   },
 
@@ -88,9 +88,9 @@ export default Node.create({
 
   parseHTML () {
     return [{
-      tag: `dp-resizable-image[style="width:${this.att}"]`
+      tag: `dp-resizable-image[style="width:${this.att}"]`,
     }, {
-      tag: 'img[src]'
+      tag: 'img[src]',
     }]
   },
 
@@ -107,7 +107,7 @@ export default Node.create({
         const transaction = state.tr.insert(position, node)
 
         dispatch(transaction)
-      }
+      },
     }
   },
 
@@ -115,13 +115,13 @@ export default Node.create({
     return [
       nodeInputRule({
         find: IMAGE_INPUT_REGEX,
-        type: this.type
-      })
+        type: this.type,
+      }),
     ]
   },
 
   // Return a vue component
   addNodeView() {
     return VueNodeViewRenderer(DpResizableImage)
-  }
+  },
 })

--- a/src/components/DpEditor/libs/editorCustomInsert.js
+++ b/src/components/DpEditor/libs/editorCustomInsert.js
@@ -26,5 +26,5 @@ export default Mark.create({
         return commands.unsetMark(this.name)
       },
     }
-  }
+  },
 })

--- a/src/components/DpEditor/libs/editorCustomLink.js
+++ b/src/components/DpEditor/libs/editorCustomLink.js
@@ -10,22 +10,22 @@ export default Link.extend({
       openOnClick: true,
       HTMLAttributes: {
         target: null,
-        rel: 'noopener noreferrer nofollow'
-      }
+        rel: 'noopener noreferrer nofollow',
+      },
     }
   },
 
   addAttributes () {
     return {
       href: {
-        default: null
+        default: null,
       },
       target: {
-        default: null
+        default: null,
       },
       class: {
-        default: null
-      }
+        default: null,
+      },
     }
   },
 
@@ -34,15 +34,15 @@ export default Link.extend({
   parseHTML () {
     return [
       {
-        tag: 'a[href]'
-      }
+        tag: 'a[href]',
+      },
     ]
   },
 
   renderHTML ({ HTMLAttributes }) {
     return ['a', mergeAttributes(
       this.options.HTMLAttributes,
-      HTMLAttributes
+      HTMLAttributes,
     ), 0]
   },
 
@@ -58,5 +58,5 @@ export default Link.extend({
         return commands.unsetMark(this.name)
       },
     }
-  }
+  },
 })

--- a/src/components/DpEditor/libs/editorCustomMark.js
+++ b/src/components/DpEditor/libs/editorCustomMark.js
@@ -24,6 +24,6 @@ export default Mark.create({
         return commands.unsetMark(this.name)
       },
     }
-  }
+  },
 })
 

--- a/src/components/DpEditor/libs/editorInsertAtCursorPos.js
+++ b/src/components/DpEditor/libs/editorInsertAtCursorPos.js
@@ -26,5 +26,5 @@ export default Node.create({
     const transaction = state.tr.insert(selection.anchor, slice.content)
 
     dispatch(transaction)
-  }
+  },
 })

--- a/src/components/DpEditor/libs/editorObscure.js
+++ b/src/components/DpEditor/libs/editorObscure.js
@@ -11,7 +11,7 @@
 import {
   Mark,
   markInputRule,
-  markPasteRule
+  markPasteRule,
 } from '@tiptap/core'
 
 const markInputRegex = /(?:<o>)([^<o>]+)(?:<o>)$/
@@ -22,7 +22,7 @@ export default Mark.create({
   parseHTML () {
     return [
       { tag: '.u-obscure' },
-      { tag: 'dp-obscure' }
+      { tag: 'dp-obscure' },
     ]
   },
 
@@ -48,8 +48,8 @@ export default Mark.create({
     return [
       markInputRule({
         find: markInputRegex,
-        type: this.type
-      })
+        type: this.type,
+      }),
     ]
   },
 
@@ -57,8 +57,8 @@ export default Mark.create({
     return [
       markPasteRule({
         find: markPasteRegex,
-        type: this.type
-      })
+        type: this.type,
+      }),
     ]
-  }
+  },
 })

--- a/src/components/DpEditor/libs/editorUnAnonymize.js
+++ b/src/components/DpEditor/libs/editorUnAnonymize.js
@@ -14,13 +14,13 @@ export default Mark.create({
 
   parseHTML () {
     return [{
-      tag: 'span.unanonymized'
+      tag: 'span.unanonymized',
     }]
   },
 
   renderHTML: () => {
     return ['span', {
-      class: 'unanonymized'
+      class: 'unanonymized',
     }, 0]
   },
 
@@ -28,7 +28,7 @@ export default Mark.create({
     return {
       toggleUnanonymize: () => ({ commands }) => {
         return commands.toggleMark(this.name)
-      }
+      },
     }
-  }
+  },
 })

--- a/src/components/DpEditor/libs/preventEditing.js
+++ b/src/components/DpEditor/libs/preventEditing.js
@@ -24,8 +24,8 @@ export default Extension.create({
               event.preventDefault()
 
               return true
-            }
-          }
+            },
+          },
         },
       }),
     ]

--- a/src/components/DpEditor/libs/tiptapExtensions.js
+++ b/src/components/DpEditor/libs/tiptapExtensions.js
@@ -41,5 +41,5 @@ export {
   TableHeader,
   TableRow,
   Text,
-  Underline
+  Underline,
 }

--- a/src/components/DpFlyout/DpFlyout.vue
+++ b/src/components/DpFlyout/DpFlyout.vue
@@ -7,7 +7,8 @@
       'is-expanded': isExpanded,
       'bg-surface-medium rounded-md': variant === 'dark'
     }, position]"
-    data-cy="flyoutTrigger">
+    data-cy="flyoutTrigger"
+  >
     <button
       :disabled="disabled"
       type="button"
@@ -18,10 +19,12 @@
         'bg-interactive-subtle-hover': isExpanded
       }"
       :data-cy="dataCy !== '' ? dataCy : null"
-      @click="toggle">
+      @click="toggle"
+    >
       <slot
         name="trigger"
-        :is-expanded="isExpanded">
+        :is-expanded="isExpanded"
+      >
         <i class="fa fa-ellipsis-h" />
       </slot>
     </button>
@@ -34,7 +37,8 @@
         'right-1': align === 'right',
         'px-2 py-1': padded
       }"
-      data-cy="flyout">
+      data-cy="flyout"
+    >
       <slot />
     </span>
   </span>
@@ -47,7 +51,7 @@ export default {
   name: 'DpFlyout',
 
   directives: {
-    onClickOutside: vOnClickOutside
+    onClickOutside: vOnClickOutside,
   },
 
   props: {
@@ -55,45 +59,45 @@ export default {
       required: false,
       type: String,
       default: 'right',
-      validator: (prop) => ['left', 'right'].includes(prop)
+      validator: (prop) => ['left', 'right'].includes(prop),
     },
 
     ariaLabel: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     dataCy: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     disabled: {
       required: false,
       type: Boolean,
-      default: false
+      default: false,
     },
 
     padded: {
       required: false,
       type: Boolean,
-      default: true
+      default: true,
     },
 
     position: {
       required: false,
       type: String,
       default: 'relative',
-      validator: (prop) => ['relative', 'absolute'].includes(prop)
+      validator: (prop) => ['relative', 'absolute'].includes(prop),
     },
 
     variant: {
       required: false,
       type: String,
       default: 'light',
-      validator: (prop) => ['light', 'dark'].includes(prop)
+      validator: (prop) => ['light', 'dark'].includes(prop),
     },
   },
 
@@ -101,7 +105,7 @@ export default {
 
   data () {
     return {
-      isExpanded: false
+      isExpanded: false,
     }
   },
 
@@ -121,7 +125,7 @@ export default {
       } else {
         this.$emit('close')
       }
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpIcon/DpIcon.vue
+++ b/src/components/DpIcon/DpIcon.vue
@@ -3,7 +3,8 @@
     :is="_icon"
     :class="proportionClass"
     :size="SIZES[size as IconSize]"
-    :weight="weight" />
+    :weight="weight"
+  />
 </template>
 
 <script setup lang="ts">
@@ -12,19 +13,19 @@ import {
   markRaw,
   PropType,
   toRefs,
-  watchEffect
+  watchEffect,
 } from 'vue'
 
 import {
   iconComponents,
   proportions,
-  SIZES
+  SIZES,
 } from './util/iconConfig'
 
 import {
   IconName,
   IconSize,
-  IconWeight
+  IconWeight,
 } from '../../../types'
 
 import type { Component } from 'vue'
@@ -33,7 +34,7 @@ const props = defineProps({
   icon: {
     type: String as PropType<IconName>,
     required: true,
-    validator: (prop: IconName) => Object.keys(iconComponents).includes(prop)
+    validator: (prop: IconName) => Object.keys(iconComponents).includes(prop),
   },
 
   /**
@@ -47,15 +48,15 @@ const props = defineProps({
     type: String as PropType<IconSize>,
     required: false,
     default: 'medium',
-    validator: (prop: IconSize) => Object.keys(SIZES).includes(prop)
+    validator: (prop: IconSize) => Object.keys(SIZES).includes(prop),
   },
 
   weight: {
     type: String as PropType<IconWeight>,
     required: false,
     default: 'regular',
-    validator: (prop: IconWeight) => ['light', 'regular', 'bold', 'fill'].includes(prop)
-  }
+    validator: (prop: IconWeight) => ['light', 'regular', 'bold', 'fill'].includes(prop),
+  },
 })
 
 /**

--- a/src/components/DpIcon/util/iconConfig.ts
+++ b/src/components/DpIcon/util/iconConfig.ts
@@ -46,7 +46,7 @@ import {
   PhWarningCircle,
   PhWarningDiamond,
   PhX,
-  PhXCircle
+  PhXCircle,
 } from '@phosphor-icons/vue'
 import {
   AliasedPhosphorIconName,
@@ -137,7 +137,7 @@ const mappedIconAliases: Record<IconAlias, Component> = {
   'success': PhCheck,
   'unlock': PhLockSimpleOpen,
   'userSolid': PhUser,
-  'xmark': PhX
+  'xmark': PhX,
 }
 
 // ICON PROPORTIONS
@@ -155,7 +155,7 @@ const iconsProportions: Record<string, IconProportion> = {
   'caret-double-up': 'portrait',
   'check': 'landscape',
   'dots-six-vertical': 'portrait',
-  'envelope-simple': 'landscape'
+  'envelope-simple': 'landscape',
 }
 
 const aliasedIconsProportions: Record<string, IconProportion> = {
@@ -171,12 +171,12 @@ const aliasedIconsProportions: Record<string, IconProportion> = {
 
 export const iconComponents: Record<IconName, Component> = {
   ...mappedIcons,
-  ...mappedIconAliases
+  ...mappedIconAliases,
 }
 
 export const proportions: Record<string, IconProportion> = {
   ...iconsProportions,
-  ...aliasedIconsProportions
+  ...aliasedIconsProportions,
 }
 
 export const SIZES: Record<IconSize, number> = {

--- a/src/components/DpInlineNotification/DpInlineNotification.vue
+++ b/src/components/DpInlineNotification/DpInlineNotification.vue
@@ -2,36 +2,43 @@
   <div
     v-if="isDismissed === false"
     :data-cy="dataCy"
-    :class="`flash flash-${type} flex`">
+    :class="`flash flash-${type} flex`"
+  >
     <i
       class="fa u-pr-0_25 line-height--1_4"
       :class="iconClasses[type]"
-      aria-hidden="true" />
+      aria-hidden="true"
+    />
     <div class="space-stack-xs">
       <div
         v-if="message"
         :data-cy="`${dataCy}:message`"
-        v-html="message" />
+        v-html="message"
+      />
       <slot />
       <button
         v-if="dismissible"
         class="btn--blank o-link--default weight--bold"
         :data-cy="`${dataCy}:hideHint`"
         @click="dismiss"
-        v-text="translations.hintDismiss" />
+        v-text="translations.hintDismiss"
+      />
     </div>
   </div>
   <div
     v-else
-    class="flow-root">
+    class="flow-root"
+  >
     <button
       :aria-label="translations.hintShow"
       class="btn--blank color--grey float-right"
       :data-cy="`${dataCy}:showHint`"
-      @click="show">
+      @click="show"
+    >
       <dp-icon
         icon="info"
-        aria-hidden="true" />
+        aria-hidden="true"
+      />
     </button>
   </div>
 </template>
@@ -45,14 +52,14 @@ export default {
   name: 'DpInlineNotification',
 
   components: {
-    DpIcon
+    DpIcon,
   },
 
   props: {
     dataCy: {
       type: String,
       required: false,
-      default: 'inlineNotification'
+      default: 'inlineNotification',
     },
 
     /**
@@ -62,7 +69,7 @@ export default {
     dismissible: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -71,20 +78,20 @@ export default {
     dismissibleKey: {
       type: String,
       required: false,
-      default: null
+      default: null,
     },
 
     message: {
       type: String,
       required: false,
-      default: null
+      default: null,
     },
 
     type: {
       type: String,
       required: false,
-      default: 'error'
-    }
+      default: 'error',
+    },
   },
 
   data () {
@@ -93,13 +100,13 @@ export default {
         confirm: 'fa-check',
         error: 'fa-exclamation-circle',
         info: 'fa-info-circle',
-        warning: 'fa-exclamation-triangle'
+        warning: 'fa-exclamation-triangle',
       },
       isDismissed: true,
       translations: {
         hintDismiss: de.hint.dismiss,
-        hintShow: de.hint.show
-      }
+        hintShow: de.hint.show,
+      },
     }
   },
 
@@ -112,11 +119,11 @@ export default {
     show () {
       this.isDismissed = false
       this.dismissibleKey && lscache.remove(this.dismissibleKey)
-    }
+    },
   },
 
   mounted () {
     this.isDismissed = (this.dismissible && this.dismissibleKey) ? !!lscache.get(this.dismissibleKey) : false
-  }
+  },
 }
 </script>

--- a/src/components/DpInput/DpInput.vue
+++ b/src/components/DpInput/DpInput.vue
@@ -9,7 +9,8 @@
         required: required
       }"
       :text="label.text"
-      class="mb-0.5" />
+      class="mb-0.5"
+    />
     <input
       :id="id"
       :name="name !== '' ? name : null"
@@ -34,7 +35,8 @@
       @blur="emit('blur', $event.target.value)"
       @focus="emit('focus')"
       @input="onInput"
-      @keydown.enter="handleEnter">
+      @keydown.enter="handleEnter"
+    >
   </div>
 </template>
 
@@ -51,7 +53,7 @@ const props = defineProps({
   ariaLabelledby: {
     type: String,
     required: false,
-    default: null
+    default: null,
   },
 
   /**
@@ -61,49 +63,49 @@ const props = defineProps({
   autocomplete: {
     type: String,
     required: false,
-    default: ''
+    default: '',
   },
 
   dataCounter: {
     type: String,
     required: false,
-    default: ''
+    default: '',
   },
 
   dataCy: {
     type: String,
     required: false,
-    default: ''
+    default: '',
   },
 
   dataDpValidateError: {
     type: String,
     required: false,
-    default: ''
+    default: '',
   },
 
   dataDpValidateErrorFieldname: {
     type: String,
     required: false,
-    default: ''
+    default: '',
   },
 
   dataDpValidateIf: {
     type: String,
     required: false,
-    default: ''
+    default: '',
   },
 
   dataDpValidateShouldEqual: {
     type: String,
     required: false,
-    default: ''
+    default: '',
   },
 
   disabled: {
     type: Boolean,
     required: false,
-    default: null
+    default: null,
   },
 
   /**
@@ -112,12 +114,12 @@ const props = defineProps({
   hasIcon: {
     type: Boolean,
     required: false,
-    default: false
+    default: false,
   },
 
   id: {
     type: String,
-    required: true
+    required: true,
   },
 
   label: {
@@ -128,8 +130,8 @@ const props = defineProps({
       hide: false,
       hint: '',
       text: '',
-      tooltip: ''
-    })
+      tooltip: '',
+    }),
   },
 
   /**
@@ -138,7 +140,7 @@ const props = defineProps({
   maxlength: {
     type: [Number, String],
     required: false,
-    default: null
+    default: null,
   },
 
   /**
@@ -147,31 +149,31 @@ const props = defineProps({
   minlength: {
     type: [Number, String],
     required: false,
-    default: null
+    default: null,
   },
 
   modelValue: {
     type: String,
     required: false,
-    default: ''
+    default: '',
   },
 
   name: {
     type: String,
     required: false,
-    default: ''
+    default: '',
   },
 
   pattern: {
     type: String,
     required: false,
-    default: ''
+    default: '',
   },
 
   placeholder: {
     type: String,
     required: false,
-    default: ''
+    default: '',
   },
 
   /**
@@ -180,19 +182,19 @@ const props = defineProps({
   preventDefaultOnEnter: {
     type: Boolean,
     required: false,
-    default: true
+    default: true,
   },
 
   readonly: {
     type: Boolean,
     required: false,
-    default: null
+    default: null,
   },
 
   required: {
     type: Boolean,
     required: false,
-    default: null
+    default: null,
   },
 
   /**
@@ -207,7 +209,7 @@ const props = defineProps({
     type: String,
     required: false,
     default: 'full',
-    validator: (prop: string) => ['full', 'left', 'right'].includes(prop)
+    validator: (prop: string) => ['full', 'left', 'right'].includes(prop),
   },
 
   /**
@@ -219,13 +221,13 @@ const props = defineProps({
   size: {
     type: Number,
     required: false,
-    default: null
+    default: null,
   },
 
   type: {
     type: String,
     required: false,
-    default: 'text'
+    default: 'text',
   },
 
   /**
@@ -235,8 +237,8 @@ const props = defineProps({
   width: {
     type: String,
     required: false,
-    default: 'w-full'
-  }
+    default: 'w-full',
+  },
 })
 
 const emit = defineEmits(['blur', 'enter', 'focus', 'input', 'update:modelValue'])
@@ -249,8 +251,8 @@ const emit = defineEmits(['blur', 'enter', 'focus', 'input', 'update:modelValue'
 defineOptions({
   model: {
     prop: 'modelValue',
-    event: 'update:modelValue'
-  }
+    event: 'update:modelValue',
+  },
 })
 
 const classes = computed(() => {
@@ -259,7 +261,7 @@ const classes = computed(() => {
     text-base leading-4 bg-surface
     outline-1 outline-offset-0 outline-transparent
     focus-visible:outline-interactive focus-visible:border-interactive focus-visible:z-above-zero
-    required:shadow-none`
+    required:shadow-none`,
   ]
 
   if (props.rounded === 'full') {

--- a/src/components/DpLabel/DpLabel.vue
+++ b/src/components/DpLabel/DpLabel.vue
@@ -1,24 +1,29 @@
 <template>
   <label
     :class="classes"
-    :for="labelFor">
+    :for="labelFor"
+  >
     <span>
       <span v-cleanhtml="text" /><span
         v-if="required"
-        aria-hidden="true">*</span>
+        aria-hidden="true"
+      >*</span>
       <dp-contextual-help
         v-if="tooltip"
         :class="prefixClass('ml-0.5')"
-        :text="tooltip" />
+        :text="tooltip"
+      />
     </span>
     <span
       v-if="hints.length"
-      :class="prefixClass('block text-sm font-normal')">
+      :class="prefixClass('block text-sm font-normal')"
+    >
       <span
         v-for="(hint, i) in hints"
         :key="i"
         v-cleanhtml="hint"
-        :class="prefixClass('inline-block')" />
+        :class="prefixClass('inline-block')"
+      />
     </span>
   </label>
 </template>
@@ -33,44 +38,44 @@ const props = defineProps({
   bold: {
     type: Boolean,
     required: false,
-    default: true
+    default: true,
   },
 
   for: {
     type: String,
-    required: true
+    required: true,
   },
 
   // This is used to hide the label visually, but keep it accessible for screen readers
   hide: {
     type: Boolean,
     required: false,
-    default: false
+    default: false,
   },
 
   // Can be string or array (the second element being the "maxlength" hint).
   hint: {
     type: [String, Array] as PropType<string | string[]>,
     required: false,
-    default: () => []
+    default: () => [],
   },
 
   text: {
     type: String,
-    required: true
+    required: true,
   },
 
   tooltip: {
     type: String,
     required: false,
-    default: ''
+    default: '',
   },
 
   required: {
     type: Boolean,
     required: false,
-    default: false
-  }
+    default: false,
+  },
 })
 
 const classes = computed(() : string[] => {

--- a/src/components/DpLoading/DpLoading.vue
+++ b/src/components/DpLoading/DpLoading.vue
@@ -5,22 +5,26 @@
       'c-loading--overlay': overlay,
       'flex items-center space-inline-xs': !overlay
     }"
-    @click.prevent="">
+    @click.prevent=""
+  >
     <div
       v-if="overlay"
-      class="c-loading__inner flex items-center space-inline-xs">
+      class="c-loading__inner flex items-center space-inline-xs"
+    >
       <span class="c-loading__spinner" />
       <span
         v-if="!hideLabel"
         class="c-loading__text"
-        v-text="label" />
+        v-text="label"
+      />
     </div>
     <template v-else>
       <span class="c-loading__spinner" />
       <span
         v-if="!hideLabel"
         class="c-loading__text"
-        v-text="label" />
+        v-text="label"
+      />
     </template>
   </div>
 </template>
@@ -35,20 +39,20 @@ export default {
     hideLabel: {
       required: false,
       type: Boolean,
-      default: false
+      default: false,
     },
 
     overlay: {
       type: Boolean,
       required: false,
-      default: false
-    }
+      default: false,
+    },
   },
 
   data () {
     return {
-      label: de.loadingData
+      label: de.loadingData,
     }
-  }
+  },
 }
 </script>

--- a/src/components/DpModal/DpModal.vue
+++ b/src/components/DpModal/DpModal.vue
@@ -1,29 +1,35 @@
 <template>
   <div
     :class="prefixClass('o-modal')"
-    @keydown="checkKeyEvent">
+    @keydown="checkKeyEvent"
+  >
     <transition
       name="content"
       appear
-      @enter="preventScroll">
+      @enter="preventScroll"
+    >
       <aside
         v-if="isOpenModal"
         :aria-label="ariaLabel"
         :class="prefixClass('o-modal__content ' + contentClasses)"
-        role="dialog">
+        role="dialog"
+      >
         <button
           :class="prefixClass('btn--blank o-link--default absolute u-right-0')"
           :aria-label="title"
           :title="title"
-          @click.prevent.stop="toggle()">
+          @click.prevent.stop="toggle()"
+        >
           <dp-icon
             icon="close"
-            size="large" />
+            size="large"
+          />
         </button>
         <div :class="prefixClass('o-modal__body ' + contentBodyClasses)">
           <h2
             v-if="hasHeader"
-            :class="prefixClass('font-size-h1 border--bottom u-pb-0_25 ' + contentHeaderClasses)">
+            :class="prefixClass('font-size-h1 border--bottom u-pb-0_25 ' + contentHeaderClasses)"
+          >
             <slot name="header" />
           </h2>
           <slot name="default" />
@@ -33,11 +39,13 @@
     <transition
       name="backdrop"
       appear
-      @after-leave="preventScroll(false)">
+      @after-leave="preventScroll(false)"
+    >
       <div
         v-if="isOpenModal"
         :class="prefixClass('o-modal__backdrop')"
-        @click.prevent.stop="toggle()" />
+        @click.prevent.stop="toggle()"
+      />
     </transition>
   </div>
 </template>
@@ -51,7 +59,7 @@ export default {
   name: 'DpModal',
 
   components: {
-    DpIcon
+    DpIcon,
   },
 
   mixins: [prefixClassMixin],
@@ -60,33 +68,33 @@ export default {
     ariaLabel: {
       required: false,
       type: String,
-      default: ''
+      default: '',
     },
 
     contentBodyClasses: {
       required: false,
       type: String,
-      default: ''
+      default: '',
     },
 
     contentClasses: {
       required: false,
       type: String,
-      default: ''
+      default: '',
     },
 
     contentHeaderClasses: {
       required: false,
       type: String,
-      default: ''
+      default: '',
     },
 
     //  Required when toggling modal with toggleByEvent()
     modalId: {
       required: false,
       type: String,
-      default: ''
-    }
+      default: '',
+    },
   },
 
   data () {
@@ -94,14 +102,14 @@ export default {
       isOpenModal: false,
       lastFocusedElement: '',
       focusableElements: [],
-      title: de.window.close
+      title: de.window.close,
     }
   },
 
   computed: {
     hasHeader () {
       return typeof this.$slots.header !== 'undefined'
-    }
+    },
   },
 
   methods: {
@@ -204,13 +212,13 @@ export default {
           this.focusableElements[idxToFocus].focus()
         }
       }
-    }
+    },
   },
 
   updated () {
     // When component is re-rendered, we have to collect all focusable elements again, as new ones may have appeared
     this.$nextTick(() => this.getFocusableElements())
-  }
+  },
 
 }
 </script>

--- a/src/components/DpMultiselect/DpMultiselect.vue
+++ b/src/components/DpMultiselect/DpMultiselect.vue
@@ -39,7 +39,8 @@
     @remove="newVal => $emit('remove', newVal)"
     @search-change="newVal => $emit('search-change', newVal)"
     @select="newVal => $emit('select', newVal)"
-    @tag="newVal => $emit('tag', newVal)">
+    @tag="newVal => $emit('tag', newVal)"
+  >
     <template v-slot:noOptions>
       <slot name="noOptions">
         {{ translations.noEntriesAvailable }}
@@ -54,34 +55,40 @@
 
     <template
       v-for="slot in subSlots"
-      v-slot:[slot]="props">
+      v-slot:[slot]="props"
+    >
       <slot
         :props="props"
-        :name="slot" />
+        :name="slot"
+      />
     </template>
 
     <!-- put more slots here -->
 
     <template
       v-if="selectionControls"
-      v-slot:beforeList="props">
+      v-slot:beforeList="props"
+    >
       <slot
         name="beforeList"
-        :props="props">
+        :props="props"
+      >
         <div class="border-bottom">
           <button
             class="btn--blank weight--bold u-ph-0_5 u-pv-0_25"
             :disabled="value.length === options.length"
             type="button"
             @click="$emit('selectAll')"
-            v-text="translations.selectAll" />
+            v-text="translations.selectAll"
+          />
 
           <button
             class="btn--blank weight--bold u-ph-0_5 u-pv-0_25"
             :disabled="value.length === 0"
             type="button"
             @click="$emit('deselectAll')"
-            v-text="translations.deselectAll" />
+            v-text="translations.deselectAll"
+          />
         </div>
       </slot>
     </template>
@@ -97,11 +104,11 @@ export default {
   name: 'DpMultiselect',
 
   components: {
-    VueMultiselect
+    VueMultiselect,
   },
 
   directives: {
-    dpValidateMultiselectDirective
+    dpValidateMultiselectDirective,
   },
 
   props: {
@@ -114,7 +121,7 @@ export default {
     allowEmpty: {
       type: Boolean,
       required: false,
-      default: true
+      default: true,
     },
 
     /**
@@ -124,7 +131,7 @@ export default {
     clearOnSelect: {
       type: Boolean,
       required: false,
-      default: true
+      default: true,
     },
 
     /**
@@ -134,7 +141,7 @@ export default {
     closeOnSelect: {
       type: Boolean,
       required: false,
-      default: true
+      default: true,
     },
 
     /**
@@ -145,7 +152,7 @@ export default {
     customLabel: {
       type: Function,
       required: false,
-      default: undefined
+      default: undefined,
     },
 
     /**
@@ -154,7 +161,7 @@ export default {
     dataCy: {
       type: String,
       required: false,
-      default: 'multiselect'
+      default: 'multiselect',
     },
 
     /**
@@ -163,7 +170,7 @@ export default {
     dataDpValidateErrorFieldname: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -172,7 +179,7 @@ export default {
     deselectLabel: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -181,7 +188,7 @@ export default {
     deselectGroupLabel: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -190,7 +197,7 @@ export default {
     disabled: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -200,7 +207,7 @@ export default {
     groupLabel: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -210,7 +217,7 @@ export default {
     groupSelect: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -220,7 +227,7 @@ export default {
     groupValues: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -229,7 +236,7 @@ export default {
     id: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -240,7 +247,7 @@ export default {
     label: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -249,7 +256,7 @@ export default {
     loading: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -258,7 +265,7 @@ export default {
     maxHeight: {
       type: Number,
       required: false,
-      default: 300
+      default: 300,
     },
 
     /**
@@ -268,7 +275,7 @@ export default {
     multiple: {
       required: false,
       type: Boolean,
-      default: false
+      default: false,
     },
 
     /**
@@ -277,7 +284,7 @@ export default {
     name: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -287,7 +294,7 @@ export default {
     openDirection: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -296,7 +303,7 @@ export default {
      */
     options: {
       type: Array,
-      required: true
+      required: true,
     },
 
     /**
@@ -305,7 +312,7 @@ export default {
     placeholder: {
       type: String,
       required: false,
-      default: de.choose
+      default: de.choose,
     },
 
     /**
@@ -314,7 +321,7 @@ export default {
     required: {
       required: false,
       type: Boolean,
-      default: false
+      default: false,
     },
 
     /**
@@ -323,7 +330,7 @@ export default {
     searchable: {
       required: false,
       type: Boolean,
-      default: true
+      default: true,
     },
 
     /**
@@ -334,7 +341,7 @@ export default {
     selectionControls: {
       required: false,
       type: Boolean,
-      default: false
+      default: false,
     },
 
     /**
@@ -343,7 +350,7 @@ export default {
     selectGroupLabel: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -352,7 +359,7 @@ export default {
     selectLabel: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -361,7 +368,7 @@ export default {
     selectedLabel: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -371,7 +378,7 @@ export default {
     subSlots: {
       type: Array,
       required: false,
-      default: () => ['option', 'tag']
+      default: () => ['option', 'tag'],
     },
 
     /**
@@ -380,7 +387,7 @@ export default {
     tagPlaceholder: {
       type: String,
       required: false,
-      default: de.tag.create
+      default: de.tag.create,
     },
 
     /**
@@ -392,7 +399,7 @@ export default {
     trackBy: {
       type: [String, null],
       required: false,
-      default: null
+      default: null,
     },
 
     /**
@@ -403,8 +410,8 @@ export default {
     value: {
       type: [String, Number, Array, Object],
       required: false,
-      default: ''
-    }
+      default: '',
+    },
   },
 
   emits: [
@@ -416,7 +423,7 @@ export default {
     'select',
     'selectAll',
     'tag',
-    'deselectAll'
+    'deselectAll',
   ],
 
   data () {
@@ -425,9 +432,9 @@ export default {
         autocompleteNoResults: de.autocompleteNoResults,
         deselectAll: de.operations.deselect.all,
         noEntriesAvailable: de.noEntriesAvailable,
-        selectAll: de.operations.select.all
-      }
+        selectAll: de.operations.select.all,
+      },
     }
-  }
+  },
 }
 </script>

--- a/src/components/DpMultistepNav/DpMultistepNav.vue
+++ b/src/components/DpMultistepNav/DpMultistepNav.vue
@@ -12,12 +12,14 @@
         idx === activeStep ? prefixClass('is-active') : '',
         idx > activeStep ? prefixClass('is-disabled') : ''
       ]"
-      @click="changeStep(idx)">
+      @click="changeStep(idx)"
+    >
       <span>
         <i
           v-if="step.icon"
           aria-hidden="true"
-          :class="[prefixClass(step.icon), prefixClass('fa u-mr-0_25')]" />
+          :class="[prefixClass(step.icon), prefixClass('fa u-mr-0_25')]"
+        />
         {{ step.label }}
       </span>
     </button>
@@ -36,19 +38,19 @@ export default {
     activeStep: {
       type: Number,
       required: false,
-      default: 0
+      default: 0,
     },
 
     dataCy: {
       type: String,
       required: false,
-      default: 'multistepNav'
+      default: 'multistepNav',
     },
 
     steps: {
       type: Array,
-      required: true
-    }
+      required: true,
+    },
   },
 
   emits: ['change-step'],
@@ -56,7 +58,7 @@ export default {
   methods: {
     changeStep (val) {
       this.$emit('change-step', val)
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpNotification/DpNotification.vue
+++ b/src/components/DpNotification/DpNotification.vue
@@ -1,21 +1,25 @@
 <template>
   <div
-    :class="prefixClass('c-notify__message ' + messageClass)">
+    :class="prefixClass('c-notify__message ' + messageClass)"
+  >
     <i
       :class="prefixClass('c-notify__icon c-notify__closer fa fa-times-circle cursor-pointer')"
       aria-hidden="true"
-      @click.stop.prevent="hide" />
+      @click.stop.prevent="hide"
+    />
 
     <div :class="prefixClass('flow-root')">
       <i
-        :class="prefixClass('c-notify__icon fa u-mt-0_125 u-mr-0_25 float-left ' + messageIcon)" />
+        :class="prefixClass('c-notify__icon fa u-mt-0_125 u-mr-0_25 float-left ' + messageIcon)"
+      />
       <div :class="prefixClass('u-ml')">
         {{ message.text }}
         <a
           v-if="message.linkUrl"
           :class="prefixClass('c-notify__link u-mt-0_25')"
           :href="message.linkUrl"
-          data-cy="messageLink">
+          data-cy="messageLink"
+        >
           {{ message.linkText || message.linkUrl }}
         </a>
       </div>
@@ -37,13 +41,13 @@ export default {
      */
     message: {
       type: Object,
-      required: true
+      required: true,
     },
     hideTimer: {
       type: Number,
       required: false,
-      default: 20000
-    }
+      default: 20000,
+    },
   },
 
   data () {
@@ -54,8 +58,8 @@ export default {
         warning: 'fa-exclamation-triangle',
         error: 'fa-exclamation-circle',
         confirm: 'fa-check-circle',
-        dev: 'fa-info-circle'
-      }
+        dev: 'fa-info-circle',
+      },
     }
   },
 
@@ -66,13 +70,13 @@ export default {
 
     messageIcon () {
       return this.icons[this.message.type]
-    }
+    },
   },
 
   methods: {
     hide () {
       this.$emit('dp-notify-remove', this.message)
-    }
+    },
   },
 
   mounted () {
@@ -81,6 +85,6 @@ export default {
         this.hide()
       }, this.hideTimer)
     }
-  }
+  },
 }
 </script>

--- a/src/components/DpObscure/DpObscure.vue
+++ b/src/components/DpObscure/DpObscure.vue
@@ -1,7 +1,8 @@
 <template>
   <span
     class="u-obscure"
-    :title="title">
+    :title="title"
+  >
     <slot />
   </span>
 </template>
@@ -14,8 +15,8 @@ export default {
 
   data () {
     return {
-      title: de.obscure.title
+      title: de.obscure.title,
     }
-  }
+  },
 }
 </script>

--- a/src/components/DpPager/DpPager.vue
+++ b/src/components/DpPager/DpPager.vue
@@ -2,7 +2,8 @@
   <div class="c-pager__dropdown">
     <label
       class="c-pager__dropdown-label u-m-0 u-p-0 weight--normal flex items-center gap-1"
-      :aria-label="translations.selectNumberOfItems">
+      :aria-label="translations.selectNumberOfItems"
+    >
       <dp-sliding-pagination
         v-if="totalItems > Math.min(...limits)"
         class="inline-block"
@@ -11,17 +12,20 @@
         :sliding-ending-size="1"
         :sliding-window-size="1"
         :total="totalPages || 1"
-        @page-change="handlePageChange" />
+        @page-change="handlePageChange"
+      />
       <div
         v-if="totalItems > Math.min(...limits)"
-        class="inline-block">
+        class="inline-block"
+      >
         <dp-multiselect
           v-model="itemsPerPage"
           class="inline-block"
           :options="filteredLimits"
           :searchable="false"
           selected-label=""
-          @select="handleSizeChange" />
+          @select="handleSizeChange"
+        />
       </div>
       <span v-else>{{ totalItems }}</span>
       <span aria-hidden="true">
@@ -43,39 +47,39 @@ export default {
 
   components: {
     DpSlidingPagination,
-    DpMultiselect
+    DpMultiselect,
   },
 
   props: {
     currentPage: {
       required: false,
       type: Number,
-      default: 1
+      default: 1,
     },
 
     totalItems: {
       required: false,
       type: Number,
-      default: 1
+      default: 1,
     },
 
     totalPages: {
       required: false,
       type: Number,
-      default: 1
+      default: 1,
     },
 
     perPage: {
       required: false,
       type: Number,
-      default: 1
+      default: 1,
     },
 
     limits: {
       required: false,
       type: Array,
-      default: () => []
-    }
+      default: () => [],
+    },
   },
 
   emits: ['page-change', 'size-change'],
@@ -88,9 +92,9 @@ export default {
         multipleItems: de.pager.multipleItems,
         selectNumberOfItems: de.pager.selectNumberOfItems({
           results: this.totalItems,
-          items: de.pager.multipleItems
-        })
-      }
+          items: de.pager.multipleItems,
+        }),
+      },
     }
   },
 
@@ -108,7 +112,7 @@ export default {
       filtered.sort((a, b) => a - b)
 
       return filtered
-    }
+    },
   },
 
   methods: {
@@ -118,7 +122,7 @@ export default {
 
     handleSizeChange (selectedOption) {
       this.$emit('size-change', parseInt(selectedOption))
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpProgressBar/DpProgressBar.vue
+++ b/src/components/DpProgressBar/DpProgressBar.vue
@@ -16,7 +16,8 @@
       <div class="bg-color--grey-light-2">
         <div
           :style="style"
-          class="mb-1 c-progress-bar__line" />
+          class="mb-1 c-progress-bar__line"
+        />
       </div>
       <span v-if="showPercentage">
         {{ percentage }}%
@@ -33,32 +34,32 @@ export default {
     showPercentage: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     indeterminate: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     label: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     percentage: {
       type: Number,
       required: false,
-      default: 0
-    }
+      default: 0,
+    },
   },
 
   computed: {
     style () {
       return 'width: ' + this.percentage + '%;'
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpRadio/DpRadio.vue
+++ b/src/components/DpRadio/DpRadio.vue
@@ -13,7 +13,8 @@
       :value="value"
       :data-cy="dataCy !== '' ? dataCy : null"
       :data-dp-validate-error-fieldname="dataDpValidateErrorFieldname || label.text || null"
-      @change="$emit('change', $event.target.checked)"><!--
+      @change="$emit('change', $event.target.checked)"
+    ><!--
  --><dp-label
       v-if="label.text"
       :class="prefixClass('o-form__label')"
@@ -23,7 +24,8 @@
         for: id,
         required: required,
         ...label,
-      }" />
+      }"
+/>
   </div>
 </template>
 
@@ -35,56 +37,56 @@ export default {
   name: 'DpRadio',
 
   components: {
-    DpLabel
+    DpLabel,
   },
 
   mixins: [prefixClassMixin],
 
   model: {
     prop: 'checked',
-    event: 'change'
+    event: 'change',
   },
 
   props: {
     bold: {
       type: Boolean,
       required: false,
-      default: true
+      default: true,
     },
 
     checked: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     dataCy: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     dataDpValidateErrorFieldname: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     disabled: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     hint: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     id: {
       type: String,
-      required: true
+      required: true,
     },
 
     label: {
@@ -92,13 +94,13 @@ export default {
       default: (): Record<string, any> => ({}),
       validator: (prop: Record<string, any>): boolean => {
         return Object.keys(prop).every((key: string) => ['bold', 'hint', 'text'].includes(key))
-      }
+      },
     },
 
     name: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -108,20 +110,20 @@ export default {
     readonly: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     required: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     value: {
       type: String,
       required: false,
-      default: '1'
-    }
-  }
+      default: '1',
+    },
+  },
 }
 </script>

--- a/src/components/DpResettableInput/DpResettableInput.vue
+++ b/src/components/DpResettableInput/DpResettableInput.vue
@@ -12,7 +12,8 @@
       @blur="$emit('blur', currentValue)"
       @input="onInput"
       @enter="$emit('enter', currentValue)"
-      @focus="$emit('focus')" />
+      @focus="$emit('focus')"
+    />
     <span class="space-x-0.5">
       <button
         v-if="!inputAttributes.disabled"
@@ -20,10 +21,12 @@
         :class="buttonClass"
         data-cy="resetButton"
         :disabled="currentValue === defaultValue"
-        @click="resetValue">
+        @click="resetValue"
+      >
         <dp-icon
           icon="xmark"
-          :size="iconSize" />
+          :size="iconSize"
+        />
       </button>
       <slot />
     </span>
@@ -40,7 +43,7 @@ export default {
 
   components: {
     DpIcon,
-    DpInput
+    DpInput,
   },
 
   props: {
@@ -51,42 +54,42 @@ export default {
       type: String,
       required: false,
       default: 'medium',
-      validator: (prop) => ['small', 'medium'].includes(prop)
+      validator: (prop) => ['small', 'medium'].includes(prop),
     },
 
     dataCy: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     defaultValue: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     id: {
       type: String,
-      required: true
+      required: true,
     },
 
     inputAttributes: {
       type: Object,
       required: false,
-      default: () => ({})
+      default: () => ({}),
     },
 
     pattern: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     required: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -101,21 +104,21 @@ export default {
       type: String,
       required: false,
       default: 'full',
-      validator: (prop) => ['full', 'left', 'right'].includes(prop)
+      validator: (prop) => ['full', 'left', 'right'].includes(prop),
     },
 
     value: {
       type: String,
       required: false,
-      default: ''
-    }
+      default: '',
+    },
   },
 
   emits: ['blur', 'enter', 'focus'],
 
   data () {
     return {
-      currentValue: this.value
+      currentValue: this.value,
     }
   },
 
@@ -128,7 +131,7 @@ export default {
         if (node.type === Fragment) {
           return node.children && node.children.some(child =>
             child.type !== Comment &&
-            (child.type !== Text || (child.children && child.children.trim()))
+            (child.type !== Text || (child.children && child.children.trim())),
           )
         }
         return true
@@ -140,13 +143,13 @@ export default {
 
     iconSize () {
       return this.buttonVariant
-    }
+    },
   },
 
   watch: {
     value: function () {
       this.currentValue = this.value
-    }
+    },
   },
 
   methods: {
@@ -157,7 +160,7 @@ export default {
 
     resetValue () {
       this.$emit('reset')
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpSearchField/DpSearchField.vue
+++ b/src/components/DpSearchField/DpSearchField.vue
@@ -1,7 +1,8 @@
 <template>
   <span
     class="inline-flex relative"
-    :class="{ 'w-full': inputWidth === '' }">
+    :class="{ 'w-full': inputWidth === '' }"
+  >
     <dp-resettable-input
       id="searchField"
       v-model="searchTerm"
@@ -10,7 +11,8 @@
       :input-attributes="{ placeholder: translations.search, type: 'search' }"
       rounded="left"
       @reset="handleReset"
-      @enter="handleSearch">
+      @enter="handleSearch"
+    >
       <!-- Slot for additional buttons -->
       <slot />
     </dp-resettable-input>
@@ -22,7 +24,8 @@
       icon="search"
       :text="translations.searching"
       variant="outline"
-      @click="handleSearch" />
+      @click="handleSearch"
+    />
   </span>
 </template>
 
@@ -36,14 +39,14 @@ export default {
 
   components: {
     DpButton,
-    DpResettableInput
+    DpResettableInput,
   },
 
   props: {
     initSearchTerm: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -52,29 +55,29 @@ export default {
      */
     inputWidth: {
       type: String,
-      default: ''
+      default: '',
     },
 
     placeholder: {
       type: String,
       required: false,
-      default: 'search'
-    }
+      default: 'search',
+    },
   },
 
   emits: [
     'search',
-    'reset'
+    'reset',
   ],
 
   data () {
     return {
       translations: {
         search: de.search.text,
-        searching: de.search.searching
+        searching: de.search.searching,
       },
       searchTerm: this.initSearchTerm,
-      searchTermApplied: ''
+      searchTermApplied: '',
     }
   },
 
@@ -83,7 +86,7 @@ export default {
       const classes = 'inline-block rounded-r-none focus-within:z-above-zero'
 
       return this.inputWidth !== '' ? `${classes} ${this.inputWidth}` : classes
-    }
+    },
   },
 
   methods: {
@@ -108,11 +111,11 @@ export default {
 
       this.searchTermApplied = this.searchTerm
       this.$emit('search', this.searchTerm)
-    }
+    },
   },
 
   mounted () {
     this.searchTermApplied = this.searchTerm
-  }
+  },
 }
 </script>

--- a/src/components/DpSelect/DpSelect.vue
+++ b/src/components/DpSelect/DpSelect.vue
@@ -7,7 +7,8 @@
         for: nameOrId,
         required: required
       }"
-      class="mb-0.5" /><!--
+      class="mb-0.5"
+    /><!--
  --><select
       :id="nameOrId"
       :data-cy="dataCy"
@@ -17,20 +18,23 @@
       class="o-form__control-select"
       :class="[disabled ? ' border border-input-disabled bg-surface-light cursor-default' : 'border border-input', classes]"
       :disabled="disabled"
-      @change="update">
+      @change="update"
+>
       <option
         v-if="showPlaceholder"
         data-id="placeholder"
         disabled
         value=""
-        :selected="selected === ''">
+        :selected="selected === ''"
+>
         {{ selectPlaceholder }}
       </option>
       <option
         v-for="(option, idx) in options"
         :key="idx"
         :selected="option.value === selected"
-        :value="option.value">
+        :value="option.value"
+>
         {{ option.label }}
       </option>
     </select>
@@ -46,7 +50,7 @@ export default {
   name: 'DpSelect',
 
   components: {
-    DpLabel
+    DpLabel,
   },
 
   mixins: [prefixClassMixin],
@@ -57,7 +61,7 @@ export default {
    */
   model: {
     prop: 'selected',
-    event: 'select'
+    event: 'select',
   },
 
   props: {
@@ -67,31 +71,31 @@ export default {
     classes: {
       type: [Array, String],
       required: false,
-      default: ''
+      default: '',
     },
 
     dataCy: {
       type: String,
       required: false,
-      default: 'selectElement'
+      default: 'selectElement',
     },
 
     dataDpValidateErrorFieldname: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     disabled: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     id: {
       type: String,
       required: false,
-      default: () => ''
+      default: () => '',
     },
 
     label: {
@@ -100,43 +104,43 @@ export default {
       default: () => ({}),
       validator: (prop) => {
         return Object.keys(prop).every(key => ['bold', 'hint', 'text', 'tooltip'].includes(key))
-      }
+      },
     },
 
     name: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     // Need label and value
     options: {
       required: true,
-      type: Array
+      type: Array,
     },
 
     required: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     showPlaceholder: {
       type: Boolean,
       required: false,
-      default: true
+      default: true,
     },
 
     selected: {
       type: String,
       required: false,
-      default: ''
-    }
+      default: '',
+    },
   },
 
   data () {
     return {
-      selectPlaceholder: de.operations.select.placeholder
+      selectPlaceholder: de.operations.select.placeholder,
     }
   },
 
@@ -147,13 +151,13 @@ export default {
        * it should not be required to specify it.
        */
       return this.id === '' ? this.name : this.id
-    }
+    },
   },
 
   methods: {
     update (event) {
       this.$emit('select', event.target.value)
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpSkeletonBox/DpSkeletonBox.vue
+++ b/src/components/DpSkeletonBox/DpSkeletonBox.vue
@@ -1,7 +1,8 @@
 <template>
   <span
     :style="{ height: height, width: width }"
-    class="c-skeleton-box" />
+    class="c-skeleton-box"
+  />
 </template>
 
 <script>
@@ -11,13 +12,13 @@ export default {
   props: {
     height: {
       type: String,
-      default: '1em'
+      default: '1em',
     },
 
     width: {
       type: String,
-      default: '100%'
-    }
-  }
+      default: '100%',
+    },
+  },
 }
 </script>

--- a/src/components/DpSlidebar/DpSlidebar.vue
+++ b/src/components/DpSlidebar/DpSlidebar.vue
@@ -1,20 +1,24 @@
 <template>
   <div
     class="c-slidebar u-pr-0"
-    data-slidebar="right">
+    data-slidebar="right"
+  >
     <div
       class="c-slidebar__container"
       data-slidebar-container=""
-      data-cy="sidebarModal">
+      data-cy="sidebarModal"
+    >
       <div class="u-ml-1_5">
         <button
           type="button"
           class="btn--blank o-link--default u-mt-0_5 u-n-ml u-mb"
           data-slidebar-hide=""
-          @click="$emit('close')">
+          @click="$emit('close')"
+        >
           <dp-icon
             icon="close"
-            size="large" />
+            size="large"
+          />
         </button>
         <slot />
       </div>
@@ -31,12 +35,12 @@ export default {
   name: 'DpSlidebar',
 
   components: {
-    DpIcon
+    DpIcon,
   },
 
   data () {
     return {
-      sideNav: {}
+      sideNav: {},
     }
   },
 
@@ -52,7 +56,7 @@ export default {
       if (hasOwnProp(this.sideNav, 'showSideNav')) {
         this.sideNav.showSideNav()
       }
-    }
+    },
   },
 
   mounted () {
@@ -66,6 +70,6 @@ export default {
     this.$root.$on('show-slidebar', () => {
       this.showSlideBar()
     })
-  }
+  },
 }
 </script>

--- a/src/components/DpSlidingPagination/DpSlidingPagination.vue
+++ b/src/components/DpSlidingPagination/DpSlidingPagination.vue
@@ -15,7 +15,8 @@
     }"
     :current="current"
     :total="total"
-    @page-change="pageChange" />
+    @page-change="pageChange"
+  />
 </template>
 
 <script>
@@ -27,19 +28,19 @@ export default {
   name: 'DpSlidingPagination',
 
   components: {
-    SlidingPagination
+    SlidingPagination,
   },
 
   props: {
     current: {
       type: Number,
-      required: true
+      required: true,
     },
 
     total: {
       type: Number,
-      required: true
-    }
+      required: true,
+    },
   },
 
   data () {
@@ -50,7 +51,7 @@ export default {
         pageNavigation: de.pager.pageNavigation,
         pagerPrevious: de.pager.previous,
         pagerNext: de.pager.next,
-      }
+      },
     }
   },
 
@@ -63,7 +64,7 @@ export default {
 
     prefixClass (classList) {
       return prefixClass(classList)
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpSplitButton/DpSplitButton.vue
+++ b/src/components/DpSplitButton/DpSplitButton.vue
@@ -1,11 +1,13 @@
 <template>
   <div
     v-on-click-outside="close"
-    class="c-splitbutton">
+    class="c-splitbutton"
+  >
     <slot>
       <button
         class="btn btn--primary"
-        type="button">
+        type="button"
+      >
         Primary Action Button
       </button>
     </slot><!--
@@ -18,7 +20,8 @@
       aria-haspopup="true"
       :aria-expanded="isOpen"
       @click="toggleDropdown"
-      @keyup.esc.prevent="isOpen ? isOpen = !isOpen : ''">
+      @keyup.esc.prevent="isOpen ? isOpen = !isOpen : ''"
+>
       <i class="fa fa-caret-down c-splitbutton__trigger-icon" />
       <span class="sr-only">{{ isOpen ? translations.close : translations.open }}</span>
     </button>
@@ -26,7 +29,8 @@
       v-if="hasDropdownContent"
       class="c-splitbutton__dropdown"
       role="menu"
-      :class="{ 'is-open': isOpen }">
+      :class="{ 'is-open': isOpen }"
+    >
       <slot name="dropdown">
         Dropdown Actions
       </slot>
@@ -42,7 +46,7 @@ export default {
   name: 'DpSplitButton',
 
   directives: {
-    onClickOutside: vOnClickOutside
+    onClickOutside: vOnClickOutside,
   },
 
   data () {
@@ -51,8 +55,8 @@ export default {
       hasDropdownContent: false,
       translations: {
         open: de.dropdown.open,
-        close: de.dropdown.close
-      }
+        close: de.dropdown.close,
+      },
     }
   },
 
@@ -63,11 +67,11 @@ export default {
 
     toggleDropdown () {
       this.isOpen = (this.isOpen === false)
-    }
+    },
   },
 
   mounted () {
     this.hasDropdownContent = (typeof this.$slots.dropdown !== 'undefined')
-  }
+  },
 }
 </script>

--- a/src/components/DpStickyElement/DpStickyElement.vue
+++ b/src/components/DpStickyElement/DpStickyElement.vue
@@ -1,7 +1,8 @@
 <template>
   <div
     :class="{ 'o-sticky--border': border, 'z-fixed': applyZIndex }"
-    class="o-sticky bg-color--white">
+    class="o-sticky bg-color--white"
+  >
     <slot />
   </div>
 </template>
@@ -19,7 +20,7 @@ export default {
     applyZIndex: {
       required: false,
       type: Boolean,
-      default: true
+      default: true,
     },
 
     /**
@@ -30,7 +31,7 @@ export default {
     border: {
       required: false,
       type: Boolean,
-      default: false
+      default: false,
     },
 
     /**
@@ -40,7 +41,7 @@ export default {
     context: {
       type: HTMLElement,
       required: false,
-      default: undefined
+      default: undefined,
     },
 
     /**
@@ -49,7 +50,7 @@ export default {
     direction: {
       required: false,
       type: String,
-      default: 'top'
+      default: 'top',
     },
 
     /**
@@ -58,7 +59,7 @@ export default {
     observeContext: {
       required: false,
       type: Boolean,
-      default: true
+      default: true,
     },
 
     /**
@@ -67,8 +68,8 @@ export default {
     offset: {
       required: false,
       type: Number,
-      default: 0
-    }
+      default: 0,
+    },
   },
 
   mounted () {
@@ -79,8 +80,8 @@ export default {
       this.direction,
       'palm',
       false,
-      this.observeContext
+      this.observeContext,
     )
-  }
+  },
 }
 </script>

--- a/src/components/DpTabs/DpTab.vue
+++ b/src/components/DpTabs/DpTab.vue
@@ -2,7 +2,8 @@
   <section
     v-show="isActive"
     :id="id"
-    role="tabpanel">
+    role="tabpanel"
+  >
     <slot />
   </section>
 </template>
@@ -14,12 +15,12 @@ export default {
   props: {
     id: {
       type: String,
-      required: true
+      required: true,
     },
 
     isActive: {
       type: Boolean,
-      default: false
+      default: false,
     },
 
     /**
@@ -28,7 +29,7 @@ export default {
      */
     label: {
       type: String,
-      required: true
+      required: true,
     },
 
     /**
@@ -37,8 +38,8 @@ export default {
     suffix: {
       type: String,
       required: false,
-      default: null
-    }
-  }
+      default: null,
+    },
+  },
 }
 </script>

--- a/src/components/DpTabs/DpTabs.vue
+++ b/src/components/DpTabs/DpTabs.vue
@@ -2,11 +2,13 @@
   <div>
     <ul
       class="flex space-inline-m list-style-none border--bottom"
-      role="tablist">
+      role="tablist"
+    >
       <li
         v-for="(tab, idx) in tabs"
         :key="`tab:${idx}`"
-        :class="{ 'is-active': activeTabId === tab.props.id }">
+        :class="{ 'is-active': activeTabId === tab.props.id }"
+      >
         <button
           role="tab"
           class="btn--blank o-link--default u-pb-0_5 border--bottom"
@@ -17,11 +19,13 @@
           :aria-selected="activeTabId === tab.props.id"
           :aria-controls="tab.props.id"
           :data-cy="tab.props.id"
-          @click.prevent="handleTabChange(tab.props.id)">
+          @click.prevent="handleTabChange(tab.props.id)"
+        >
           {{ tab.props.label }}
           <span
             v-if="tab.props.suffix"
-            v-cleanhtml="tab.props.suffix" />
+            v-cleanhtml="tab.props.suffix"
+          />
         </button>
       </li>
     </ul>
@@ -39,14 +43,14 @@ const props = defineProps( {
   activeId: {
     type: String,
     required: false,
-    default: null
+    default: null,
   },
 
   tabSize: {
     type: String,
     required: false,
     default: 'large',
-    validator: (prop) => ['medium', 'large'].includes(prop)
+    validator: (prop) => ['medium', 'large'].includes(prop),
   },
 
   /**
@@ -56,8 +60,8 @@ const props = defineProps( {
   useUrlFragment: {
     type: Boolean,
     required: false,
-    default: false
-  }
+    default: false,
+  },
 })
 
 const emit = defineEmits(['change'])

--- a/src/components/DpTextArea/DpTextArea.vue
+++ b/src/components/DpTextArea/DpTextArea.vue
@@ -3,7 +3,8 @@
     <dp-label
       v-if="label !== ''"
       v-bind="labelProps"
-      class="mb-0.5" /><!--
+      class="mb-0.5"
+    /><!--
  --><textarea
       v-bind="allowedAttributes"
       :id="id"
@@ -17,7 +18,8 @@
       :disabled="disabled"
       :maxlength="maxlength"
       :required="required"
-      @input="$emit('input', currentValue)" />
+      @input="$emit('input', currentValue)"
+/>
   </div>
 </template>
 
@@ -32,7 +34,7 @@ export default {
   components: {
     DpLabel: defineAsyncComponent(async () => {
       return await import('../DpLabel/DpLabel')
-    })
+    }),
   },
 
   props: {
@@ -41,7 +43,7 @@ export default {
     dataDpValidateErrorFieldname: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -50,19 +52,19 @@ export default {
     dataDpValidateIf: {
       type: [Boolean, String],
       required: false,
-      default: false
+      default: false,
     },
 
     dataCy: {
       type: String,
       required: false,
-      default: 'textAreaElement'
+      default: 'textAreaElement',
     },
 
     disabled: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -71,25 +73,25 @@ export default {
     growToParent: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     hint: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     id: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     label: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     maxlength: length,
@@ -97,7 +99,7 @@ export default {
     name: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -106,25 +108,25 @@ export default {
     reducedHeight: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     required: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     value: {
       type: String,
       required: false,
-      default: ''
-    }
+      default: '',
+    },
   },
 
   data () {
     return {
-      currentValue: this.value
+      currentValue: this.value,
     }
   },
 
@@ -146,15 +148,15 @@ export default {
         hint: this.maxlength ? [this.hint, maxlengthHint(this.currentValue.length, this.maxlength)] : this.hint,
         required: this.required,
         text: this.label,
-        tooltip: this.tooltip
+        tooltip: this.tooltip,
       }
-    }
+    },
   },
 
   watch: {
     value () {
       this.currentValue = this.value
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpTimePicker/DpTimePicker.vue
+++ b/src/components/DpTimePicker/DpTimePicker.vue
@@ -3,11 +3,13 @@
     v-on-click-outside="closeFlyout"
     class="c-timepicker inline-block"
     @keydown.esc="closeFlyout"
-    @keydown.enter="e => handleEnter(e)">
+    @keydown.enter="e => handleEnter(e)"
+  >
     <dp-label
       v-if="label !== ''"
       for="timeInput"
-      :text="label" />
+      :text="label"
+    />
     <dp-resettable-input
       v-if="!isMobileDevice"
       :id="`timeInput:${id}`"
@@ -23,7 +25,8 @@
       @enter="val => handleEnter(val)"
       @focus="handleFocus"
       @blur="handleBlur"
-      @input="val => handleInput(val)" />
+      @input="val => handleInput(val)"
+    />
     <dp-input
       v-else
       :id="`timeInput:${id}`"
@@ -33,43 +36,50 @@
       pattern="([01]?[0-9]|2[0-3]):[0-5][0-9]"
       :value="currentTime"
       autocomplete="off"
-      @input="val => handleInput(val)" />
+      @input="val => handleInput(val)"
+    />
 
     <div
       ref="flyout"
       class="flex items-start justify-evenly c-timepicker__flyout font-size-small"
       :class="{ 'hidden': !showFlyout }"
-      tabindex="0">
+      tabindex="0"
+    >
       <ul class="u-m-0_25 u-mr-0 u-pr-0_25 overflow-y-scroll h-9">
         <li
           v-for="hour in availableHours"
           :key="`${id}:hour:${hour}`"
           class="c-timepicker__flyout-item"
-          :class="{ 'is-selected': currentHour === hour }">
+          :class="{ 'is-selected': currentHour === hour }"
+        >
           <button
             :id="`${id}:hour:${hour}`"
             class="btn--blank u-ph-0_125 u-pv-0_125"
             tabindex="0"
             :value="hour"
-            @click.prevent="handleInput(hour, 'hour')">
+            @click.prevent="handleInput(hour, 'hour')"
+          >
             {{ hour }}
           </button>
         </li>
       </ul>
       <ul
         class="u-m-0_25 h-9"
-        :class="minutes.length > 5 ? 'overflow-y-scroll' : ''">
+        :class="minutes.length > 5 ? 'overflow-y-scroll' : ''"
+      >
         <li
           v-for="minute in availableMinutes"
           :key="`${id}:minute:${minute}`"
           class="c-timepicker__flyout-item"
-          :class="{ 'is-selected': currentMinutes === minute }">
+          :class="{ 'is-selected': currentMinutes === minute }"
+        >
           <button
             :id="`${id}:minute:${minute}`"
             tabindex="0"
             class="btn--blank u-ph-0_125 u-pv-0_125"
             :value="minute"
-            @click.prevent="handleInput(minute, 'minute')">
+            @click.prevent="handleInput(minute, 'minute')"
+          >
             {{ minute }}
           </button>
         </li>
@@ -93,41 +103,41 @@ export default {
   components: {
     DpInput,
     DpLabel,
-    DpResettableInput
+    DpResettableInput,
   },
 
   directives: {
-    onClickOutside: vOnClickOutside
+    onClickOutside: vOnClickOutside,
   },
 
   props: {
     dataCy: {
       type: String,
       required: false,
-      default: 'timePicker'
+      default: 'timePicker',
     },
 
     disabled: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     id: {
       type: String,
-      required: true
+      required: true,
     },
 
     label: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     minuteSteps: {
       type: Number,
       required: false,
-      default: 15
+      default: 15,
     },
 
     /**
@@ -136,22 +146,22 @@ export default {
     minValue: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     // Expects ISO datetime
     value: {
       type: String,
       required: false,
-      default: DEFAULT_TIME
-    }
+      default: DEFAULT_TIME,
+    },
   },
 
   data: () => ({
     currentHour: '00',
     currentMinutes: '00',
     isInputFocused: false,
-    showFlyout: false
+    showFlyout: false,
   }),
 
   computed: {
@@ -213,7 +223,7 @@ export default {
         return h.toString().padStart(2, '0')
       })
       return minutes
-    }
+    },
   },
 
   watch: {
@@ -236,7 +246,7 @@ export default {
 
     value () {
       this.updateTime(this.value)
-    }
+    },
   },
 
   methods: {
@@ -364,7 +374,7 @@ export default {
 
       this.setHour(hour)
       this.setMinutes(minutes)
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpToggle/DpToggle.vue
+++ b/src/components/DpToggle/DpToggle.vue
@@ -6,16 +6,20 @@
     :aria-disabled="disabled ? true : null"
     tabindex="0"
     @click="toggle"
-    @keydown.space.prevent="toggle">
+    @keydown.space.prevent="toggle"
+  >
     <div
       v-show="disabled"
-      class="toggle-disabled" />
+      class="toggle-disabled"
+    />
     <span
       class="toggle-background"
-      :style="backgroundStyles" />
+      :style="backgroundStyles"
+    />
     <span
       class="toggle-indicator"
-      :style="indicatorStyles" />
+      :style="indicatorStyles"
+    />
   </span>
 </template>
 
@@ -28,26 +32,26 @@ export default {
     value: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     disabled: {
       type: Boolean,
       required: false,
-      default: false
-    }
+      default: false,
+    },
   },
 
   computed: {
     backgroundStyles () {
       return {
-        backgroundColor: this.value ? '#3490dc' : '#dae1e7'
+        backgroundColor: this.value ? '#3490dc' : '#dae1e7',
       }
     },
 
     indicatorStyles () {
       return { transform: this.value ? 'translateX(1rem)' : 'translateX(0)' }
-    }
+    },
   },
 
   methods: {
@@ -55,7 +59,7 @@ export default {
       if (this.disabled === false) {
         this.$emit('input', !this.value)
       }
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpTooltip/DpTooltip.vue
+++ b/src/components/DpTooltip/DpTooltip.vue
@@ -1,7 +1,8 @@
 <template>
   <component
     :is="nodeType"
-    class="inline-block">
+    class="inline-block"
+  >
     <slot />
   </component>
 </template>
@@ -14,36 +15,36 @@ export default {
   name: 'DpTooltip',
 
   directives: {
-    cleanhtml: CleanHtml
+    cleanhtml: CleanHtml,
   },
 
   props: {
     container: {
       type: String,
-      required: false
+      required: false,
     },
 
     placement: {
       type: String,
       required: false,
-      default: 'top'
+      default: 'top',
     },
 
     nodeType: {
       type: String,
       required: false,
-      default: 'div'
+      default: 'div',
     },
 
     text: {
       type: String,
-      required: true
-    }
+      required: true,
+    },
   },
 
   data () {
     return {
-      tooltipHook: null
+      tooltipHook: null,
     }
   },
 
@@ -64,6 +65,6 @@ export default {
 
   beforeUnmount () {
     destroyTooltip(this.tooltipHook)
-  }
+  },
 }
 </script>

--- a/src/components/DpTooltip/utils/tooltip.js
+++ b/src/components/DpTooltip/utils/tooltip.js
@@ -45,7 +45,7 @@ const initTooltip = (el, value, options) => {
     id,
     el,
     options,
-    zIndex
+    zIndex,
   )
   handleRemoveTooltip = () => deleteTooltip(document.getElementById(el.getAttribute('aria-describedby')))
 
@@ -81,15 +81,15 @@ const createTooltip = async (id, wrapperEl, { place = 'top', container = 'body',
         offset(12),
         flip(),
         shift({ padding: 8 }),
-        arrow({ element: arrowEl })
-      ]
-    }
+        arrow({ element: arrowEl }),
+      ],
+    },
   )
 
   Object.assign(tooltipEl.style, {
     left: `${x}px`,
     top: `${y}px`,
-    zIndex: Number(zIndex) + 1
+    zIndex: Number(zIndex) + 1,
   })
 
   /*
@@ -102,7 +102,7 @@ const createTooltip = async (id, wrapperEl, { place = 'top', container = 'body',
     top: 'bottom',
     right: 'left',
     bottom: 'top',
-    left: 'right'
+    left: 'right',
   }[placement.split('-')[0]]
 
   Object.assign(arrowEl.style, {
@@ -110,7 +110,7 @@ const createTooltip = async (id, wrapperEl, { place = 'top', container = 'body',
     top: arrowY ? `${arrowY}px` : '',
     bottom: '',
     right: '',
-    [opposedSide]: (opposedSide === 'top' || opposedSide === 'bottom') ? '0px' : '-6px' // Always sets the arrow to the correct side.
+    [opposedSide]: (opposedSide === 'top' || opposedSide === 'bottom') ? '0px' : '-6px', // Always sets the arrow to the correct side.
   })
 }
 

--- a/src/components/DpTransitionExpand/DpTransitionExpand.vue
+++ b/src/components/DpTransitionExpand/DpTransitionExpand.vue
@@ -52,15 +52,15 @@ export default {
         requestAnimationFrame(() => {
           element.style.height = 0
         })
-      }
+      },
     }
 
     return h(
       Transition,
       data,
-      () => this.$slots.default ? this.$slots.default() : null
+      () => this.$slots.default ? this.$slots.default() : null,
     )
-  }
+  },
 }
 </script>
 

--- a/src/components/DpTreeList/DpTreeList.vue
+++ b/src/components/DpTreeList/DpTreeList.vue
@@ -1,19 +1,22 @@
 <template>
   <div
     class="c-treelist"
-    :class="{ 'is-dragging': dragging }">
+    :class="{ 'is-dragging': dragging }"
+  >
     <!-- Header -->
     <div
       ref="header"
       class="c-treelist__header o-sticky line-height--2"
-      :class="{ 'has-checkbox': checkAll }">
+      :class="{ 'has-checkbox': checkAll }"
+    >
       <div class="flex bg-color--white">
         <dp-tree-list-checkbox
           v-if="checkAll"
           v-model="allElementsSelected"
           name="checkAll"
           check-all
-          :style="checkboxIndentationStyle" />
+          :style="checkboxIndentationStyle"
+        />
         <div class="grow color--grey">
           <!--
             @slot Content displayed at the top of the tree list. Typically used for column headers or global actions.
@@ -26,7 +29,8 @@
           data-cy="treeListNodeToggle"
           :value="allElementsExpanded"
           toggle-all
-          @input="toggleAll" />
+          @input="toggleAll"
+        />
       </div>
     </div>
 
@@ -43,7 +47,8 @@
       :handle-drag="handleDrag"
       :is-draggable="draggable ? draggable : null"
       :on-move="onMove"
-      :opts="opts.draggable">
+      :opts="opts.draggable"
+    >
       <dp-tree-list-node
         v-for="(node, idx) in optimizedTreeData"
         :ref="`node_${node.id}`"
@@ -64,16 +69,19 @@
         @end="handleDrag('end')"
         @node-selected="handleNodeSelectionChanged"
         @start="handleDrag('start')"
-        @tree:change="bubbleChangeEvent">
+        @tree:change="bubbleChangeEvent"
+      >
         <template
           v-for="slot in Object.keys($slots)"
-          v-slot:[slot]="scope">
+          v-slot:[slot]="scope"
+        >
           <!--
             @slot branch: Template for rendering branch nodes. Receives props: nodeElement, nodeChildren, nodeId, parentId. leaf: Template for rendering leaf nodes. Receives props: nodeElement, nodeId, parentId.
           -->
           <slot
             :name="slot"
-            v-bind="scope" />
+            v-bind="scope"
+          />
         </template>
       </dp-tree-list-node>
     </component>
@@ -82,7 +90,8 @@
     <div
       v-if="$slots.footer"
       ref="footer"
-      class="c-treelist__footer o-sticky">
+      class="c-treelist__footer o-sticky"
+    >
       <div class="u-p-0_5 bg-color--white">
         <!--
           @slot Content displayed at the bottom of the tree list. Useful for summary information or action buttons.
@@ -110,7 +119,7 @@ export default {
     DpDraggable,
     DpTreeListCheckbox,
     DpTreeListNode,
-    DpTreeListToggle
+    DpTreeListToggle,
   },
 
   props: {
@@ -119,7 +128,7 @@ export default {
      */
     branchIdentifier: {
       type: Function,
-      required: true
+      required: true,
     },
 
     /**
@@ -128,7 +137,7 @@ export default {
     draggable: {
       type: Boolean,
       required: false,
-      default: true
+      default: true,
     },
 
     /**
@@ -138,7 +147,7 @@ export default {
     onMove: {
       type: Function,
       required: false,
-      default: () => true
+      default: () => true,
     },
 
     /**
@@ -147,7 +156,7 @@ export default {
     options: {
       type: Object,
       required: false,
-      default: () => ({})
+      default: () => ({}),
     },
 
     /**
@@ -155,14 +164,14 @@ export default {
      */
     treeData: {
       type: Array,
-      required: true
-    }
+      required: true,
+    },
   },
 
   emits: [
     'tree:change',
     'draggable:change',
-    'node-selection-change'
+    'node-selection-change',
   ],
 
   data () {
@@ -178,7 +187,7 @@ export default {
       opts: {},
       selectionManager: null,
       optimizedTreeData: [],
-      updateScheduled: false
+      updateScheduled: false,
     }
   },
 
@@ -208,7 +217,7 @@ export default {
          * @type {Event}
          */
         this.$emit('tree:change', payload)
-      }
+      },
     },
 
     allElementsSelected: {
@@ -229,8 +238,8 @@ export default {
         const selectedNodes = this.selectionManager.getSelectedNodes()
         const filteredSelections = this.filterSelectableNodes(selectedNodes)
         this.$emit('node-selection-change', filteredSelections)
-      }
-    }
+      },
+    },
   },
 
   watch: {
@@ -239,8 +248,8 @@ export default {
         this.rebuildIndexesAndUpdateTree(newData)
       },
       immediate: true,
-      deep: false // Only watch array reference changes for performance
-    }
+      deep: false, // Only watch array reference changes for performance
+    },
   },
 
   methods: {
@@ -336,7 +345,7 @@ export default {
         const payload = {
           elementId: evt.item.id,
           newIndex: newIndex,
-          parentId: nodeId
+          parentId: nodeId,
         }
 
         this.$emit('draggable:change', payload)
@@ -369,7 +378,7 @@ export default {
             header,
             this.$refs.treeList.$el,
             0,
-            'top'
+            'top',
           )
         }
 
@@ -380,7 +389,7 @@ export default {
               footer,
               this.$refs.treeList.$el,
               0,
-              'bottom'
+              'bottom',
             )
           }
         }
@@ -399,7 +408,7 @@ export default {
         this.allElementsSelected = false
         this.$emit('node-selection-change', [])
       }
-    }
+    },
   },
 
   mounted () {
@@ -418,20 +427,20 @@ export default {
          */
         handle: '.c-treelist__drag-handle',
         ghostClass: 'c-treelist__node-ghost',
-        chosenClass: 'c-treelist__node-chosen'
+        chosenClass: 'c-treelist__node-chosen',
       },
       checkboxIdentifier: {
         branch: 'nodeSelected',
-        leaf: 'nodeSelected'
+        leaf: 'nodeSelected',
       },
       selectOn: {
         childSelect: false,
-        parentSelect: false
+        parentSelect: false,
       },
       deselectOn: {
         childDeselect: false,
-        parentDeselect: false
-      }
+        parentDeselect: false,
+      },
     }
 
     this.opts = deepMerge(defaults, this.options)
@@ -444,6 +453,6 @@ export default {
 
   beforeUnmount() {
     this.destroyFixedControls()
-  }
+  },
 }
 </script>

--- a/src/components/DpTreeList/DpTreeListCheckbox.vue
+++ b/src/components/DpTreeList/DpTreeListCheckbox.vue
@@ -7,7 +7,8 @@
       :name="name"
       :checked="checked"
       :value="stringValue"
-      @click="check">
+      @click="check"
+    >
     <span class="sr-only">{{ label }}</span>
   </label>
 </template>
@@ -20,33 +21,33 @@ export default {
 
   model: {
     prop: 'checked',
-    event: 'check'
+    event: 'check',
   },
 
   props: {
     checked: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     checkAll: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     name: {
       type: String,
-      required: true
+      required: true,
     },
 
     // Some implementations may require to set a custom value, eg. when submitting DpTreeList as a whole form.
     stringValue: {
       type: String,
       required: false,
-      default: 'on'
-    }
+      default: 'on',
+    },
   },
 
   computed: {
@@ -56,7 +57,7 @@ export default {
       }
 
       return this.toggleCheckedStatus(de.aria.deselect.element, de.aria.select.element)
-    }
+    },
   },
 
   methods: {
@@ -66,7 +67,7 @@ export default {
 
     toggleCheckedStatus (deselect, select) {
       return this.checked ? deselect : select
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpTreeList/DpTreeListNode.vue
+++ b/src/components/DpTreeList/DpTreeListNode.vue
@@ -2,31 +2,37 @@
   <li
     :id="nodeId"
     class="border--top relative"
-    data-cy="treeListNode">
+    data-cy="treeListNode"
+  >
     <div class="c-treelist__node flex">
       <div
         v-if="isDraggable"
         class="inline-block u-p-0_25 u-pr-0 u-mt-0_125"
-        :class="dragHandle">
+        :class="dragHandle"
+      >
         <dp-icon
           class="c-treelist__drag-handle-icon"
-          icon="drag-handle" />
+          icon="drag-handle"
+        />
       </div>
       <dp-tree-list-checkbox
         v-if="isSelectable"
         :checked="isNodeSelected"
         :name="checkboxIdentifier"
         :string-value="nodeId"
-        @check="handleSelectionToggle" />
+        @check="handleSelectionToggle"
+      />
       <div
         class="flex grow items-start"
-        :style="indentationStyle">
+        :style="indentationStyle"
+      >
         <dp-tree-list-toggle
           v-if="isBranch"
           v-model="isExpanded"
           class="c-treelist__folder text--left u-pv-0_25"
           :class="{ 'pointer-events-none': 0 === children.length }"
-          :icon-class-prop="iconClassFolder" />
+          :icon-class-prop="iconClassFolder"
+        />
         <div class="grow u-pl-0 u-p-0_25">
           <slot
             v-if="isBranch"
@@ -34,13 +40,15 @@
             :node-element="node"
             :node-children="children"
             :node-id="nodeId"
-            :parent-id="parentId" />
+            :parent-id="parentId"
+          />
           <slot
             v-if="isLeaf"
             name="leaf"
             :node-element="node"
             :node-id="nodeId"
-            :parent-id="parentId" />
+            :parent-id="parentId"
+          />
         </div>
       </div>
       <dp-tree-list-toggle
@@ -49,10 +57,12 @@
         v-tooltip="!hasToggle ? translations.noElementsExisting : ''"
         data-cy="treeListChildToggle"
         class="self-start"
-        :disabled="!hasToggle" />
+        :disabled="!hasToggle"
+      />
       <div
         v-else
-        class="min-w-4" />
+        class="min-w-4"
+      />
     </div>
     <component
       :is="draggable ? 'dp-draggable' : 'div'"
@@ -67,7 +77,8 @@
       :is-draggable="hasDraggableChildren ? hasDraggableChildren : null"
       :node-id="nodeId"
       :on-move="onMove"
-      :opts="options.draggable">
+      :opts="options.draggable"
+    >
       <dp-tree-list-node
         v-for="(child, idx) in children"
         v-show="true === isExpanded"
@@ -89,13 +100,16 @@
         @end="handleDrag('end')"
         @node-selected="bubbleSelectionChange"
         @start="handleDrag('start')"
-        @tree:change="bubbleChangeEvent">
+        @tree:change="bubbleChangeEvent"
+      >
         <template
           v-for="slot in Object.keys($slots)"
-          v-slot:[slot]="scope">
+          v-slot:[slot]="scope"
+        >
           <slot
             v-bind="scope"
-            :name="slot" />
+            :name="slot"
+          />
         </template>
       </dp-tree-list-node>
     </component>
@@ -118,28 +132,28 @@ export default {
     DpDraggable,
     DpIcon,
     DpTreeListCheckbox,
-    DpTreeListToggle
+    DpTreeListToggle,
   },
 
   directives: {
-    tooltip: Tooltip
+    tooltip: Tooltip,
   },
 
   props: {
     checkBranch: {
       type: Function,
-      required: true
+      required: true,
     },
 
     children: {
       type: Array,
-      required: true
+      required: true,
     },
 
     draggable: {
       type: Boolean,
       required: false,
-      default: true
+      default: true,
     },
 
     /*
@@ -149,7 +163,7 @@ export default {
      */
     handleChange: {
       type: Function,
-      required: true
+      required: true,
     },
 
     /*
@@ -157,60 +171,60 @@ export default {
      */
     handleDrag: {
       type: Function,
-      required: true
+      required: true,
     },
 
     level: {
       type: Number,
-      required: true
+      required: true,
     },
 
     node: {
       type: Object,
-      required: true
+      required: true,
     },
 
     nodeId: {
       type: String,
-      required: true
+      required: true,
     },
 
     onMove: {
       type: Function,
-      required: true
+      required: true,
     },
 
     options: {
       type: Object,
       required: false,
-      default: () => ({})
+      default: () => ({}),
     },
 
     parentId: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     selectionManager: {
       type: Object,
       required: false,
-      default: null
+      default: null,
     },
   },
 
   emits: [
     'draggable:change',
     'tree:change',
-    'node-selected'
+    'node-selected',
   ],
 
   data () {
     return {
       isExpanded: false,
       translations: {
-        noElementsExisting: de.noElementsExisting
-      }
+        noElementsExisting: de.noElementsExisting,
+      },
     }
   },
 
@@ -302,8 +316,8 @@ export default {
 
       set (payload) {
         this.$emit('tree:change', payload)
-      }
-    }
+      },
+    },
   },
 
   methods: {
@@ -326,6 +340,6 @@ export default {
 
   mounted () {
     this.$root.$on('treelist:toggle-all', (expanded) => (this.isExpanded = expanded))
-  }
+  },
 }
 </script>

--- a/src/components/DpTreeList/DpTreeListToggle.vue
+++ b/src/components/DpTreeList/DpTreeListToggle.vue
@@ -3,10 +3,12 @@
     type="button"
     class="o-link--default btn--blank"
     :aria-label="label"
-    @click="toggle">
+    @click="toggle"
+  >
     <i
       :class="iconClass"
-      aria-hidden="true" />
+      aria-hidden="true"
+    />
   </button>
 </template>
 
@@ -20,20 +22,20 @@ export default {
     value: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     iconClassProp: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     toggleAll: {
       type: Boolean,
       required: false,
-      default: false
-    }
+      default: false,
+    },
   },
 
   computed: {
@@ -52,14 +54,14 @@ export default {
       return this.toggleAll
         ? this.value ? de.aria.collapse.all : de.aria.expand.all
         : this.value ? de.aria.collapse : de.aria.expand
-    }
+    },
   },
 
   methods: {
     toggle () {
       this.$emit('input', !this.value)
       this.$emit('update:modelValue', !this.value)
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpTreeList/utils/SelectionManager.js
+++ b/src/components/DpTreeList/utils/SelectionManager.js
@@ -9,13 +9,13 @@ export class SelectionManager {
       leavesSelectable: false,
       selectOn: {
         childSelect: false,
-        parentSelect: false
+        parentSelect: false,
       },
       deselectOn: {
         childDeselect: false,
-        parentDeselect: false
+        parentDeselect: false,
       },
-      ...options
+      ...options,
     }
 
     // High-performance data structures
@@ -100,7 +100,7 @@ export class SelectionManager {
     // Batch the operation
     this.pendingOperations.push({
       nodeId,
-      newState
+      newState,
     })
 
     if (!this.isProcessingBatch) {
@@ -220,7 +220,7 @@ export class SelectionManager {
     }
 
     const allSiblingsSelected = Array.from(siblings).every(siblingId =>
-      this.isSelected(siblingId) || !this._isNodeSelectable(siblingId)
+      this.isSelected(siblingId) || !this._isNodeSelectable(siblingId),
     )
 
     if (allSiblingsSelected) {
@@ -249,7 +249,7 @@ export class SelectionManager {
     }
 
     const noSiblingsSelected = Array.from(siblings).every(siblingId =>
-      !this.isSelected(siblingId)
+      !this.isSelected(siblingId),
     )
 
     if (noSiblingsSelected) {
@@ -296,7 +296,7 @@ export class SelectionManager {
             nodeId: nodeId,
             nodeType: this.nodeType.get(nodeId),
             nodeIsSelected: true,
-            explicitlySelected: this.explicitlySelected.has(nodeId)
+            explicitlySelected: this.explicitlySelected.has(nodeId),
           }
 
           result.push(enrichedNode)
@@ -325,7 +325,7 @@ export class SelectionManager {
           ...node,
           nodeIsSelected: isSelected,
           nodeId: node.id,
-          nodeType: this.nodeType.get(node.id)
+          nodeType: this.nodeType.get(node.id),
         }
       }
 
@@ -335,7 +335,7 @@ export class SelectionManager {
 
         // Only create new object if children actually changed
         const childrenChanged = updatedChildren.some((child, index) =>
-          child !== node.children[index]
+          child !== node.children[index],
         )
 
         if (childrenChanged) {

--- a/src/components/DpUploadFiles/DpUpload.vue
+++ b/src/components/DpUploadFiles/DpUpload.vue
@@ -1,7 +1,8 @@
 <template>
   <div
     ref="fileInput"
-    :data-cy="dataCy" />
+    :data-cy="dataCy"
+  />
 </template>
 
 <script>
@@ -21,7 +22,7 @@ export default {
     'file-error',
     'upload',
     'uploads-completed',
-    'upload-success'
+    'upload-success',
   ],
 
   props: {
@@ -32,7 +33,7 @@ export default {
     allowedFileTypes: {
       type: [Array, String],
       required: false,
-      default: 'pdf'
+      default: 'pdf',
     },
 
     /**
@@ -40,7 +41,7 @@ export default {
      */
     allowedFileTypesWarning: {
       type: String,
-      default: de().strings.warningFileType
+      default: de().strings.warningFileType,
     },
 
     /**
@@ -48,13 +49,13 @@ export default {
      */
     allowMultipleUploads: {
       type: Boolean,
-      default: false
+      default: false,
     },
 
     basicAuth: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -66,13 +67,13 @@ export default {
     chunkSize: {
       type: Number,
       default: Infinity,
-      required: false
+      required: false,
     },
 
     dataCy: {
       type: String,
       required: false,
-      default: 'upload'
+      default: 'upload',
     },
 
     /**
@@ -80,7 +81,7 @@ export default {
      */
     maxFileSize: {
       type: Number,
-      default: 10000000
+      default: 10000000,
     },
 
     /**
@@ -90,13 +91,13 @@ export default {
     maxNumberOfFiles: {
       type: Number,
       required: false,
-      default: 1
+      default: 1,
     },
 
     translations: {
       type: Object,
       required: false,
-      default: () => ({})
+      default: () => ({}),
     },
 
     /**
@@ -104,8 +105,8 @@ export default {
      */
     tusEndpoint: {
       type: String,
-      required: true
-    }
+      required: true,
+    },
   },
 
   data () {
@@ -115,8 +116,8 @@ export default {
       uppy: null,
       uppyTranslations: {
         strings: {
-          ...de().strings, ...this.translations
-        }
+          ...de().strings, ...this.translations,
+        },
       },
     }
   },
@@ -124,7 +125,7 @@ export default {
   computed: {
     allowedFileTypeArray () {
       return getFileTypes(this.allowedFileTypes)
-    }
+    },
   },
 
   methods: {
@@ -159,7 +160,7 @@ export default {
         '"',
         '/',
         ':',
-        '\\'
+        '\\',
       ]
 
       for (let i = 0; i < reservedCharacters.length; i++) {
@@ -174,8 +175,8 @@ export default {
           name: fileName,
           meta: {
             ...currentFile.meta,
-            name: fileName
-          }
+            name: fileName,
+          },
         }
       } else {
         return currentFile
@@ -190,23 +191,23 @@ export default {
         restrictions: {
           allowedFileTypes: this.allowedFileTypeArray,
           maxFileSize: this.maxFileSize,
-          maxNumberOfFiles: this.maxNumberOfFiles
+          maxNumberOfFiles: this.maxNumberOfFiles,
         },
         onBeforeFileAdded: this.handleOnBeforeFileAdded,
-        locale: this.uppyTranslations
+        locale: this.uppyTranslations,
       })
 
       this.uppy.use(DragDrop, {
         target: this.$refs.fileInput,
         width: '100%',
         note: null,
-        locale: this.uppyTranslations
+        locale: this.uppyTranslations,
       })
 
       this.uppy.use(ProgressBar, {
         target: this.$refs.fileInput,
         fixed: false,
-        hideAfterFinish: false
+        hideAfterFinish: false,
       })
 
       let currentProcedureId = null
@@ -234,7 +235,7 @@ export default {
           this.currentFileId = res.getHeader('X-Demosplan-File-Id')
         },
         removeFingerprintOnSuccess: true,
-        headers
+        headers,
       })
 
       // Access the hidden input element, that accepted files array.
@@ -245,7 +246,7 @@ export default {
           uppyInput.setAttribute('data-cy', `uppyDragDropInput:${index}`)
         })
       }
-    }
+    },
   },
 
   mounted () {
@@ -293,7 +294,7 @@ export default {
         size,
         type,
         id: file.id, // The uppy internal file id
-        fileId: this.currentFileId // The id of the file within demosplan
+        fileId: this.currentFileId, // The id of the file within demosplan
       }
       this.currentFileHash = ''
       this.currentFileId = ''
@@ -305,6 +306,6 @@ export default {
     if (this.uppy) {
       this.uppy.clear()
     }
-  }
+  },
 }
 </script>

--- a/src/components/DpUploadFiles/DpUploadFiles.vue
+++ b/src/components/DpUploadFiles/DpUploadFiles.vue
@@ -2,7 +2,8 @@
   <fieldset :class="prefixClass('layout')">
     <legend
       class="sr-only"
-      v-text="mergedTranslations.uploadFiles" />
+      v-text="mergedTranslations.uploadFiles"
+    />
     <dp-label
       v-if="label.text"
       class="layout__item"
@@ -10,7 +11,8 @@
         for: id,
         required: required,
         ...label
-      }" />
+      }"
+    />
     <dp-upload
       :allowed-file-types="allowedFileTypes"
       :allow-multiple-uploads="allowMultipleUploads"
@@ -22,13 +24,15 @@
       :max-file-size="maxFileSize"
       :translations="mergedTranslations"
       :tus-endpoint="tusEndpoint"
-      @upload-success="handleUpload" /><!--
+      @upload-success="handleUpload"
+    /><!--
 
  --><dp-uploaded-file-list
       v-if="uploadedFiles.length > 0"
       :class="[prefixClass('layout__item u-1-of-1-palm'), prefixClass(sideBySide ? 'u-1-of-2' : 'u-1-of-1 u-mt')]"
       :files="uploadedFiles"
-      @file-remove="handleRemove" />
+      @file-remove="handleRemove"
+/>
 
     <!--
       If the component is used in the context of a "traditional" form post, the hashes (ids)
@@ -41,7 +45,8 @@
       :name="name !== 'uploadedFiles' ? `uploadedFiles[${name}]` : 'uploadedFiles'"
       :required="required"
       :data-dp-validate-if="dataDpValidateIf ? true : null"
-      :value="fileHashes">
+      :value="fileHashes"
+    >
   </fieldset>
 </template>
 
@@ -58,7 +63,7 @@ export default {
   components: {
     DpLabel,
     DpUpload,
-    DpUploadedFileList
+    DpUploadedFileList,
   },
 
   mixins: [prefixClassMixin, sessionStorageMixin],
@@ -71,7 +76,7 @@ export default {
     allowedFileTypes: {
       type: [Array, String],
       required: true,
-      default: 'pdf'
+      default: 'pdf',
     },
 
     /**
@@ -79,13 +84,13 @@ export default {
      */
     allowMultipleUploads: {
       type: Boolean,
-      default: false
+      default: false,
     },
 
     basicAuth: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -94,19 +99,19 @@ export default {
     chunkSize: {
       type: Number,
       default: Infinity,
-      required: false
+      required: false,
     },
 
     clearAllFiles: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     dataCy: {
       type: String,
       required: false,
-      default: 'uploadFile'
+      default: 'uploadFile',
     },
 
     /**
@@ -116,7 +121,7 @@ export default {
     dataDpValidateIf: {
       type: [Boolean, String],
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -124,7 +129,7 @@ export default {
      */
     getFileByHash: {
       type: Function,
-      required: true
+      required: true,
     },
 
     /**
@@ -133,7 +138,7 @@ export default {
     id: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -148,7 +153,7 @@ export default {
       default: () => ({}),
       validator: (prop) => {
         return Object.keys(prop).every(key => ['hint', 'text', 'tooltip'].includes(key))
-      }
+      },
     },
 
     /**
@@ -157,7 +162,7 @@ export default {
     maxFileSize: {
       type: Number,
       required: false,
-      default: 10000000
+      default: 10000000,
     },
 
     /**
@@ -167,7 +172,7 @@ export default {
     maxNumberOfFiles: {
       type: Number,
       required: false,
-      default: 1
+      default: 1,
     },
 
     /**
@@ -176,7 +181,7 @@ export default {
     name: {
       type: String,
       required: false,
-      default: 'uploadedFiles'
+      default: 'uploadedFiles',
     },
 
     /**
@@ -186,7 +191,7 @@ export default {
      */
     needsHiddenInput: {
       type: Boolean,
-      default: false
+      default: false,
     },
 
     /**
@@ -196,7 +201,7 @@ export default {
     required: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -209,7 +214,7 @@ export default {
     translations: {
       type: Object,
       required: false,
-      default: () => ({})
+      default: () => ({}),
     },
 
     /**
@@ -219,7 +224,7 @@ export default {
     sideBySide: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -229,7 +234,7 @@ export default {
     storageName: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -237,15 +242,15 @@ export default {
      */
     tusEndpoint: {
       type: String,
-      required: true
-    }
+      required: true,
+    },
   },
 
   emits: ['upload-success'],
 
   provide () {
     return {
-      getFileByHash: this.getFileByHash
+      getFileByHash: this.getFileByHash,
     }
   },
 
@@ -256,7 +261,7 @@ export default {
         uploadFiles: de.upload.files,
       },
       mergedTranslations: {},
-      uploadedFiles: []
+      uploadedFiles: [],
     }
   },
 
@@ -269,7 +274,7 @@ export default {
 
     storageName () {
       this.updateSessionStorage(this.storageName, this.uploadedFiles)
-    }
+    },
   },
 
   methods: {
@@ -313,7 +318,7 @@ export default {
 
       this.uploadedFiles = this.uploadedFiles.filter(el => el.hash !== file.hash)
       this.updateSessionStorage(this.storageName, this.uploadedFiles)
-    }
+    },
   },
 
   created () {
@@ -322,6 +327,6 @@ export default {
 
   mounted () {
     this.uploadedFiles = this.getItemFromSessionStorage(this.storageName) || []
-  }
+  },
 }
 </script>

--- a/src/components/DpUploadFiles/DpUploadedFile.vue
+++ b/src/components/DpUploadFiles/DpUploadedFile.vue
@@ -2,20 +2,24 @@
   <li data-cy="uploadFile:uploadedFileItem">
     <span
       v-if="file.mimeType === 'txt'"
-      aria-hidden="true">
+      aria-hidden="true"
+    >
       <i
-        :class="fileIcon" />
+        :class="fileIcon"
+      />
     </span>
     <span v-if="isImage">
       <img
         :alt="file.name"
         :src="getFileByHash(file.hash)"
         :aria-label="translations.imagePreview"
-        width="50px">
+        width="50px"
+      >
     </span>
     <span
       :class="prefixClass('inline-block u-pl-0_5')"
-      style="width: calc(100% - 62px);">
+      style="width: calc(100% - 62px);"
+    >
       <span class="break-words">
         {{ file.name }}
       </span>
@@ -25,10 +29,12 @@
         :class="prefixClass('btn-icns u-m-0')"
         :aria-label="translations.removeFile"
         data-cy="uploadFile:uploadedFileDeleteItem"
-        @click="removeFile">
+        @click="removeFile"
+      >
         <i
           :class="prefixClass('fa fa-trash')"
-          aria-hidden="true" />
+          aria-hidden="true"
+        />
       </button>
     </span>
   </li>
@@ -47,8 +53,8 @@ export default {
   props: {
     file: {
       type: Object,
-      required: true
-    }
+      required: true,
+    },
   },
 
   emits: ['file-remove'],
@@ -59,8 +65,8 @@ export default {
     return {
       translations: {
         imagePreview: de.image.preview,
-        removeFile: de.file.remove
-      }
+        removeFile: de.file.remove,
+      },
     }
   },
 
@@ -77,13 +83,13 @@ export default {
     isImage () {
       const imageTypes = ['png', 'jpg', 'gif', 'bmp', 'ico', 'tiff', 'svg']
       return typeof imageTypes.find(type => type === this.file.mimeType) !== 'undefined'
-    }
+    },
   },
 
   methods: {
     removeFile () {
       this.$emit('file-remove', this.file)
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/components/DpUploadFiles/DpUploadedFileList.vue
+++ b/src/components/DpUploadFiles/DpUploadedFileList.vue
@@ -2,7 +2,8 @@
   <div>
     <h4
       :class="prefixClass('u-mb-0_25')"
-      data-cy="uploadFile:uploadedFiles">
+      data-cy="uploadFile:uploadedFiles"
+    >
       {{ translations.uploadedFiles }}
     </h4>
     <ul :class="prefixClass('o-list space-stack-xs')">
@@ -10,7 +11,8 @@
         v-for="(file, idx) in files"
         :key="idx"
         :file="file"
-        @file-remove="file => $emit('file-remove', file)" />
+        @file-remove="file => $emit('file-remove', file)"
+      />
     </ul>
   </div>
 </template>
@@ -24,7 +26,7 @@ export default {
   name: 'DpUploadedFileList',
 
   components: {
-    DpUploadedFile
+    DpUploadedFile,
   },
 
   mixins: [prefixClassMixin],
@@ -33,8 +35,8 @@ export default {
     files: {
       type: Array,
       required: false,
-      default: () => ([])
-    }
+      default: () => ([]),
+    },
   },
 
   emits: ['file-remove'],

--- a/src/components/DpUploadFiles/utils/GetFileIdsByHash.js
+++ b/src/components/DpUploadFiles/utils/GetFileIdsByHash.js
@@ -16,11 +16,11 @@ function getFileIdsByHash (hashes, route) {
           condition: {
             operator: 'IN',
             path: 'hash',
-            value: hashes
-          }
-        }
-      }
-    }
+            value: hashes,
+          },
+        },
+      },
+    },
   )
     .then(({ data }) => {
       return data.data.map(el => el.id)

--- a/src/components/DpUploadFiles/utils/UppyTranslations.js
+++ b/src/components/DpUploadFiles/utils/UppyTranslations.js
@@ -10,14 +10,14 @@ const de = () => {
        */
       dropHereOr: german.upload.select.pdf({
         browse: '{browse}',
-        maxUploadSize: convertSize('GB', 2)
+        maxUploadSize: convertSize('GB', 2),
       }),
       errorFileUpload: german.validation.error.fileUpload,
       failedToUpload: german.upload.failed,
       // This string is clickable and opens the system file selection dialog.
       browse: german.computer,
-      warningFileType: german.upload.warningFileType
-    }
+      warningFileType: german.upload.warningFileType,
+    },
   }
 }
 

--- a/src/components/DpVideoPlayer/DpVideoPlayer.vue
+++ b/src/components/DpVideoPlayer/DpVideoPlayer.vue
@@ -5,7 +5,8 @@
         :id="id"
         :data-cy="dataCy"
         :data-plyr-embed-id="primarySource.embedId"
-        :data-plyr-provider="primarySource.provider" />
+        :data-plyr-provider="primarySource.provider"
+      />
     </template>
     <template v-else>
       <video
@@ -13,12 +14,14 @@
         :aria-labelledby="ariaLabelledby"
         :data-cy="dataCy"
         playsinline
-        :data-poster="poster">
+        :data-poster="poster"
+      >
         <source
           v-for="source in sources"
           :key="source.src"
           :src="source.src"
-          :type="source.type">
+          :type="source.type"
+        >
         <track
           v-for="track in tracks"
           :key="track.src"
@@ -26,7 +29,8 @@
           :kind="track.kind"
           :label="track.label"
           :src="track.src"
-          :srclang="track.srclang">
+          :srclang="track.srclang"
+        >
       </video>
     </template>
   </div>
@@ -42,7 +46,7 @@ export default defineComponent({
     dataCy: {
       type: String,
       required: false,
-      default: 'videoPlayer'
+      default: 'videoPlayer',
     },
 
     /**
@@ -51,7 +55,7 @@ export default defineComponent({
     ariaLabelledby: {
       type: [String, Boolean],
       required: false,
-      default: false
+      default: false,
     },
 
     /**
@@ -59,24 +63,24 @@ export default defineComponent({
      */
     iconUrl: {
       type: String,
-      required: true
+      required: true,
     },
 
     id: {
       type: String,
-      required: true
+      required: true,
     },
 
     isEmbedded: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
 
     poster: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
 
     /**
@@ -108,7 +112,7 @@ export default defineComponent({
           return (source.src && source.type) || (source.embedId && source.provider)
         })
       },
-      default: () => ([])
+      default: () => ([]),
     },
 
     tracks: {
@@ -117,13 +121,13 @@ export default defineComponent({
         // Check if all tracks have their required attributes
         return Array.isArray(value) && value.filter(track => track.kind && track.srclang && track.label && track.src).length === value.length
       },
-      default: () => ([])
-    }
+      default: () => ([]),
+    },
   },
 
   data () {
     return {
-      player: {}
+      player: {},
     }
   },
 
@@ -133,7 +137,7 @@ export default defineComponent({
     },
     primarySource() {
       return this.sources[0] || null
-    }
+    },
   },
 
   mounted () {
@@ -151,9 +155,9 @@ export default defineComponent({
         'captions',
         'settings',
         'download',
-        'fullscreen'
-      ]
+        'fullscreen',
+      ],
     })
-  }
+  },
 })
 </script>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -57,7 +57,7 @@ import DpTransitionExpand from './DpTransitionExpand'
 import DpTreeList from './DpTreeList'
 import {
   DpUpload,
-  DpUploadFiles
+  DpUploadFiles,
 } from './DpUploadFiles'
 import DpVideoPlayer from './DpVideoPlayer'
 
@@ -121,5 +121,5 @@ export {
   DpUpload,
   DpUploadFiles,
   DpVideoPlayer,
-  getFileIdsByHash
+  getFileIdsByHash,
 }

--- a/src/components/shared/translations.js
+++ b/src/components/shared/translations.js
@@ -1,39 +1,39 @@
 const de = {
   anonymization: {
     mark: 'Markierung anonymisieren',
-    unmark: 'Anonymisierung aufheben'
+    unmark: 'Anonymisierung aufheben',
   },
   altText: {
-    default: 'Alternativer Text'
+    default: 'Alternativer Text',
   },
   aria: {
     deselect: {
       all: 'Auswahl für alle Elemente aufheben',
-      element: 'Auswahl für Element aufheben'
+      element: 'Auswahl für Element aufheben',
     },
     select: {
       all: 'Alle Elemente auswählen',
-      element: 'Element auswählen'
+      element: 'Element auswählen',
     },
     collapse: {
       all: 'Alle Elemente zuklappen',
-      element: 'Element zuklappen'
+      element: 'Element zuklappen',
     },
     expand: {
       all: 'Alle Elemente ausklappen',
-      element: 'Element ausklappen'
+      element: 'Element ausklappen',
     },
   },
   autocompleteNoResults: 'Keine Suchtreffer.',
   choose: "Auswählen",
   computer: 'Computer',
   confirmDialog: {
-    confirm: 'Sind Sie sicher, dass Sie fortfahren möchten?'
+    confirm: 'Sind Sie sicher, dass Sie fortfahren möchten?',
   },
   contextualHelp: 'Kontexthilfe',
   dropdown: {
     close: "Einklappen",
-    open: "Ausklappen"
+    open: "Ausklappen",
   },
   editor: {
     bold: 'Fett',
@@ -47,12 +47,12 @@ const de = {
       edit: 'Link bearbeiten',
       editOrInsert: 'Link einfügen/bearbeiten',
       insert: 'Link einfügen',
-      hint: 'URLs sollten mit \'https://\' beginnen.'
+      hint: 'URLs sollten mit \'https://\' beginnen.',
     },
     mark: {
       delete: 'Als entfernt markieren',
       element: 'Markieren',
-      insert: 'Als hinzugefügt markieren'
+      insert: 'Als hinzugefügt markieren',
     },
     orderedList: 'Nummerierte Liste',
     redo: 'Wiederholen',
@@ -65,11 +65,11 @@ const de = {
       delete: 'Tabelle löschen',
       deleteColumn: 'Spalte löschen',
       deleteRow: 'Zeile löschen',
-      toggleCellMerge: 'Zelle verbinden / Verbindung aufheben'
+      toggleCellMerge: 'Zelle verbinden / Verbindung aufheben',
     },
     underline: 'Unterstrichen',
     undo: 'Rückgängig',
-    unorderedList: 'Aufzählung'
+    unorderedList: 'Aufzählung',
   },
   entrySelected: "Eintrag ausgewählt",
   entriesSelected: "Einträge ausgewählt",
@@ -77,27 +77,27 @@ const de = {
     mandatoryFields: {
       default: 'Bitte füllen Sie alle Pflichtfelder korrekt aus. Erst dann können Sie Ihre Angaben speichern.',
       intro: 'Bitte korrigieren Sie Ihre Eingabe in folgenden Feldern: ',
-      outro: '. Erst dann können Sie Ihre Angaben speichern.'
-    }
+      outro: '. Erst dann können Sie Ihre Angaben speichern.',
+    },
   },
   expandAll: "Alle Elemente ausklappen",
   file: {
-    remove: 'Datei entfernen'
+    remove: 'Datei entfernen',
   },
   hint: {
     dismiss: 'Hinweis ausblenden',
-    show: 'Hinweis einblenden'
+    show: 'Hinweis einblenden',
   },
   image: {
     alt: {
       editHint: 'Strg + Klick, um den alternativen Text zu bearbeiten',
       explanation: 'Ein Screenreader liest diesen Text anstelle des Bildes vor.',
-      placeholder: 'Hier können Sie Ihren alternativen Text einfügen.'
+      placeholder: 'Hier können Sie Ihren alternativen Text einfügen.',
     },
     edit: 'Bild bearbeiten',
     insert: 'Bild einfügen',
     placeholder: '[An dieser Stelle wird ihr Bild angezeigt]',
-    preview: 'Bildvorschau'
+    preview: 'Bildvorschau',
   },
   input: {
     text: {
@@ -109,18 +109,18 @@ const de = {
       },
       minlength({ cssClass, count, min }) {
         return `Noch <span class="${cssClass}"> ${count} </span> um ${min} Zeichen zu erreichen.`
-      }
-    }
+      },
+    },
   },
   item: {
     lockedForSelection: "Element kann nicht ausgewählt werden",
   },
   link: {
-    text: 'Linktext'
+    text: 'Linktext',
   },
   loadingData: 'Daten werden geladen...',
   obscure: {
-    title: 'Dieser Text wurde als geschwärzt markiert, um Datenschutzrichtlinien zu entsprechen.'
+    title: 'Dieser Text wurde als geschwärzt markiert, um Datenschutzrichtlinien zu entsprechen.',
   },
   noElementsExisting: 'Keine Elemente vorhanden',
   noEntriesAvailable: 'Es sind keine Einträge vorhanden.',
@@ -129,7 +129,7 @@ const de = {
     add: 'Hinzufügen',
     delete: 'Löschen',
     deselect: {
-      all: 'Auswahl aufheben'
+      all: 'Auswahl aufheben',
     },
     confirm: 'Bestätigen',
     insert: 'Einfügen',
@@ -139,9 +139,9 @@ const de = {
     save: 'Speichern',
     select: {
       all: 'Alle auswählen',
-      placeholder: 'Bitte wählen Sie einen Eintrag aus.'
+      placeholder: 'Bitte wählen Sie einen Eintrag aus.',
     },
-    update: 'Aktualisierung'
+    update: 'Aktualisierung',
   },
   pager: {
     multipleOf: 'von',
@@ -158,7 +158,7 @@ const de = {
     },
     showEntries: 'Einträge anzeigen',
     pageNavigation: 'Seitennavigation',
-    previous: 'Vorherige Seite'
+    previous: 'Vorherige Seite',
   },
   placeholderAutoSuggest: "Suchbegriff...",
   search: {
@@ -169,11 +169,11 @@ const de = {
     text: 'Suche',
   },
   tab: {
-    openNew: 'in neuem Tab öffnen'
+    openNew: 'in neuem Tab öffnen',
   },
   table: {
     colsSort: 'Spalten sortieren nach',
-    colsSelect: 'Spalten auswählen'
+    colsSelect: 'Spalten auswählen',
   },
   tag: {
     create: "Tag erstellen",
@@ -181,7 +181,7 @@ const de = {
   text: {
     deleted: 'Dieser Text wurde entfernt',
     inserted: 'Dieser Text wurde hinzugefügt',
-    marked: 'markierter Text'
+    marked: 'markierter Text',
   },
   url: 'URL',
   upload: {
@@ -193,10 +193,10 @@ const de = {
       },
       pdf({ browse, maxUploadSize }) {
         return `PDF-Dokument zum Upload hierher ziehen oder vom ${browse} auswählen (max. ${maxUploadSize})`
-      }
+      },
     },
     uploadedFiles: 'Hochgeladene Dateien',
-    warningFileType: 'Der von Ihnen hochgeladene Dateityp ist nicht erlaubt.'
+    warningFileType: 'Der von Ihnen hochgeladene Dateityp ist nicht erlaubt.',
   },
   validation: {
     error: {
@@ -205,12 +205,12 @@ const de = {
       fileUpload: 'Beim Upload der Datei ist ein Fehler aufgetreten.',
       email: 'Bitte geben Sie eine gültige E-Mail-Adresse an.',
       format: 'Bitte verwenden Sie das korrekte Format.',
-      zipCode: 'Bitte geben Sie genau 5 Zahlen ein (z.B. \'12345\').'
-    }
+      zipCode: 'Bitte geben Sie genau 5 Zahlen ein (z.B. \'12345\').',
+    },
   },
   window: {
-    close: 'Fenster schließen'
-  }
+    close: 'Fenster schließen',
+  },
 }
 
 export { de }

--- a/src/composables/index.js
+++ b/src/composables/index.js
@@ -1,5 +1,5 @@
 import { sanitizeHtml } from './SanitizeHtml/SanitizeHtml'
 
 export {
-  sanitizeHtml
+  sanitizeHtml,
 }

--- a/src/directives/CleanHtml/CleanHtml.js
+++ b/src/directives/CleanHtml/CleanHtml.js
@@ -28,7 +28,7 @@ const getOptions = (value) => {
   const type = typeof value
   if (type === 'string') {
     return {
-      content: value
+      content: value,
     }
   } else if (type === 'object') {
     return value
@@ -54,7 +54,7 @@ const CleanHtml = {
     if (binding.value !== binding.oldValue) {
       setSanitizedInnerHTML(el, binding)
     }
-  }
+  },
 }
 
 export { CleanHtml }

--- a/src/directives/Tooltip/Tooltip.js
+++ b/src/directives/Tooltip/Tooltip.js
@@ -16,7 +16,7 @@ const tooltipConfig = {
   defaultBoundariesElement: 'scrollParent',
   defaultDelay: {
     show: 300,
-    hide: 100
+    hide: 100,
   },
   defaultOffset: 12,
   defaultTemplate: `
@@ -31,10 +31,10 @@ const tooltipConfig = {
     defaultArrowClass: 'tooltip__arrow',
     defaultDelay: {
       show: 300,
-      hide: 100
+      hide: 100,
     },
-    defaultTrigger: 'hover'
-  }
+    defaultTrigger: 'hover',
+  },
 }
 VPopover.options = { ...VPopover.options, ...tooltipConfig }
 
@@ -86,7 +86,7 @@ const Tooltip = {
 
   unmounted: function (element) {
     destroyTooltip(element)
-  }
+  },
 }
 
 export { VPopover, Tooltip }

--- a/src/directives/index.js
+++ b/src/directives/index.js
@@ -4,5 +4,5 @@ import { Tooltip, VPopover } from './Tooltip/Tooltip'
 export {
   CleanHtml,
   Tooltip,
-  VPopover
+  VPopover,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -24,5 +24,5 @@ export default {
   ...mixins,
   ...shared,
   ...utils,
-  ...validation
+  ...validation,
 }

--- a/src/lib/Detabinator.js
+++ b/src/lib/Detabinator.js
@@ -31,7 +31,7 @@ class Detabinator {
     this._inert = false
     this._focusableElementsString = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex], [contenteditable]'
     this._focusableElements = Array.from(
-      element.querySelectorAll(this._focusableElementsString)
+      element.querySelectorAll(this._focusableElementsString),
     )
   }
 

--- a/src/lib/DpApi.js
+++ b/src/lib/DpApi.js
@@ -18,24 +18,24 @@ if (typeof dplan !== 'undefined') {
 
 const apiDefaultHeaders = {
   'X-JWT-Authorization': 'Bearer ' + jwtToken,
-  'x-csrf-token': csrfToken
+  'x-csrf-token': csrfToken,
 }
 
 const api2defaultHeaders = {
   'Accept': 'application/vnd.api+json',
   'Content-Type': 'application/vnd.api+json',
-  'X-JWT-Authorization': 'Bearer ' + jwtToken
+  'X-JWT-Authorization': 'Bearer ' + jwtToken,
 }
 
 const demosplanProcedureHeaders = {
-  'X-Demosplan-Procedure-Id': currentProcedureId
+  'X-Demosplan-Procedure-Id': currentProcedureId,
 }
 
 const getHeaders = function ({ headers, url }) {
   return {
     ...(url.includes('api/2.0/') ? api2defaultHeaders : apiDefaultHeaders),
     ...(currentProcedureId !== null ? demosplanProcedureHeaders : {}),
-    ...headers
+    ...headers,
   }
 }
 
@@ -72,7 +72,7 @@ const appendSerializedUrlParams = (url, params) => {
 const doRequest = (async ({ method = 'GET', url, data = {}, headers, params, options = {} }) => {
   const fetchOptions = {
     headers: getHeaders({ headers, url }),
-    method
+    method,
   }
 
   if (method.toUpperCase() !== 'GET') {
@@ -110,7 +110,7 @@ const doRequest = (async ({ method = 'GET', url, data = {}, headers, params, opt
     return checkResponse({
       data: null,
       status: '400',
-      ok: 'Bad Request'
+      ok: 'Bad Request',
     }, options.messages)
   }
 })
@@ -138,7 +138,7 @@ const dpRpc = function (method, params, id = null) {
     jsonrpc: '2.0',
     method,
     params,
-    id: id === null ? uuid() : id
+    id: id === null ? uuid() : id,
   }
 
   return doRequest({
@@ -146,8 +146,8 @@ const dpRpc = function (method, params, id = null) {
     url: Routing.generate('rpc_generic_post'),
     data,
     headers: {
-      'Content-Type': 'application/json'
-    }
+      'Content-Type': 'application/json',
+    },
   })
 }
 
@@ -239,7 +239,7 @@ function makeFormPost (payload, url) {
   return dpApi({
     method: 'POST',
     url: url,
-    data: postData
+    data: postData,
   })
 }
 

--- a/src/lib/FileInfo.js
+++ b/src/lib/FileInfo.js
@@ -13,7 +13,7 @@ const fileTypes = {
   csv: ['.csv'],
   'pdf-video': ['.pdf', 'video/*'],
   'pdf-zip-video': ['.pdf', 'video/*', '.zip'],
-  xls: ['.xls', '.xlsx', '.ods']
+  xls: ['.xls', '.xlsx', '.ods'],
 }
 
 const mimeTypes = {
@@ -56,7 +56,7 @@ const mimeTypes = {
   'application/vnd.ms-powerpoint': 'ppt',
   // Open office,
   'application/vnd.oasis.opendocument.text': 'odt',
-  'application/vnd.oasis.opendocument.spreadsheet': 'ods'
+  'application/vnd.oasis.opendocument.spreadsheet': 'ods',
 }
 
 /**
@@ -118,7 +118,7 @@ const convertMimeType = function (value) {
 const getFileInfo = function (fileString = '', options = {}) {
   const defaults = {
     sizeScale: 'KB',
-    separator: ':'
+    separator: ':',
   }
 
   const mergedOptions = { ...defaults, ...options }
@@ -132,7 +132,7 @@ const getFileInfo = function (fileString = '', options = {}) {
       hash: fileArray[1],
       size: convertSize(mergedOptions.sizeScale, fileArray[2]),
       mimeType: convertMimeType(fileArray[3]),
-      id: fileArray[1] || ''
+      id: fileArray[1] || '',
     }
   } else {
     fileObject = {
@@ -140,7 +140,7 @@ const getFileInfo = function (fileString = '', options = {}) {
       hash: fileArray[0],
       size: fileArray[0],
       mimeType: fileArray[0],
-      id: fileArray[0]
+      id: fileArray[0],
     }
   }
 

--- a/src/lib/MatchMedia.js
+++ b/src/lib/MatchMedia.js
@@ -20,7 +20,7 @@ class MatchMedia {
       palm: 0,
       'lap-up': 1,
       'desk-up': 2,
-      wide: 3
+      wide: 3,
     }
   }
 

--- a/src/lib/SideNav.js
+++ b/src/lib/SideNav.js
@@ -80,7 +80,7 @@ class SideNav {
       document.addEventListener('test', null, {
         get passive () {
           isSupported = true
-        }
+        },
       })
     } catch (e) { }
     this.supportsPassive = isSupported

--- a/src/lib/Stickier.js
+++ b/src/lib/Stickier.js
@@ -32,7 +32,7 @@ class Stickier {
     stickToDirection = 'top',
     stickFromBreakpoint = 'palm',
     containerElement = null,
-    observeContext = true
+    observeContext = true,
   ) {
     // Set up variables from options
     this.element = stickyElement
@@ -48,7 +48,7 @@ class Stickier {
       top: 'is-top',
       bottom: 'is-bottom',
       fixed: 'is-fixed',
-      bound: 'is-bound'
+      bound: 'is-bound',
     }
 
     // Initialize MatchMedia() for later usage when determining  if the element should be initialized.
@@ -74,7 +74,7 @@ class Stickier {
       this.contextMutationObserver = new MutationObserver(this._handleContextChange.bind(this))
       this.contextMutationObserver.observe(this.context, {
         childList: true,
-        subtree: true
+        subtree: true,
       })
     }
 
@@ -84,7 +84,7 @@ class Stickier {
 
     // Bind scroll handler to check if sticky state has to be updated.
     document.addEventListener('scroll', this._handleScroll.bind(this), {
-      passive: true
+      passive: true,
     })
   }
 
@@ -164,7 +164,7 @@ class Stickier {
     const viewport = stored.viewport
     const scroll = {
       top: getScrollTop() + this.elementOffset,
-      bottom: getScrollTop() + this.elementOffset + viewport.height
+      bottom: getScrollTop() + this.elementOffset + viewport.height,
     }
     const elementScroll = stored.fitsViewport ? 0 : this._getElementScroll(scroll.top)
 
@@ -348,14 +348,14 @@ class Stickier {
   _savePositions () {
     const element = {
       height: this._getHeight(this.element),
-      top: this._getOffsetTop(this.element)
+      top: this._getOffsetTop(this.element),
     }
     const context = {
       height: this._getHeight(this.context),
-      top: this._getOffsetTop(this.context)
+      top: this._getOffsetTop(this.context),
     }
     const viewport = {
-      height: Math.max(document.documentElement.clientHeight, window.innerHeight || 0)
+      height: Math.max(document.documentElement.clientHeight, window.innerHeight || 0),
     }
 
     this.stored = {
@@ -365,16 +365,16 @@ class Stickier {
       element: {
         top: element.top,
         height: element.height,
-        bottom: element.top + element.height
+        bottom: element.top + element.height,
       },
       context: {
         top: context.top,
         height: context.height,
-        bottom: context.top + context.height
+        bottom: context.top + context.height,
       },
       viewport: {
-        height: viewport.height
-      }
+        height: viewport.height,
+      },
     }
 
     this._setContainerHeight()

--- a/src/lib/Sticky.js
+++ b/src/lib/Sticky.js
@@ -27,7 +27,7 @@ export default function Sticky () {
       elementOffset,
       stickToDirection,
       stickFromBreakpoint,
-      containerElement
+      containerElement,
     ))
   })
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -31,5 +31,5 @@ export {
   SideNav,
   Stickier,
   Sticky,
-  TableWrapper
+  TableWrapper,
 }

--- a/src/lib/validation/dpValidateMultiselectDirective.js
+++ b/src/lib/validation/dpValidateMultiselectDirective.js
@@ -34,7 +34,7 @@ const dpValidateMultiselectDirective = {
 
     component.$el.setAttribute('data-dp-validate-is-valid', isValid)
     validateMultiselect(component.$el)
-  }
+  },
 }
 
 function checkValue (val) {

--- a/src/lib/validation/index.js
+++ b/src/lib/validation/index.js
@@ -23,5 +23,5 @@ export {
   validateForm,
   validateInput,
   validateMultiselect,
-  validateTiptap
+  validateTiptap,
 }

--- a/src/lib/validation/utils/assignObserver.js
+++ b/src/lib/validation/utils/assignObserver.js
@@ -46,7 +46,7 @@ export default function assignObserver (form) {
     attributes: true,
     attributeOldValue: true,
     childList: true,
-    subtree: true
+    subtree: true,
   }
   const observer = new MutationObserver(subscriber)
   observer.observe(target, config)

--- a/src/lib/validation/utils/helpers.js
+++ b/src/lib/validation/utils/helpers.js
@@ -102,7 +102,7 @@ function awaitElement (selector, context) {
     })
       .observe(document, {
         childList: true,
-        subtree: true
+        subtree: true,
       })
   })
 }
@@ -128,7 +128,7 @@ function scrollToVisibleElement (element) {
     const elementOffset = visibleElement.getBoundingClientRect().top + getScrollTop()
     window.scrollTo({
       behavior: 'smooth',
-      top: elementOffset - 50
+      top: elementOffset - 50,
     })
   }
 }

--- a/src/mixins/dpSelectAllMixin.js
+++ b/src/mixins/dpSelectAllMixin.js
@@ -8,7 +8,7 @@ export default {
        * DpSelectAll adds the itemId and the corresponding {Boolean} selectedStatus of all items to this Object
        * For huge numbers of items, this is more performant than using an array of itemIds
        */
-      itemSelections: {}
+      itemSelections: {},
     }
   },
 
@@ -41,9 +41,9 @@ export default {
       return Object.keys(items).reduce((acc, key) => {
         return {
           ...acc,
-          ...{ [key]: status }
+          ...{ [key]: status },
         }
       }, {})
-    }
-  }
+    },
+  },
 }

--- a/src/mixins/dpValidateMixin.js
+++ b/src/mixins/dpValidateMixin.js
@@ -15,7 +15,7 @@ import validateForm from '~/lib/validation/utils/validateForm'
 export default {
   data () {
     return {
-      dpValidate: {}
+      dpValidate: {},
     }
   },
 
@@ -57,7 +57,7 @@ export default {
             let topicName = topicElement ? topicElement.getAttribute('data-dp-validate-topic') : ''
 
             const existingIndex = fieldsWithTopics.findIndex(
-              item => item.fieldName === fieldName && item.topicName === topicName
+              item => item.fieldName === fieldName && item.topicName === topicName,
             )
 
             if (existingIndex === -1) {
@@ -82,7 +82,7 @@ export default {
       if ((this.dpValidate[formId] === false && forceCallback) || this.dpValidate[formId]) {
         return callback()
       }
-    }
+    },
   },
 
   mounted () {
@@ -137,5 +137,5 @@ export default {
         })
       }
     })
-  }
+  },
 }

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -9,5 +9,5 @@ export {
   dpValidateMixin,
   prefixClassMixin,
   sessionStorageMixin,
-  tableSelectAllItems
+  tableSelectAllItems,
 }

--- a/src/mixins/prefixClassMixin/prefixClassMixin.js
+++ b/src/mixins/prefixClassMixin/prefixClassMixin.js
@@ -7,6 +7,6 @@ export default {
   methods: {
     prefixClass (classList) {
       return prefixClass(classList)
-    }
-  }
+    },
+  },
 }

--- a/src/mixins/sessionStorageMixin.js
+++ b/src/mixins/sessionStorageMixin.js
@@ -20,6 +20,6 @@ export default {
 
     clearSessionStorage () {
       sessionStorage.clear()
-    }
-  }
+    },
+  },
 }

--- a/src/mixins/tableSelectAllItems.js
+++ b/src/mixins/tableSelectAllItems.js
@@ -27,7 +27,7 @@ export default {
       allItemsCount: null, // Holds the total count of items
       allSelectedVisually: false, // This fakes "select all" for multi-page selection
       toggledItems: [], // All items that either got selected or deselected on multiple pages
-      trackDeselected: false // Determines if `toggledItems` holds selected or deselected items
+      trackDeselected: false, // Determines if `toggledItems` holds selected or deselected items
     }
   },
 
@@ -51,7 +51,7 @@ export default {
       return selected.reduce((acc, el) => {
         return {
           ...acc,
-          [el.id]: true
+          [el.id]: true,
         }
       }, {})
     },
@@ -62,7 +62,7 @@ export default {
       } else {
         return this.toggledItems.length
       }
-    }
+    },
   },
 
   methods: {
@@ -109,6 +109,6 @@ export default {
       this.allSelectedVisually = false
       this.trackDeselected = false
       this.toggledItems = []
-    }
-  }
+    },
+  },
 }

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -2,5 +2,5 @@ import { attributes, length } from './props/props'
 
 export {
   attributes,
-  length
+  length,
 }

--- a/src/shared/props/props.js
+++ b/src/shared/props/props.js
@@ -39,7 +39,7 @@ const length = {
      * converted into a whole number.
      */
     return string !== true && Number(string) % 1 === 0
-  }
+  },
 }
 
 /**
@@ -52,7 +52,7 @@ const length = {
  */
 const attributes = element => {
   const allowed = {
-    textarea: ['cols', 'rows']
+    textarea: ['cols', 'rows'],
   }
   return {
     type: Array,
@@ -68,7 +68,7 @@ const attributes = element => {
       } else {
         console.error(`A Vue form component of type "${element}" is used with the "attributes" prop containing a disallowed attr.`)
       }
-    }
+    },
   }
 }
 

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -37,5 +37,5 @@ const toDate = function (date, format = 'DD.MM.YYYY') {
 export {
   DATE_FORMAT_LONG,
   formatDate,
-  toDate
+  toDate,
 }

--- a/src/utils/getAnimationEventName.js
+++ b/src/utils/getAnimationEventName.js
@@ -10,7 +10,7 @@ export default function getAnimationEventName () {
     animation: 'animationend',
     OAnimation: 'oAnimationEnd',
     MozAnimation: 'animationend',
-    WebkitAnimation: 'webkitAnimationEnd'
+    WebkitAnimation: 'webkitAnimationEnd',
   }
   let t
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -40,5 +40,5 @@ export {
   sortAlphabetically,
   throttle,
   prefixClass,
-  uniqueArrayByObjectKey
+  uniqueArrayByObjectKey,
 }

--- a/src/utils/lengthHint/lengthHint.js
+++ b/src/utils/lengthHint/lengthHint.js
@@ -35,7 +35,7 @@ const maxlengthHint = (currentLength, maxlength) => {
     ? de.input.text.maxlength({
       cssClass: (max - currentLength > errorThreshold) ? 'text-status-progress' : 'text-status-failed',
       count: max - currentLength,
-      max
+      max,
     })
     : ''
 }

--- a/tests/DataTableSearch.spec.js
+++ b/tests/DataTableSearch.spec.js
@@ -3,7 +3,7 @@ import DataTableSearch from '~/components/DpDataTableExtended/DataTableSearch'
 describe('DataTableSearch a utility function to perform full-text search in strings', () => {
   it('should escape all regex special chars', () => {
     const itemsToSearch = [
-      { text: 'Hello, this is some text.' }
+      { text: 'Hello, this is some text.' },
     ]
     const fields = ['text']
     const searchTerm = 'he*l+l.l?o( t)h[i]s^ is $some|'
@@ -13,7 +13,7 @@ describe('DataTableSearch a utility function to perform full-text search in stri
 
   it('should properly match text containing special chars', () => {
     const itemsToSearch = [
-      { text: 'Hello? import * from ./../stars.js' }
+      { text: 'Hello? import * from ./../stars.js' },
     ]
     const fields = ['text']
     const searchTerm = 'Hello? import * from ./../stars.js'
@@ -23,7 +23,7 @@ describe('DataTableSearch a utility function to perform full-text search in stri
 
   it('should match even if number of whitespaces differ', () => {
     const itemsToSearch = [
-      { text: 'Hello, this is some text.' }
+      { text: 'Hello, this is some text.' },
     ]
     const fields = ['text']
     const searchTerm = 'Hello,  this is some text.'

--- a/tests/DpAccordion.spec.js
+++ b/tests/DpAccordion.spec.js
@@ -12,8 +12,8 @@ describe('DpAccordion', () => {
         fontWeight: 'bold',
         compressed: false,
         isOpen: false,
-        title: 'Test Title'
-      }
+        title: 'Test Title',
+      },
     })
   })
 

--- a/tests/DpBadge.spec.js
+++ b/tests/DpBadge.spec.js
@@ -9,8 +9,8 @@ describe('DpBadge', () => {
       props: {
         color: 'default',
         size: 'medium',
-        text: 'Test Badge'
-      }
+        text: 'Test Badge',
+      },
     })
   })
 

--- a/tests/DpFlyout.spec.js
+++ b/tests/DpFlyout.spec.js
@@ -11,8 +11,8 @@ describe('DpFlyout', () => {
         dataCy: 'flyoutTrigger',
         disabled: false,
         hasMenu: true,
-        padded: true
-      }
+        padded: true,
+      },
     })
   })
 

--- a/tests/DpLabel.spec.js
+++ b/tests/DpLabel.spec.js
@@ -6,8 +6,8 @@ describe('DpLabel', () => {
     props: {
       for: 'test for',
       hint: '',
-      text: 'test text'
-    }
+      text: 'test text',
+    },
   })
 
   it('returns empty array when hint props is empty', () => {

--- a/tests/DpNotification.spec.js
+++ b/tests/DpNotification.spec.js
@@ -11,25 +11,25 @@ describe('DpNotification', () => {
     const validCombinations = [
       {
         type: 'confirm',
-        clazz: 'c-notify__message--confirm'
+        clazz: 'c-notify__message--confirm',
       },
       {
         type: 'info',
-        clazz: 'c-notify__message--info'
+        clazz: 'c-notify__message--info',
       },
       {
         type: 'warning',
-        clazz: 'c-notify__message--warning'
-      }
+        clazz: 'c-notify__message--warning',
+      },
     ]
 
     for (const val of validCombinations) {
       const wrapper = mount(DpNotification, {
         props: {
           message: {
-            type: val.type
-          }
-        }
+            type: val.type,
+          },
+        },
       })
 
       expect(wrapper.vm.messageClass).toBe(val.clazz)
@@ -40,9 +40,9 @@ describe('DpNotification', () => {
     let wrapper = mount(DpNotification, {
       props: {
         message: {
-          type: 'error'
-        }
-      }
+          type: 'error',
+        },
+      },
     })
 
     expect(wrapper.html()).toMatchSnapshot()
@@ -52,9 +52,9 @@ describe('DpNotification', () => {
     wrapper = mount(DpNotification, {
       props: {
         message: {
-          type: 'confirm'
-        }
-      }
+          type: 'confirm',
+        },
+      },
     })
 
     expect(wrapper.html()).toMatchSnapshot()
@@ -67,9 +67,9 @@ describe('DpNotification', () => {
       props: {
         message: {
           type: 'confirm',
-          text: 'MessageText'
-        }
-      }
+          text: 'MessageText',
+        },
+      },
     })
 
     expect(wrapper.find('.flow-root > .u-ml').text()).toBe('MessageText')
@@ -82,9 +82,9 @@ describe('DpNotification', () => {
           type: 'confirm',
           text: 'MessageText',
           linkUrl: 'about:blank',
-          linkText: 'LinkText'
-        }
-      }
+          linkText: 'LinkText',
+        },
+      },
     })
 
     expect(wrapper.find('.flow-root > .u-ml').text()).toBe('MessageText LinkText')

--- a/tests/DpSearchField.spec.js
+++ b/tests/DpSearchField.spec.js
@@ -8,17 +8,17 @@ describe('DpSearchField', () => {
   let wrapper
   const mocks = {
     Translator: {
-      trans: jest.fn((key => key))
-    }
+      trans: jest.fn((key => key)),
+    },
   }
 
   beforeEach(() => {
     wrapper = mount (DpSearchField, {
       components: {
         DpButton,
-        DpResettableInput
+        DpResettableInput,
       },
-      mocks
+      mocks,
     })
   })
 

--- a/tests/DpTreeListCheckbox.spec.js
+++ b/tests/DpTreeListCheckbox.spec.js
@@ -8,8 +8,8 @@ describe('should return result \'Auswahl aufheben\' when props are: checked = tr
     props: {
       checked: true,
       checkAll: true,
-      name: 'someName'
-    }
+      name: 'someName',
+    },
   })
 
   it('returns operations.deselect.all', () => {
@@ -22,8 +22,8 @@ describe('should return result aria.select.all when props are: checked = false, 
     props: {
       checked: false,
       checkAll: true,
-      name: 'someName'
-    }
+      name: 'someName',
+    },
   })
 
   it('returns aria.select.all', () => {
@@ -36,8 +36,8 @@ describe('should return result \'Auswahl für Element aufheben\' when props are:
     props: {
       checked: true,
       checkAll: false,
-      name: 'someName'
-    }
+      name: 'someName',
+    },
   })
 
   it('returns \'Auswahl für Element aufheben\'', () => {
@@ -50,8 +50,8 @@ describe('should return result \'Element auswählen\' when props are: checked = 
     props: {
       checked: false,
       checkAll: false,
-      name: 'someName'
-    }
+      name: 'someName',
+    },
   })
 
   it('returns \'Element auswählen\'', () => {

--- a/tests/DpUpload/DpUploadFiles.spec.js
+++ b/tests/DpUpload/DpUploadFiles.spec.js
@@ -13,13 +13,13 @@ describe.skip('DpUploadFiles', () => {
 
   it('should update Files-list after adding a file', () => {
     const File = {
-      hash: 'xxx-qqq-sss'
+      hash: 'xxx-qqq-sss',
     }
 
     const instance = shallowMountWith(DpUploadFiles, {
       props: {
-        allowedFileTypes: 'pdf'
-      }
+        allowedFileTypes: 'pdf',
+      },
     })
 
     const comp = instance.vm
@@ -31,14 +31,14 @@ describe.skip('DpUploadFiles', () => {
 
   it('should update filterhash-list if we need a hidden input', () => {
     const File = {
-      hash: 'xxx-qqq-sss'
+      hash: 'xxx-qqq-sss',
     }
 
     const instance = shallowMount(DpUploadFiles, {
       props: {
         allowedFileTypes: 'pdf',
-        needsHiddenInput: true
-      }
+        needsHiddenInput: true,
+      },
     })
 
     const comp = instance.vm
@@ -51,18 +51,18 @@ describe.skip('DpUploadFiles', () => {
 
   it('should reset the files and filehash-list after calling the clear-list method', () => {
     const File = {
-      hash: 'xxx-qqq-sss'
+      hash: 'xxx-qqq-sss',
     }
 
     const File2 = {
-      hash: 'yyy-qqq-sss'
+      hash: 'yyy-qqq-sss',
     }
 
     const instance = shallowMount(DpUploadFiles, {
       props: {
         allowedFileTypes: 'pdf',
-        needsHiddenInput: true
-      }
+        needsHiddenInput: true,
+      },
     })
 
     const comp = instance.vm

--- a/tests/Modal.spec.js
+++ b/tests/Modal.spec.js
@@ -16,11 +16,11 @@ describe('Modal', () => {
 
     const instance = shallowMountWithGlobalMocks(DpModal, {
       props: {
-        modalId: 'test'
+        modalId: 'test',
       },
       slots: {
-        default: '<div>Slot Content</div>'
-      }
+        default: '<div>Slot Content</div>',
+      },
     })
 
     const modal = instance.vm

--- a/tests/Obscure.spec.js
+++ b/tests/Obscure.spec.js
@@ -4,7 +4,7 @@ import DpObscure from '~/components/DpObscure'
 /* Mock hasPermission for the sake of testing */
 // TODO: hasPermission should probably live in the webpack world
 window.Translator = {
-  trans: jest.fn(key => key)
+  trans: jest.fn(key => key),
 }
 
 describe('Obscure', () => {
@@ -20,8 +20,8 @@ describe('Obscure', () => {
     window.hasPermission = () => true
     let slotInstance = shallowMountWithGlobalMocks(DpObscure, {
       slots: {
-        default: '<div>Slot Content</div>'
-      }
+        default: '<div>Slot Content</div>',
+      },
     })
     /*
      * The class is sometimes in the first and sometimes the last attr. That sucks..
@@ -31,8 +31,8 @@ describe('Obscure', () => {
     window.hasPermission = () => false
     slotInstance = shallowMountWithGlobalMocks(DpObscure, {
       slots: {
-        default: '<div>Slot Content</div>'
-      }
+        default: '<div>Slot Content</div>',
+      },
     })
     /*
      * The class is sometimes in the first and sometimes the last attr. That sucks..

--- a/tests/components/DpTreeList/DpTreeList.spec.js
+++ b/tests/components/DpTreeList/DpTreeList.spec.js
@@ -8,60 +8,60 @@ describe('DpTreeList', () => {
       id: '1',
       type: 'Elements',
       attributes: {
-        title: 'Branch 1'
+        title: 'Branch 1',
       },
       children: [
         {
           id: '2',
           type: 'SingleDocument',
           attributes: {
-            title: 'Leaf 1'
+            title: 'Leaf 1',
           },
-          children: []
+          children: [],
         },
         {
           id: '3',
           type: 'SingleDocument',
           attributes: {
-            title: 'Leaf 2'
+            title: 'Leaf 2',
           },
-          children: []
-        }
-      ]
+          children: [],
+        },
+      ],
     },
     {
       id: '4',
       type: 'Elements',
       attributes: {
-        title: 'Branch 2'
+        title: 'Branch 2',
       },
       children: [
         {
           id: '5',
           type: 'SingleDocument',
           attributes: {
-            title: 'Leaf 3'
+            title: 'Leaf 3',
           },
-          children: []
+          children: [],
         },
         {
           id: '6',
           type: 'SingleDocument',
           attributes: {
-            title: 'Leaf 4'
+            title: 'Leaf 4',
           },
-          children: []
+          children: [],
         },
         {
           id: '7',
           type: 'SingleDocument',
           attributes: {
-            title: 'Leaf 5'
+            title: 'Leaf 5',
           },
-          children: []
-        }
-      ]
-    }
+          children: [],
+        },
+      ],
+    },
   ]
 
   beforeEach(() => {
@@ -74,15 +74,15 @@ describe('DpTreeList', () => {
         branchIdentifier: jest.fn(({ node }) => node.type === 'Elements'),
         options: {
           branchesSelectable: true,
-          leavesSelectable: true
-        }
+          leavesSelectable: true,
+        },
       },
       attachTo: div,
       global: {
         config: {
           globalProperties: {
-            $root: global.$rootMock
-          }
+            $root: global.$rootMock,
+          },
         },
         stubs: {
           DpTreeListCheckbox: true,
@@ -102,11 +102,11 @@ describe('DpTreeList', () => {
               'nodeId',
               'onMove',
               'options',
-              'selectionManager'
-            ]
-          }
-        }
-      }
+              'selectionManager',
+            ],
+          },
+        },
+      },
     })
   })
 

--- a/tests/components/DpTreeList/DpTreeListMockData.js
+++ b/tests/components/DpTreeList/DpTreeListMockData.js
@@ -15,9 +15,9 @@ export const mockNode = {
           "attributes": {},
           "children": [],
           "id": "4",
-          "type": "singleDocument"
-        }
-      ]
+          "type": "singleDocument",
+        },
+      ],
     },
     {
       "id": "5",
@@ -27,11 +27,11 @@ export const mockNode = {
         "attributes": {},
         "children": [],
         "id": "6",
-        "type": "singleDocument"
-      }]
-    }
-    ]
-  }]
+        "type": "singleDocument",
+      }],
+    },
+    ],
+  }],
 }
 
 
@@ -48,9 +48,9 @@ export const mockNodeChildren = [{
         "attributes": {},
         "children": [],
         "id": "4",
-        "type": "singleDocument"
-      }
-    ]
+        "type": "singleDocument",
+      },
+    ],
   },
   {
     "id": "5",
@@ -60,10 +60,10 @@ export const mockNodeChildren = [{
       "attributes": {},
       "children": [],
       "id": "6",
-      "type": "singleDocument"
-    }]
-  }
-  ]
+      "type": "singleDocument",
+    }],
+  },
+  ],
 }]
 
 export const mockUpdatedNodes = {
@@ -94,8 +94,8 @@ export const mockUpdatedNodes = {
         "nodeType": "leaf",
         "nodeId": "4",
         "attributes": {},
-        "children": []
-      }]
+        "children": [],
+      }],
     },
     {
       "id": "5",
@@ -111,11 +111,11 @@ export const mockUpdatedNodes = {
         "nodeType": "leaf",
         "nodeId": "6",
         "attributes": {},
-        "children": []
-      }]
-    }
-    ]
-  }]
+        "children": [],
+      }],
+    },
+    ],
+  }],
 }
 
 export const mockSelectedNodes = [
@@ -150,9 +150,9 @@ export const mockSelectedNodes = [
                 "nodeType": "leaf",
                 "nodeId": "4",
                 "attributes": {},
-                "children": []
-              }
-            ]
+                "children": [],
+              },
+            ],
           },
           {
             "id": "5",
@@ -169,13 +169,13 @@ export const mockSelectedNodes = [
                 "nodeType": "leaf",
                 "nodeId": "6",
                 "attributes": {},
-                "children": []
-              }
-            ]
-          }
-        ]
-      }
-    ]
+                "children": [],
+              },
+            ],
+          },
+        ],
+      },
+    ],
   },
   {
     "id": "2",
@@ -200,9 +200,9 @@ export const mockSelectedNodes = [
             "nodeType": "leaf",
             "nodeId": "4",
             "attributes": {},
-            "children": []
-          }
-        ]
+            "children": [],
+          },
+        ],
       },
       {
         "id": "5",
@@ -219,11 +219,11 @@ export const mockSelectedNodes = [
             "nodeType": "leaf",
             "nodeId": "6",
             "attributes": {},
-            "children": []
-          }
-        ]
-      }
-    ]
+            "children": [],
+          },
+        ],
+      },
+    ],
   },
   {
     "id": "3",
@@ -240,9 +240,9 @@ export const mockSelectedNodes = [
         "nodeType": "leaf",
         "nodeId": "4",
         "attributes": {},
-        "children": []
-      }
-    ]
+        "children": [],
+      },
+    ],
   },
   {
     "id": "4",
@@ -251,7 +251,7 @@ export const mockSelectedNodes = [
     "nodeType": "leaf",
     "nodeId": "4",
     "attributes": {},
-    "children": []
+    "children": [],
   },
   {
     "id": "5",
@@ -268,9 +268,9 @@ export const mockSelectedNodes = [
         "nodeType": "leaf",
         "nodeId": "6",
         "attributes": {},
-        "children": []
-      }
-    ]
+        "children": [],
+      },
+    ],
   },
   {
     "id": "6",
@@ -279,6 +279,6 @@ export const mockSelectedNodes = [
     "nodeType": "leaf",
     "nodeId": "6",
     "attributes": {},
-    "children": []
-  }
+    "children": [],
+  },
 ]

--- a/tests/components/DpTreeList/DpTreeListNode.spec.js
+++ b/tests/components/DpTreeList/DpTreeListNode.spec.js
@@ -26,26 +26,26 @@ describe('DpTreeListNode', () => {
       onMove: jest.fn(),
       options: {},
       parentId: '',
-      parentSelected: false
+      parentSelected: false,
     }
 
     mocks = {
       Translator: {
-        trans: jest.fn(key => key)
+        trans: jest.fn(key => key),
       },
-      $on: jest.fn()
+      $on: jest.fn(),
     }
 
     stubs = {
-      DpTreeListToggle
+      DpTreeListToggle,
     }
 
     wrapper = shallowMount(DpTreeListNode, {
       propsData,
       global: {
         stubs,
-        mocks
-      }
+        mocks,
+      },
     })
   })
 

--- a/tests/form/DpAutocomplete.spec.js
+++ b/tests/form/DpAutocomplete.spec.js
@@ -5,7 +5,7 @@ import { nextTick } from 'vue'
 
 // Mock the dpApi function
 const mockDpApi = jest.fn(() => Promise.resolve({
-  data: { results: [{ id: 4, name: 'Dragon Fruit' }] }
+  data: { results: [{ id: 4, name: 'Dragon Fruit' }] },
 }))
 
 // Spy on the dpApi module
@@ -19,11 +19,11 @@ describe('DpAutocomplete', () => {
     options: [
       { id: 1, name: 'Apple' },
       { id: 2, name: 'Banana' },
-      { id: 3, name: 'Cherry' }
+      { id: 3, name: 'Cherry' },
     ],
     placeholder: 'Search fruits',
     noResultsText: 'No fruits found',
-    minChars: 2
+    minChars: 2,
   }
 
   beforeEach(() => {
@@ -34,8 +34,8 @@ describe('DpAutocomplete', () => {
   it('renders correctly with default props', () => {
     const wrapper = mount(DpAutocomplete, {
       props: {
-        routeGenerator: defaultProps.routeGenerator
-      }
+        routeGenerator: defaultProps.routeGenerator,
+      },
     })
 
     expect(wrapper.find('[role="combobox"]').exists()).toBe(true)
@@ -47,8 +47,8 @@ describe('DpAutocomplete', () => {
     const wrapper = mount(DpAutocomplete, {
       props: {
         routeGenerator: defaultProps.routeGenerator,
-        placeholder: 'Search fruits'
-      }
+        placeholder: 'Search fruits',
+      },
     })
 
     expect(wrapper.find('label').text()).toBe('Search fruits')
@@ -56,7 +56,7 @@ describe('DpAutocomplete', () => {
 
   it('does not show options list when input is empty', async () => {
     const wrapper = mount(DpAutocomplete, {
-      props: defaultProps
+      props: defaultProps,
     })
 
     // Focus the input
@@ -68,7 +68,7 @@ describe('DpAutocomplete', () => {
 
   it('shows options list when typing enough characters', async () => {
     const wrapper = mount(DpAutocomplete, {
-      props: defaultProps
+      props: defaultProps,
     })
 
     // Focus and input text
@@ -92,7 +92,7 @@ describe('DpAutocomplete', () => {
 
   it('filters options based on input text', async () => {
     const wrapper = mount(DpAutocomplete, {
-      props: defaultProps
+      props: defaultProps,
     })
 
     // Skip DOM-based testing and test the component's filtering logic directly
@@ -103,7 +103,7 @@ describe('DpAutocomplete', () => {
      * as the component (case insensitive match)
      */
     const aMatchingOptions = defaultProps.options.filter(opt =>
-      opt.name.toLowerCase().includes('a')
+      opt.name.toLowerCase().includes('a'),
     )
     expect(aMatchingOptions.length).toBe(2)
     expect(aMatchingOptions[0].name).toBe('Apple')
@@ -114,7 +114,7 @@ describe('DpAutocomplete', () => {
 
     // Manually check if 'Apple' would be filtered using the same logic as the component
     const apMatchingOptions = defaultProps.options.filter(opt =>
-      opt.name.toLowerCase().includes('ap')
+      opt.name.toLowerCase().includes('ap'),
     )
     expect(apMatchingOptions.length).toBe(1)
     expect(apMatchingOptions[0].name).toBe('Apple')
@@ -122,7 +122,7 @@ describe('DpAutocomplete', () => {
 
   it('emits update:modelValue when selecting an option', async () => {
     const wrapper = mount(DpAutocomplete, {
-      props: defaultProps
+      props: defaultProps,
     })
 
     // Setup
@@ -140,12 +140,12 @@ describe('DpAutocomplete', () => {
 
   it('fetches options from API when typing', async () => {
     const wrapper = mount(DpAutocomplete, {
-      props: defaultProps
+      props: defaultProps,
     })
 
     // Create a mock response
     const mockResponse = {
-      data: { results: [{ id: 4, name: 'Dragon Fruit' }] }
+      data: { results: [{ id: 4, name: 'Dragon Fruit' }] },
     }
 
     // Setup mock to return our fake response
@@ -161,7 +161,7 @@ describe('DpAutocomplete', () => {
       url: '/api/search?q=dragon',
       params: {},
       headers: {},
-      data: {}
+      data: {},
     })
 
     // Manually trigger the event since fetchOptions() emits it only when currentQuery matches
@@ -175,7 +175,7 @@ describe('DpAutocomplete', () => {
 
   it('handles keyboard navigation properly', async () => {
     const wrapper = mount(DpAutocomplete, {
-      props: defaultProps
+      props: defaultProps,
     })
 
     // Focus and setup for testing keyboard navigation
@@ -212,8 +212,8 @@ describe('DpAutocomplete', () => {
     const wrapper = mount(DpAutocomplete, {
       props: {
         ...defaultProps,
-        options: [] // Empty options to simulate no results
-      }
+        options: [], // Empty options to simulate no results
+      },
     })
 
     // Focus the input
@@ -236,8 +236,8 @@ describe('DpAutocomplete', () => {
     const wrapper = mount(DpAutocomplete, {
       props: {
         ...defaultProps,
-        options: [{ id: 1, name: 'Apple' }]
-      }
+        options: [{ id: 1, name: 'Apple' }],
+      },
     })
 
     // Focus the input
@@ -260,7 +260,7 @@ describe('DpAutocomplete', () => {
 
   it('handles escape key properly', async () => {
     const wrapper = mount(DpAutocomplete, {
-      props: defaultProps
+      props: defaultProps,
     })
 
     // Focus the input and ensure the list is open
@@ -280,8 +280,8 @@ describe('DpAutocomplete', () => {
     const wrapper = mount(DpAutocomplete, {
       props: {
         ...defaultProps,
-        minChars: 3
-      }
+        minChars: 3,
+      },
     })
 
     // Focus the input
@@ -312,10 +312,10 @@ describe('DpAutocomplete', () => {
         ...defaultProps,
         options: [
           { id: 1, title: 'Apple' },
-          { id: 2, title: 'Banana' }
+          { id: 2, title: 'Banana' },
         ],
-        label: 'title'
-      }
+        label: 'title',
+      },
     })
 
     // Test custom label without relying on DOM elements
@@ -335,8 +335,8 @@ describe('DpAutocomplete', () => {
     const wrapper = mount(DpAutocomplete, {
       props: {
         ...defaultProps,
-        modelValue: ''
-      }
+        modelValue: '',
+      },
     })
 
     // Update the modelValue prop
@@ -348,7 +348,7 @@ describe('DpAutocomplete', () => {
 
   it('handles accessibility attributes correctly', () => {
     const wrapper = mount(DpAutocomplete, {
-      props: defaultProps
+      props: defaultProps,
     })
 
     // Test appropriate ARIA attributes

--- a/tests/form/DpButton.spec.js
+++ b/tests/form/DpButton.spec.js
@@ -10,13 +10,13 @@ describe('DpButton', () => {
     return shallowMount(DpButton, {
       props: {
         text: 'Test Button',
-        ...props
+        ...props,
       },
       global: {
         directives: {
-          tooltip: {}
-        }
-      }
+          tooltip: {},
+        },
+      },
     })
   }
 
@@ -372,7 +372,7 @@ describe('DpButton', () => {
       wrapper = createWrapper({ hideText: true, icon: '', iconAfter: '' })
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        'A DpButton instance is used without icon or visible text. Consider showing something to users.'
+        'A DpButton instance is used without icon or visible text. Consider showing something to users.',
       )
 
       consoleSpy.mockRestore()
@@ -446,7 +446,7 @@ describe('DpButton', () => {
       const sizes = [
         { size: 'small', expectedClass: 'p-0.5' },
         { size: 'medium', expectedClass: 'p-[5px]' },
-        { size: 'large', expectedClass: 'p-1.5' }
+        { size: 'large', expectedClass: 'p-1.5' },
       ]
 
       sizes.forEach(({ size, expectedClass }) => {

--- a/tests/form/DpCheckbox.spec.js
+++ b/tests/form/DpCheckbox.spec.js
@@ -6,8 +6,8 @@ import { shallowMount } from '@vue/test-utils'
 describe('DpCheckbox', () => {
   const wrapper = shallowMount(DpCheckbox, {
     props: {
-      id: 'checkboxId'
-    }
+      id: 'checkboxId',
+    },
   })
 
   runLabelTests(wrapper)
@@ -21,8 +21,8 @@ describe('DpCheckbox', () => {
     const componentWrapper = shallowMount(DpCheckbox, {
       props: {
         id: 'checkboxId',
-        checked: true
-      }
+        checked: true,
+      },
     })
 
     const checkboxEl = await componentWrapper.find('input[type="checkbox"]')
@@ -40,8 +40,8 @@ describe('DpCheckbox', () => {
   it('has the value of `valueToSend` as its value', async () => {
     const componentWrapper = shallowMount(DpCheckbox, {
       props: {
-        id: 'checkboxId'
-      }
+        id: 'checkboxId',
+      },
     })
 
     await componentWrapper.setProps({ valueToSend: '1' })

--- a/tests/form/DpCheckboxGroup.spec.js
+++ b/tests/form/DpCheckboxGroup.spec.js
@@ -7,7 +7,7 @@ describe('DpCheckboxGroup', () => {
   const defaultOptions = [
     { id: 'option1', label: 'Option 1', name: 'test-option-1' },
     { id: 'option2', label: 'Option 2', name: 'test-option-2' },
-    { id: 'option3', label: 'Option 3' }
+    { id: 'option3', label: 'Option 3' },
   ]
 
   beforeEach(() => {
@@ -16,8 +16,8 @@ describe('DpCheckboxGroup', () => {
         options: defaultOptions,
         label: 'Test Legend',
         inline: false,
-        dataCy: 'test-group'
-      }
+        dataCy: 'test-group',
+      },
     })
   })
 
@@ -25,18 +25,18 @@ describe('DpCheckboxGroup', () => {
     expect(wrapper.vm.selected).toEqual({
       option1: false,
       option2: false,
-      option3: false
+      option3: false,
     })
   })
 
   it('updates selected state when selectedOptions prop changes', async () => {
     await wrapper.setProps({
-      selectedOptions: { option1: true, option2: false, option3: true }
+      selectedOptions: { option1: true, option2: false, option3: true },
     })
     expect(wrapper.vm.selected).toEqual({
       option1: true,
       option2: false,
-      option3: true
+      option3: true,
     })
   })
 
@@ -49,7 +49,7 @@ describe('DpCheckboxGroup', () => {
     expect(wrapper.emitted('update')[0]).toEqual([{
       option1: true,
       option2: false,
-      option3: false
+      option3: false,
     }])
   })
 
@@ -58,31 +58,31 @@ describe('DpCheckboxGroup', () => {
     const wrapperWithInitialSelection = shallowMount(DpCheckboxGroup, {
       props: {
         options: defaultOptions,
-        selectedOptions: initialSelectedOptions
-      }
+        selectedOptions: initialSelectedOptions,
+      },
     })
 
     expect(wrapperWithInitialSelection.vm.selected).toEqual({
       option1: true,
       option2: false,
-      option3: true
+      option3: true,
     })
   })
 
   it('updates selected state when options prop changes', async () => {
     const newOptions = [
       { id: 'newOption1', label: 'New Option 1' },
-      { id: 'newOption2', label: 'New Option 2' }
+      { id: 'newOption2', label: 'New Option 2' },
     ]
 
     await wrapper.setProps({
       options: newOptions,
-      selectedOptions: { newOption1: true, newOption2: false }
+      selectedOptions: { newOption1: true, newOption2: false },
     })
 
     expect(wrapper.vm.selected).toEqual({
       newOption1: true,
-      newOption2: false
+      newOption2: false,
     })
   })
 
@@ -91,14 +91,14 @@ describe('DpCheckboxGroup', () => {
     const wrapperWithPartial = shallowMount(DpCheckboxGroup, {
       props: {
         options: defaultOptions,
-        selectedOptions: partialSelectedOptions
-      }
+        selectedOptions: partialSelectedOptions,
+      },
     })
 
     expect(wrapperWithPartial.vm.selected).toEqual({
       option1: true,
       option2: false,
-      option3: false
+      option3: false,
     })
   })
 })

--- a/tests/form/DpInput.spec.js
+++ b/tests/form/DpInput.spec.js
@@ -7,9 +7,9 @@ const wrapper = shallowMount(DpInput, {
   props: {
     id: 'inputId',
     label: {
-      hint: 'test hint'
-    }
-  }
+      hint: 'test hint',
+    },
+  },
 })
 
 runLabelTests(wrapper)
@@ -31,9 +31,9 @@ describe('DpInput', () => {
       props: {
         id: 'inputId',
         label: {
-          hint: 'test hint'
-        }
-      }
+          hint: 'test hint',
+        },
+      },
     })
   })
 

--- a/tests/form/DpRadio.spec.js
+++ b/tests/form/DpRadio.spec.js
@@ -5,8 +5,8 @@ import { shallowMount } from '@vue/test-utils'
 describe('DpRadio', () => {
   const wrapper = shallowMount(DpRadio, {
     props: {
-      id: 'radioId'
-    }
+      id: 'radioId',
+    },
   })
 
   const radio = wrapper.get('input[type="radio"]')
@@ -18,8 +18,8 @@ describe('DpRadio', () => {
     const componentWrapper = shallowMount(DpRadio, {
       props: {
         id: 'radioId',
-        checked: false
-      }
+        checked: false,
+      },
     })
 
     const radioEl = await componentWrapper.get('input[type="radio"]')
@@ -39,8 +39,8 @@ describe('DpRadio', () => {
       props: {
         id: 'radioId',
         checked: false,
-        value: 'testValue'
-      }
+        value: 'testValue',
+      },
     })
 
     const radioEl = componentWrapper.get('input[type="radio"]')
@@ -57,8 +57,8 @@ describe('DpRadio', () => {
   it('has the value of `value` prop as its value attribute', async () => {
     const componentWrapper = shallowMount(DpRadio, {
       props: {
-        id: 'radioId'
-      }
+        id: 'radioId',
+      },
     })
 
     await componentWrapper.setProps({ value: 'radioValue' })
@@ -70,8 +70,8 @@ describe('DpRadio', () => {
   it('has default value of "1" when no value prop is provided', () => {
     const componentWrapper = shallowMount(DpRadio, {
       props: {
-        id: 'radioId'
-      }
+        id: 'radioId',
+      },
     })
 
     const radioEl = componentWrapper.get('input[type="radio"]')
@@ -82,8 +82,8 @@ describe('DpRadio', () => {
     const componentWrapper = shallowMount(DpRadio, {
       props: {
         id: 'radioId',
-        checked: true
-      }
+        checked: true,
+      },
     })
 
     const radioEl = componentWrapper.get('input[type="radio"]')
@@ -94,8 +94,8 @@ describe('DpRadio', () => {
     const componentWrapper = shallowMount(DpRadio, {
       props: {
         id: 'radioId',
-        checked: false
-      }
+        checked: false,
+      },
     })
 
     const radioEl = componentWrapper.get('input[type="radio"]')
@@ -106,8 +106,8 @@ describe('DpRadio', () => {
     const componentWrapper = shallowMount(DpRadio, {
       props: {
         id: 'radioId',
-        name: 'radioGroup'
-      }
+        name: 'radioGroup',
+      },
     })
 
     const radioEl = componentWrapper.get('input[type="radio"]')
@@ -118,8 +118,8 @@ describe('DpRadio', () => {
     const componentWrapper = shallowMount(DpRadio, {
       props: {
         id: 'radioId',
-        name: ''
-      }
+        name: '',
+      },
     })
 
     const radioEl = componentWrapper.get('input[type="radio"]')
@@ -130,8 +130,8 @@ describe('DpRadio', () => {
     const componentWrapper = shallowMount(DpRadio, {
       props: {
         id: 'radioId',
-        dataCy: 'radio-test'
-      }
+        dataCy: 'radio-test',
+      },
     })
 
     const radioEl = componentWrapper.get('input[type="radio"]')
@@ -142,8 +142,8 @@ describe('DpRadio', () => {
     const componentWrapper = shallowMount(DpRadio, {
       props: {
         id: 'radioId',
-        dataCy: ''
-      }
+        dataCy: '',
+      },
     })
 
     const radioEl = componentWrapper.get('input[type="radio"]')

--- a/tests/form/DpSelect.spec.js
+++ b/tests/form/DpSelect.spec.js
@@ -6,7 +6,7 @@ import shallowMountWithGlobalMocks from '../../jest/shallowMountWithGlobalMocks'
 
 
 window.Translator = {
-  trans: jest.fn(key => key)
+  trans: jest.fn(key => key),
 }
 
 describe('DpSelect', () => {
@@ -14,11 +14,11 @@ describe('DpSelect', () => {
   const options = [
     { label: 'option1', value: 'value1' },
     { label: 'option2', value: 'value2' },
-    { label: 'option3', value: 'value3' }
+    { label: 'option3', value: 'value3' },
   ]
 
   const wrapper = shallowMountWithGlobalMocks(DpSelect, {
-    props: { options }
+    props: { options },
   })
   runLabelTests(wrapper)
 
@@ -31,8 +31,8 @@ describe('DpSelect', () => {
       props: {
         options,
         placeholder,
-        showPlaceholder: true
-      }
+        showPlaceholder: true,
+      },
     })
 
     const placeholderOption = componentWrapper.find('option[data-id="placeholder"]')
@@ -46,8 +46,8 @@ describe('DpSelect', () => {
       props: {
         options,
         placeholder,
-        showPlaceholder: false
-      }
+        showPlaceholder: false,
+      },
     })
 
     const placeholderOption = componentWrapper.find('option[data-id="placeholder"]')
@@ -58,8 +58,8 @@ describe('DpSelect', () => {
   it('emits an event on select with the selected value as argument', async () => {
     const componentWrapper = shallowMountWithGlobalMocks(DpSelect, {
       props: {
-        options
-      }
+        options,
+      },
     })
 
     await componentWrapper

--- a/tests/form/shared/Label.js
+++ b/tests/form/shared/Label.js
@@ -1,7 +1,7 @@
 const runLabelTests = (wrapper) => describe('ComponentWithLabel', () => {
   it('displays a label if label is defined', async () => {
     const label  = {
-      text: 'someLabel'
+      text: 'someLabel',
     }
     await wrapper.setProps({ label: label })
     const labelStub = wrapper.find('dp-label-stub')
@@ -11,7 +11,7 @@ const runLabelTests = (wrapper) => describe('ComponentWithLabel', () => {
 
   it('does not display a label if label is not defined', async () => {
     const label = {
-      text: ''
+      text: '',
     }
     await wrapper.setProps({ label: label })
 

--- a/tests/prefixClass.spec.js
+++ b/tests/prefixClass.spec.js
@@ -2,8 +2,8 @@ import { prefixClass } from '../src/utils'
 
 window.dplan = {
   settings: {
-    publicCSSClassPrefix: 'dp-'
-  }
+    publicCSSClassPrefix: 'dp-',
+  },
 }
 
 describe('prefixClass', () => {

--- a/tests/utils/date.test.js
+++ b/tests/utils/date.test.js
@@ -10,19 +10,19 @@ describe('date', () => {
     month: 12,
     time: {
       opt1: '13:15:40.000000',
-      opt2: 'T12:15:40.000Z'
+      opt2: 'T12:15:40.000Z',
     },
-    year: 2019
+    year: 2019,
   }
   const dateTypes = {
     exactDate: new Date(`${date.year}-${date.month}-${date.day}${date.time.opt2}`),
     timestampDate: 1577276140000,
-    IsoDate: `${date.year}-${date.month}-${date.day} ${date.time.opt1}`
+    IsoDate: `${date.year}-${date.month}-${date.day} ${date.time.opt1}`,
   }
   const transformedDates = {
     long:  `${date.day}.${date.month}.${date.year}, 13:15 Uhr`,
     short1: `${date.day}.${date.month}.${date.year}`,
-    short2: `${date.firstDay}.${date.month}.${date.year}`
+    short2: `${date.firstDay}.${date.month}.${date.year}`,
   }
 
   it('sets the short date format as a default value', () => {
@@ -58,7 +58,7 @@ describe('date', () => {
     dateFormat = {
       date1: date.year + '-' + date.month + '-' + date.day,
       date2: date.year + '-' + date.month,
-      date3: date.year + '/' + date.month
+      date3: date.year + '/' + date.month,
     }
 
     expect(formatDate(dateFormat.date1)).toEqual(transformedDates.short1)
@@ -76,7 +76,7 @@ describe('date', () => {
 
   it('transforms valid ISO 8601 date format type to a Date', () => {
     dateFormat = {
-      date: date.year + '/' + date.month + '/' + date.day + date.time.opt1
+      date: date.year + '/' + date.month + '/' + date.day + date.time.opt1,
     }
 
     expect(toDate(dateFormat.date)).toEqual(dateTypes.exactDate)

--- a/tests/utils/deepMerge.test.js
+++ b/tests/utils/deepMerge.test.js
@@ -5,16 +5,16 @@ let source = {
   autoSuggest: {},
   controls: [],
   hideDefaultLayer: true,
-  procedureExtent: false
+  procedureExtent: false,
 }
 let target = {
   autoSuggest: {
     enabled: true,
-    serviceUrlPath: 'test-path1'
+    serviceUrlPath: 'test-path1',
   },
   controls: ['contr1', 'contr2'],
   hideDefaultLayer: false,
-  procedureExtent: false
+  procedureExtent: false,
 }
 
 describe.each([
@@ -23,7 +23,7 @@ describe.each([
   { wrongType: Array },
   { wrongType: null },
   { wrongType: undefined },
-  { wrongType: true }
+  { wrongType: true },
 ]) ('checks the incorrect data type', ({ wrongType }) => {
   it(`returns a second parameter "source" when the first parameter "target" has a ${wrongType} type`, () => {
     expect(deepMerge(wrongType, source)).toBe(source)
@@ -42,8 +42,8 @@ describe('deepMerge', () => {
       controls: ['contr1', 'contr2'],
       autoSuggest: {
         enabled: true,
-        serviceUrlPath: 'test-path1'
-      }
+        serviceUrlPath: 'test-path1',
+      },
     }
 
     expect(deepMerge(target, source)).toEqual(mergedTarget)
@@ -56,11 +56,11 @@ describe('deepMerge', () => {
       controls: ['contr1', 'contr2', 'contr3'],
       autoSuggest: {
         enabled: true,
-        serviceUrlPath: 'test-path1'
-      }
+        serviceUrlPath: 'test-path1',
+      },
     }
     source = {
-      controls: ['contr3']
+      controls: ['contr3'],
     }
     target = {
       hideDefaultLayer: false,
@@ -68,8 +68,8 @@ describe('deepMerge', () => {
       controls: ['contr1', 'contr2'],
       autoSuggest: {
         enabled: true,
-        serviceUrlPath: 'test-path1'
-      }
+        serviceUrlPath: 'test-path1',
+      },
     }
 
     expect(deepMerge(target, source)).toEqual(mergedTarget)
@@ -82,14 +82,14 @@ describe('deepMerge', () => {
       controls: ['contr1', 'contr2'],
       autoSuggest: {
         enabled: false,
-        serviceUrlPath: 'test-path2'
-      }
+        serviceUrlPath: 'test-path2',
+      },
     }
     source = {
       autoSuggest: {
         enabled: false,
-        serviceUrlPath: 'test-path2'
-      }
+        serviceUrlPath: 'test-path2',
+      },
     }
     target = {
       hideDefaultLayer: false,
@@ -97,8 +97,8 @@ describe('deepMerge', () => {
       controls: ['contr1', 'contr2'],
       autoSuggest: {
         enabled: true,
-        serviceUrlPath: 'test-path1'
-      }
+        serviceUrlPath: 'test-path1',
+      },
     }
 
     expect(deepMerge(target, source)).toEqual(mergedTarget)

--- a/tests/utils/formatBytes.test.js
+++ b/tests/utils/formatBytes.test.js
@@ -5,20 +5,20 @@ describe('formatBytes', () => {
     bytes1: 1234,
     bytes2: 1,
     bytes3: 100005464,
-    bytes4: 10000546456
+    bytes4: 10000546456,
   }
   const decimalCounts = {
     decimalCount1: 3,
     decimalCount2: 4,
     decimalCount3: -1,
-    decimalCount4: 0
+    decimalCount4: 0,
   }
   const finalBytes = {
     finalBytes1: 1.205,
     finalBytes2: 1.2051,
     finalBytes3: 1,
     finalBytes4: 95.373,
-    finalBytes5: 9.314
+    finalBytes5: 9.314,
   }
 
   it('transforms the bytes into a size with the same count of decimals like in the argument of the function', () => {

--- a/tests/utils/hasOwnProp.test.js
+++ b/tests/utils/hasOwnProp.test.js
@@ -8,7 +8,7 @@ describe.each([
   { obj: { test: 'x' }, prop: 'test', result: true, warn: 0 },
   { obj: { foo: 'x' }, prop: 'test', result: false, warn: 0 },
   { obj: [], prop: 'foo', result: false, warn: 0 },
-  { obj: 42, prop: 'bar', result: false, warn: 1 }
+  { obj: 42, prop: 'bar', result: false, warn: 1 },
 ])('hasOwnProp - a util to shorten Object.prototype.hasOwnProperty', ({ obj, prop, result, warn }) => {
   const warnings = []
 

--- a/tests/utils/hasPermission.test.js
+++ b/tests/utils/hasPermission.test.js
@@ -6,8 +6,8 @@ window.dplan = {
     notMyPermission: false,
     someOtherPermission: true,
     andICanAccessEverything: true,
-    youShallNotPass: false
-  }
+    youShallNotPass: false,
+  },
 }
 
 describe.each([

--- a/tests/utils/sortAlphabetically.test.js
+++ b/tests/utils/sortAlphabetically.test.js
@@ -5,12 +5,12 @@ describe('sortAlphabetically', () => {
   const filteredUsersByFirstName =  [
     { id: 1031, firstName: 'Daniel', lastName: 'Ostermann' },
     { id: 1035, firstName: 'Katharina', lastName: 'Maier' },
-    { id: 1067, firstName: 'Torsten', lastName: 'Wulf' }
+    { id: 1067, firstName: 'Torsten', lastName: 'Wulf' },
   ]
   const users = [
     { id: 1067, firstName: 'Torsten', lastName: 'Wulf' },
     { id: 1035, firstName: 'Katharina', lastName: 'Maier' },
-    { id: 1031, firstName: 'Daniel', lastName: 'Ostermann' }
+    { id: 1031, firstName: 'Daniel', lastName: 'Ostermann' },
   ]
 
   it('returns an unchanged array if an object does not contain the given property', () => {
@@ -29,7 +29,7 @@ describe('sortAlphabetically', () => {
     const filteredUsersReverse =  [
       { id: 1067, firstName: 'Torsten', lastName: 'Wulf' },
       { id: 1035, firstName: 'Katharina', lastName: 'Maier' },
-      { id: 1031, firstName: 'Daniel', lastName: 'Ostermann' }
+      { id: 1031, firstName: 'Daniel', lastName: 'Ostermann' },
     ]
 
     expect(sortAlphabetically(users, 'firstName', 'desc')).toEqual(filteredUsersReverse)

--- a/tests/utils/uniqueArrayByObjectKey.test.js
+++ b/tests/utils/uniqueArrayByObjectKey.test.js
@@ -6,12 +6,12 @@ describe('uniqueArrayByObjectKey', () => {
     { id: 1067, firstName: 'Torsten', lastName: 'Wulf' },
     { id: 1035, firstName: 'Katharina', lastName: 'Maier' },
     { id: 1035, firstName: 'Katharina', lastName: 'Maier' },
-    { id: 1031, firstName: 'Daniel', lastName: 'Ostermann' }
+    { id: 1031, firstName: 'Daniel', lastName: 'Ostermann' },
   ]
   const uniqueArray = [
     { id: 1067, firstName: 'Torsten', lastName: 'Wulf' },
     { id: 1035, firstName: 'Katharina', lastName: 'Maier' },
-    { id: 1031, firstName: 'Daniel', lastName: 'Ostermann' }
+    { id: 1031, firstName: 'Daniel', lastName: 'Ostermann' },
   ]
 
   it('filters array of objects by the parameter "id" to hold only unique values', () => {


### PR DESCRIPTION
- since we agreed to enable these rules in demosplan, we should also do so in demosplan-ui
- trailing commas should now always be added on multi-line objects, arrays, imports, etc.
- closing brackets should be placed on a new line for multi-line elements