### PR TITLE
fix: use new plyr import path

### DIFF
--- a/src/components/DpVideoPlayer/DpVideoPlayer.vue
+++ b/src/components/DpVideoPlayer/DpVideoPlayer.vue
@@ -38,7 +38,7 @@
 
 <script>
 import { defineComponent } from 'vue'
-import Plyr from 'plyr/dist/plyr.polyfilled.min'
+import Plyr from 'plyr'
 export default defineComponent({
   name: 'DpVideoPlayer',
 


### PR DESCRIPTION
Fix build error from new Plyr version: replace removed deep import plyr/dist/plyr.polyfilled.min with main entry plyr.