### PR TITLE
refac: updates the styling of the DpButtonRow component 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Changed
+- ([#1484](https://github.com/demos-europe/demosplan-ui/pull/1484)) DpButtonRow: new button order; set the secondary button to the outline variant ([@sakutademos](https://github.com/sakutademos))
+
 ## v0.19.0 - 2026-4-30
 
 ### Added

--- a/src/components/DpButtonRow/DpButtonRow.vue
+++ b/src/components/DpButtonRow/DpButtonRow.vue
@@ -4,6 +4,16 @@
     class="space-x-2"
   >
     <dp-button
+      v-if="secondary"
+      color="secondary"
+      :data-cy="`${dataCy}:abortButton`"
+      :disabled="isDisabledSecondary"
+      :href="href"
+      :text="secondaryText"
+      variant="outline"
+      @click.prevent="$emit('secondary-action')"
+    />
+    <dp-button
       v-if="primary"
       :busy="busy ? true : null"
       :data-cy="`${dataCy}:saveButton`"
@@ -11,16 +21,6 @@
       :text="primaryText"
       :variant="primaryBtnVariant"
       @click.prevent="$emit('primary-action')"
-    />
-    <dp-button
-      v-if="secondary"
-      color="secondary"
-      :data-cy="`${dataCy}:abortButton`"
-      :disabled="isDisabledSecondary"
-      :href="href"
-      :text="secondaryText"
-      :variant="secondaryBtnVariant"
-      @click.prevent="$emit('secondary-action')"
     />
     <slot />
   </div>
@@ -126,13 +126,6 @@ export default {
       type: Boolean,
       required: false,
       default: false,
-    },
-
-    secondaryBtnVariant: {
-      required: false,
-      type: String as PropType<ButtonVariant>,
-      default: 'solid',
-      validator: (prop: ButtonVariant) => ['solid', 'outline', 'subtle'].includes(prop),
     },
 
     /**

--- a/tests/form/DpButtonRow.spec.js
+++ b/tests/form/DpButtonRow.spec.js
@@ -87,8 +87,8 @@ describe('DpButtonRow', () => {
       const buttons = getButtons()
 
       expectButtonLength(buttons, 2)
-      expectButtonColor(buttons[0], 'primary')
-      expectButtonColor(buttons[1], 'secondary')
+      expectButtonColor(buttons[0], 'secondary')
+      expectButtonColor(buttons[1], 'primary')
     })
   })
 
@@ -141,8 +141,8 @@ describe('DpButtonRow', () => {
       })
       const buttons = getButtons()
 
-      expectButtonIsDisabled(buttons[0], true)
-      expectButtonIsDisabled(buttons[1], false)
+      expectButtonIsDisabled(buttons[0], false)
+      expectButtonIsDisabled(buttons[1], true)
     })
 
     it('disables only secondary button when disabled object has secondary: true', () => {
@@ -153,8 +153,8 @@ describe('DpButtonRow', () => {
       })
       const buttons = getButtons()
 
-      expectButtonIsDisabled(buttons[0], false)
-      expectButtonIsDisabled(buttons[1], true)
+      expectButtonIsDisabled(buttons[0], true)
+      expectButtonIsDisabled(buttons[1], false)
     })
 
     it('does not disable buttons when disabled is false', () => {


### PR DESCRIPTION
**Ticket:** https://demosdeutschland.slack.com/archives/C5BA8ABB2/p1777449660735409?thread_ts=1777041601.817489&cid=C5BA8ABB2 and https://www.figma.com/design/A1KcVmxRk6kap5Yo1pR7AV/Component-Library-2.0?node-id=0-1&p=f

**Description:** This PR updates the styling of the DpButtonRow component according to the new design of the component library:

- new button order: the primary button is on the right, and the secondary button is on the left
- set the secondary button to the outline variant, as this is now the new default


Refactoring PR in core: https://github.com/demos-europe/demosplan-core/pull/6216