### PR TITLE
fix(refs DPLAN-17692): restore beforeList slot for single selects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+- ([#1479](https://github.com/demos-europe/demosplan-ui/pull/1479)) DpMultiselect: restore beforeList slot for single selects ([@hwiem](https://github.com/hwiem))
+
 ## v0.17.0 - 2026-4-17
 
 ### Added

--- a/src/components/DpMultiselect/DpMultiselect.vue
+++ b/src/components/DpMultiselect/DpMultiselect.vue
@@ -67,14 +67,17 @@
     <!-- put more slots here -->
 
     <template
-      v-if="selectionControls && multiple"
+      v-if="$slots['beforeList'] || (selectionControls && multiple)"
       v-slot:beforeList="props"
     >
       <slot
         name="beforeList"
         :props="props"
       >
-        <div class="border-bottom">
+        <div
+          v-if="selectionControls && multiple"
+          class="border-bottom"
+        >
           <button
             class="btn--blank weight--bold u-ph-0_5 u-pv-0_25"
             :data-cy="`${dataCy}-select-all`"


### PR DESCRIPTION
- if `multiple` was `false`, the `beforeList` slot in DpMultiselect was no longer displayed; but the slot is not only used for `selectionControls` (which only make sense if `multiple` is `true`), but also to display other content
- now the slot is displayed either if the parent component provides content for it or if `selectionControls` and `multiple` are `true`