### PR TITLE
chore: remove obsolete resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,10 +139,8 @@
   "packageManager": "yarn@4.2.2",
   "resolutions": {
     "prosemirror-model": "1.25.2",
-    "qs": "^6.14.2",
     "prosemirror-view": "1.40.1",
     "prosemirror-state": "1.4.3",
-    "prosemirror-transform": "1.10.4",
-    "form-data": "^4.0.4"
+    "prosemirror-transform": "1.10.4"
   }
 }


### PR DESCRIPTION
- form-data was removed as a transitive dependency when migrating from jest to vitest
- qs was pinned because @vue/cli-service required a vulnerable version, but @vue/cli-service was removed as a dependency when migrating from webpack to vite