### PR TITLE
fix(refs DPLAN-16987): fix searchfield button spacing

### DIFF
--- a/src/components/DpResettableInput/DpResettableInput.vue
+++ b/src/components/DpResettableInput/DpResettableInput.vue
@@ -30,6 +30,7 @@
 </template>
 
 <script>
+import { Comment, Fragment, Text } from 'vue'
 import DpIcon from '~/components/DpIcon'
 import DpInput from '~/components/DpInput'
 
@@ -118,7 +119,20 @@ export default {
   computed: {
     buttonClass () {
       let classes = this.buttonVariant === 'small' ? 'o-form__control-search-reset--small' : 'o-form__control-search-reset'
-      classes = this.$slots.default ? `${classes} grouped` : classes
+
+      const slotContent = this.$slots.default && this.$slots.default().filter(node => {
+          if (node.type === Comment) {
+            return false
+          }
+
+          if (node.type === Text && !node.children.trim()) {
+            return false
+          }
+
+          return node.type !== Fragment
+      })
+
+      classes = slotContent && slotContent.length > 0 ? `${classes} grouped` : classes
 
       return classes
     },

--- a/src/components/DpSearchField/DpSearchField.vue
+++ b/src/components/DpSearchField/DpSearchField.vue
@@ -1,6 +1,6 @@
 <template>
   <span
-    class="inline-flex"
+    class="inline-flex relative"
     :class="{ 'w-full': inputWidth === '' }">
     <dp-resettable-input
       id="searchField"
@@ -16,7 +16,7 @@
     </dp-resettable-input>
 
     <dp-button
-      class="search rounded-r-md rounded-l-none"
+      class="search rounded-r-md rounded-l-none z-[5] -ml-px"
       data-cy="handleSearch"
       hide-text
       icon="search"
@@ -80,7 +80,7 @@ export default {
 
   computed: {
     cssClasses () {
-      const classes = 'inline-block rounded-r-none'
+      const classes = 'inline-block rounded-r-none focus-within:z-above-zero'
 
       return this.inputWidth !== '' ? `${classes} ${this.inputWidth}` : classes
     }


### PR DESCRIPTION
While working on https://demoseurope.youtrack.cloud/issue/DPLAN-16987, it seemed a good idea to also fix the spacing between reset and search button, which is done in this PR. This is basically a backport of a fix already done in `main`, but I tried to keep the changes minimal, so the exact code differs somewhat from `main`.

To test it, check out `b_DPLAN-16987_search_field_width` in demosplan (`release_bobsh` for bobsh) and symlink this branch for demosplan-ui.