### PR TITLE
feat(refs: DPLAN-17244): add watcher on props.activeId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Since v0.0.10, this Changelog is formatted according to the [Common Changelog][common-changelog] recommendations.
 
 ## UNRELEASED
+### Added
+- ([#1474](https://github.com/demos-europe/demosplan-ui/pull/1474)) DpTabs: add ability that makes it possible to change active tab by prop and not only by click([@huellnerdemos](https://github.com/huellnerdemos))
 
 ## v0.18.0 - 2026-4-24
 

--- a/src/components/DpTabs/DpTabs.vue
+++ b/src/components/DpTabs/DpTabs.vue
@@ -34,7 +34,7 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref, useSlots } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, useSlots, watch } from 'vue'
 import { CleanHtml as vCleanhtml } from '~/directives'
 
 const props = defineProps( {
@@ -119,6 +119,12 @@ const setInitialTab = () => {
     handleTabChange(tabs.value[0].props.id)
   }
 }
+
+watch(() => props.activeId, (newId) => {
+  if (newId && isTabId(newId)) {
+    setActiveTab(newId)
+  }
+})
 
 onMounted (() => {
   setInitialTab()


### PR DESCRIPTION
### Ticket
DPLAN-17244

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

This PR adds a watcher on the activeId prop of DpTabs to make it possible that the component reacts on changes of the active tab even if it was not actively clicked, but changed in prop.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

Admin:
1. If both field types are available in a project, create a procedure and create some Segment and some Statement custom fields in the custom field dialog of the procedure.
2. After creation of a custom field the dialog should switch to the tab of the corresponding target, the field was created for

### Linked PRs
Core PR: [#6143](https://github.com/demos-europe/demosplan-core/pull/6143)

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Run `yarn lint`
- [x] Move the tickets on the board accordingly
- [x] Update changelog 