### PR TITLE
chore: add cooldowns for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
         time: "09:00"
         timezone: Europe/Berlin
     open-pull-requests-limit: 10
+    # Cooldown applies to version updates only - security updates (triggered by security alerts) bypass it and are
+    # opened immediately.
+    # See https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
     cooldown:
       default-days: 7
       semver-major-days: 30

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
         time: "09:00"
         timezone: Europe/Berlin
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       babel:
         patterns:


### PR DESCRIPTION
This slightly changes the cooldown periods as they were defined in https://demoseurope.youtrack.cloud/articles/TECH-A-338/Updating-frontend-dependencies (the page has been updated, too)

| type | cooldown period (before) | cooldown period (new)
| -- | -- | -- |
| patch (1.2.3 -> 1.2.4) | 3-7 days | 3 days | 
minor (1.2.x -> 1.3.0) | 14 days | 7 days |
major (1.x.x -> 2.0.0) | 1 month | 30 days |
security | 3 days | no cooldown period -> opened immediately |