### PR TITLE
fix: add font weight classes from tailwind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+- ([#1470](https://github.com/demos-europe/demosplan-ui/pull/1470)) Add missing Tailwind 4 font-weight theme variables ([@meissnerdemos](https://github.com/meissnerdemos))
+
 ## v0.16.0 - 2026-4-9
 
 ### Changed

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1,6 +1,16 @@
 @import "../tokens/dist/css/theme.css";
 
 @theme {
+  --font-weight-thin: 100;
+  --font-weight-extralight: 200;
+  --font-weight-light: 300;
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+  --font-weight-extrabold: 800;
+  --font-weight-black: 900;
+
   --flex-shrink-2: 2;
   --animate-busy: busy 1.5s linear infinite;
 

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1,15 +1,10 @@
 @import "../tokens/dist/css/theme.css";
 
 @theme {
-  --font-weight-thin: 100;
-  --font-weight-extralight: 200;
-  --font-weight-light: 300;
   --font-weight-normal: 400;
   --font-weight-medium: 500;
   --font-weight-semibold: 600;
   --font-weight-bold: 700;
-  --font-weight-extrabold: 800;
-  --font-weight-black: 900;
 
   --flex-shrink-2: 2;
   --animate-busy: busy 1.5s linear infinite;


### PR DESCRIPTION
The project imports a custom theme (`styles/theme.css`) instead of `tailwindcss/theme.css`. The custom theme defines colors, spacing, font sizes etc. but was missing font weight variables.

In Tailwind 4, utilities like `font-semibold` or `font-bold` are only generated when the corresponding `--font-weight-*` CSS variable exists in the theme. Without these variables, `font-semibold` produces a class in the HTML but no matching CSS rule, so the declaration silently has no effect.

This adds all nine default font weight values from the Tailwind 4 default theme.

## How to review/test

- Verify `font-semibold` works (for example in StatementPublicationAndVoting in the 'Details' section of a STN or in the mentioned PR)

## Related PR
fix is needed for this PR in core: [#6091](https://github.com/demos-europe/demosplan-core/pull/6091)