### PR TITLE
chore: disable install scripts in dependencies

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,2 +1,4 @@
 progressBarStyle: "patrick"
 nodeLinker: "node-modules"
+# npm worm protection: do not run dependency install scripts
+enableScripts: false


### PR DESCRIPTION
- yarn no longer runs preinstall/postinstall scripts from dependencies, closing the install-time arbitrary-code-execution vector (npm worm protection)
- skipped build scripts (core-js, esbuild, tailwindcss/oxide) are safe to ignore (core-js: just a funding message, esbuild/oxide: platform binaries don't have to be built or fetched via script, they come in as separate dependencies)