### PR TITLE
feat(ref. DPLAN-17737) Change session to localStorage DpDataTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+- ([#1485](https://github.com/demos-europe/demosplan-ui/pull/1485)) DpDataTable: opt-in persistent column widths via the `columnWidthStorageKey` prop (uses `localStorage` instead of `sessionStorage`) ([@riechedemos](https://github.com/riechedemos))
+
 ## v0.20.0 - 2026-5-5
 
 ### Changed

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -755,8 +755,10 @@ export default {
     },
 
     readStoredColWidth (headerField) {
-      // When columnWidthStorageKey is set, persist column widths in localStorage (survives tab close).
-      // Otherwise, fall back to the legacy sessionStorage behavior used by other DpDataTable consumers.
+      /*
+       * When columnWidthStorageKey is set, persist column widths in localStorage (survives tab close).
+       * Otherwise, fall back to the legacy sessionStorage behavior used by other DpDataTable consumers.
+       */
       if (this.columnWidthStorageKey) {
         try {
           const stored = localStorage.getItem(`dpDataTable:colWidth:${this.columnWidthStorageKey}:${headerField}`)

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -27,6 +27,7 @@
           :data-cy="`${dataCy}:header`"
           :all-expanded="allExpanded"
           :checked="allSelected"
+          :column-width-storage-key="columnWidthStorageKey"
           :density="density"
           :has-flyout="hasFlyout"
           :has-borders="hasBorders"
@@ -734,8 +735,7 @@ export default {
          */
         if (tableHeaderEl.nodeType === 1) {
           const headerField = tableHeaderEl.getAttribute('data-col-field')
-          const storageName = `dpDataTable:data-col-field=${headerField}`
-          const sessionColWidth = this.getItemFromSessionStorage(storageName)
+          const storedColWidth = this.readStoredColWidth(headerField)
           /**
            * Some columns, such as 'flyout' and 'wrap', should not be resizable;
            * their width is fixed; the getBoundingClientRect() function should not be applied to them
@@ -744,14 +744,43 @@ export default {
           const headerFieldWidth = this.getColWidthFromHeaderField(headerField)
 
           const width = fixedWidth
-            || sessionColWidth
+            || storedColWidth
             || headerFieldWidth
             || `${tableHeaderEl.getBoundingClientRect().width}px`
 
           tableHeaderEl.style.width = width
-          this.updateSessionStorage(storageName, width)
+          this.writeStoredColWidth(headerField, width)
         }
       })
+    },
+
+    readStoredColWidth (headerField) {
+      // When columnWidthStorageKey is set, persist column widths in localStorage (survives tab close).
+      // Otherwise, fall back to the legacy sessionStorage behavior used by other DpDataTable consumers.
+      if (this.columnWidthStorageKey) {
+        try {
+          const stored = localStorage.getItem(`dpDataTable:colWidth:${this.columnWidthStorageKey}:${headerField}`)
+
+          return stored ? JSON.parse(stored) : null
+        } catch {
+          return null
+        }
+      }
+
+      return this.getItemFromSessionStorage(`dpDataTable:data-col-field=${headerField}`)
+    },
+
+    writeStoredColWidth (headerField, width) {
+      if (this.columnWidthStorageKey) {
+        localStorage.setItem(
+          `dpDataTable:colWidth:${this.columnWidthStorageKey}:${headerField}`,
+          JSON.stringify(width),
+        )
+
+        return
+      }
+
+      this.updateSessionStorage(`dpDataTable:data-col-field=${headerField}`, width)
     },
 
     /**

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -966,12 +966,6 @@ export default {
 
       this.fillContainerWidth(tableHeaderElements)
 
-     this.tableEl.style.tableLayout = 'fixed'
-     this.tableEl.classList.add('is-fixed')
-
-     this.fillContainerWidth(tableHeaderElements)
-     this.setColsWidth(tableHeaderElements)
-     
       // Remove styles set by initialMaxWidth and initialWidth after copying rendered width into th styles
       if (this.isResizable) {
         Array.from(tableHeaderElements).forEach(th => {

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -579,7 +579,8 @@ export default {
             const tableHeaderElements = firstRow ? firstRow.children : null
 
             this.setColsWidth(tableHeaderElements)
-            this.fillContainerWidth(tableHeaderElements)
+           this.fillContainerWidth(tableHeaderElements)
+           this.setColsWidth(tableHeaderElements)
           })
         }
       },

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -298,6 +298,12 @@ export default {
       default: '',
     },
 
+    columnWidthStorageKey: {
+      type: String,
+      required: false,
+      default: '',
+    },
+
     headerFields: {
       type: Array,
       required: true,

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -579,8 +579,7 @@ export default {
             const tableHeaderElements = firstRow ? firstRow.children : null
 
             this.setColsWidth(tableHeaderElements)
-           this.fillContainerWidth(tableHeaderElements)
-           this.setColsWidth(tableHeaderElements)
+            this.fillContainerWidth(tableHeaderElements)
           })
         }
       },

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -609,7 +609,7 @@ export default {
 
       if (this.columnStorageKey) {
         const nonFixedOrder = this.orderedHeaderFields.filter(f => !f.fixed).map(f => f.field)
-        sessionStorage.setItem(
+        localStorage.setItem(
           `dpDataTable:columnOrder:${this.columnStorageKey}`,
           JSON.stringify(nonFixedOrder),
         )
@@ -679,7 +679,7 @@ export default {
       }
 
       try {
-        const stored = sessionStorage.getItem(`dpDataTable:columnOrder:${this.columnStorageKey}`)
+        const stored = localStorage.getItem(`dpDataTable:columnOrder:${this.columnStorageKey}`)
         if (!stored) {
           this.orderedHeaderFields = [...this.headerFields]
 

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -966,6 +966,12 @@ export default {
 
       this.fillContainerWidth(tableHeaderElements)
 
+     this.tableEl.style.tableLayout = 'fixed'
+     this.tableEl.classList.add('is-fixed')
+
+     this.fillContainerWidth(tableHeaderElements)
+     this.setColsWidth(tableHeaderElements)
+     
       // Remove styles set by initialMaxWidth and initialWidth after copying rendered width into th styles
       if (this.isResizable) {
         Array.from(tableHeaderElements).forEach(th => {

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -580,6 +580,7 @@ export default {
 
             this.setColsWidth(tableHeaderElements)
             this.fillContainerWidth(tableHeaderElements)
+            this.setColsWidth(tableHeaderElements)
           })
         }
       },
@@ -965,6 +966,9 @@ export default {
       this.tableEl.classList.add('is-fixed')
 
       this.fillContainerWidth(tableHeaderElements)
+
+      this.fillContainerWidth(tableHeaderElements)
+      this.setColsWidth(tableHeaderElements)
 
       // Remove styles set by initialMaxWidth and initialWidth after copying rendered width into th styles
       if (this.isResizable) {

--- a/src/components/DpDataTable/DpResizableColumn.vue
+++ b/src/components/DpDataTable/DpResizableColumn.vue
@@ -123,8 +123,10 @@ export default {
 
         this.resize.style.width = newWidth + 'px'
 
-        // When columnWidthStorageKey is set, persist column widths in localStorage (survives tab close).
-        // Otherwise fall back to the legacy sessionStorage behavior used by other DpDataTable consumers.
+        /*
+         * When columnWidthStorageKey is set, persist column widths in localStorage (survives tab close).
+         * Otherwise fall back to the legacy sessionStorage behavior used by other DpDataTable consumers.
+         */
         if (this.columnWidthStorageKey) {
           localStorage.setItem(
             `dpDataTable:colWidth:${this.columnWidthStorageKey}:${this.headerField.field}`,

--- a/src/components/DpDataTable/DpResizableColumn.vue
+++ b/src/components/DpDataTable/DpResizableColumn.vue
@@ -36,6 +36,12 @@ export default {
   mixins: [sessionStorageMixin],
 
   props: {
+    columnWidthStorageKey: {
+      type: String,
+      required: false,
+      default: '',
+    },
+
     idx: {
       required: true,
       type: Number,
@@ -116,7 +122,17 @@ export default {
         }
 
         this.resize.style.width = newWidth + 'px'
-        this.updateSessionStorage(`dpDataTable:data-col-field=${this.headerField.field}`, this.resize.style.width)
+
+        // When columnWidthStorageKey is set, persist column widths in localStorage (survives tab close).
+        // Otherwise fall back to the legacy sessionStorage behavior used by other DpDataTable consumers.
+        if (this.columnWidthStorageKey) {
+          localStorage.setItem(
+            `dpDataTable:colWidth:${this.columnWidthStorageKey}:${this.headerField.field}`,
+            JSON.stringify(this.resize.style.width),
+          )
+        } else {
+          this.updateSessionStorage(`dpDataTable:data-col-field=${this.headerField.field}`, this.resize.style.width)
+        }
       }
     },
 

--- a/src/components/DpDataTable/DpTableHeader.vue
+++ b/src/components/DpDataTable/DpTableHeader.vue
@@ -40,6 +40,7 @@
       <component
         :is="isResizable ? 'DpResizableColumn' : 'th'"
         :class="[{ 'border-r border-b-2 border-neutral-light-3': hasBorders }, { 'p-[16px]': density === 'spacious' }, { 'c-data-table__col--fixed': isColumnsDraggable && hf.fixed }]"
+        :column-width-storage-key="columnWidthStorageKey"
         :data-col-field="hf.field"
         :header-field="hf"
         :idx="idx"
@@ -132,6 +133,12 @@ export default {
     checked: {
       type: Boolean,
       required: true,
+    },
+
+    columnWidthStorageKey: {
+      type: String,
+      required: false,
+      default: '',
     },
 
     dataCy: {


### PR DESCRIPTION
  ### Ticket                                            
  [DPLAN-17737](https://demoseurope.youtrack.cloud/issue/DPLAN-17737)                       
                                                                                                    
Add `columnWidthStorageKey` prop on `DpDataTable` so consumers can opt in to persisting column widths in `localStorage` instead of `sessionStorage`. The prop is forwarded through `DpTableHeader` to `DpResizableColumn`. When the prop is unset, the existing `sessionStorage`-based behavior is preserved unchanged.                                           
                                                                                                    
  ### How to review/test                                                                            
-Go to SegmentsList (Abschnitte) → resize columns, close the tab, reopen → widths are restored                                                                    
                                                                                                    
  ### Linked PRs                                                                                    
[demos-europe/demosplan-core#<PR-Nummer>](https://github.com/demos-europe/demosplan-core/pull/6239)
