### PR TITLE
feat(refs DPLAN-17527): Add flyoutWidth prop to DpDataTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 ## UNRELEASED
 
 ### Added
-- ([#1505](https://github.com/demos-europe/demosplan-ui/pull/1505)) DpDataTable: Add prop for the flyout-width ([@rafelddemos](https://github.com/rafelddemos))
+- ([#1505](https://github.com/demos-europe/demosplan-ui/pull/1505)) DpDataTable: Add flyoutWidth prop (px only, min: 60px, default: 60px) ([@rafelddemos](https://github.com/rafelddemos))
 
 ## v0.22.0 - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+- ([#1505](https://github.com/demos-europe/demosplan-ui/pull/1505)) DpDataTable: Add prop for the flyout-width ([@rafelddemos](https://github.com/rafelddemos))
+
 ## v0.22.0 - 2026-05-18
 
 ### Added

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -307,8 +307,9 @@ export default {
 
     flyoutWidth: {
       type: String,
-      required:false,
-      default:'60px',
+      required: false,
+      default: '60px',
+      validator: (value) => /^\d+px$/.test(value),
     },
 
     headerFields: {

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -197,12 +197,14 @@
       <!-- empty items -->
       <tr v-if="items.length === 0">
         <!-- noResultsData  -->
+        <!-- eslint-disable vue/no-v-html -->
         <td
           v-if="searchTermSet"
           :colspan="colCount"
           class="u-pt"
           v-html="noResults"
         />
+        <!-- eslint-enable vue/no-v-html -->
 
         <!-- noEntriesItem -->
         <td
@@ -309,7 +311,7 @@ export default {
       type: String,
       required: false,
       default: '60px',
-      validator: (value) => /^\d+px$/.test(value),
+      validator: (value) => /^\d+px$/.test(value) && Number.parseInt(value, 10) >= 60,
     },
 
     headerFields: {
@@ -795,7 +797,7 @@ export default {
 
     /**
      * Distribute available container width among data columns so the sticky flyout always
-     * stays at its fixed 60px width and no column remains at 0px.
+     * stays at its configured width (default: '60px', prop: flyoutWidth) and no column remains at 0px.
      *
      * When scale > 1 (columns don't fill the container), all data columns are scaled up
      * proportionally. When scale <= 1 (columns fill or overflow), only columns that ended

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -589,7 +589,6 @@ export default {
 
             this.setColsWidth(tableHeaderElements)
             this.fillContainerWidth(tableHeaderElements)
-            this.setColsWidth(tableHeaderElements)
           })
         }
       },
@@ -975,9 +974,6 @@ export default {
       this.tableEl.classList.add('is-fixed')
 
       this.fillContainerWidth(tableHeaderElements)
-
-      this.fillContainerWidth(tableHeaderElements)
-      this.setColsWidth(tableHeaderElements)
 
       // Remove styles set by initialMaxWidth and initialWidth after copying rendered width into th styles
       if (this.isResizable) {

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -305,6 +305,12 @@ export default {
       default: '',
     },
 
+    flyoutWidth: {
+      type: String,
+      required:false,
+      default:'60px',
+    },
+
     headerFields: {
       type: Array,
       required: true,
@@ -671,7 +677,7 @@ export default {
 
     getFixedColWidth (field) {
       if (field === 'flyout') {
-        return '60px'
+        return this.flyoutWidth
       }
 
       return ['wrap', 'select', 'dragHandle'].includes(field) ?


### PR DESCRIPTION
**please don't review yet**

This PR adds a prop for the flyout-width to `DpDataTable`. The default remains `60px`, but can be customized if needed (min-width: `60px`), e.g. should the flyout contain more than one icon-button.

Related Ticket:[ DPLAN-17527](https://demoseurope.youtrack.cloud/issue/DPLAN-17527/NEU-ADO-50748-Bearbeiten-von-custom-Verfahrensschritten)