### PR TITLE
DpConfirmDialog: add optional icon prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+- DpConfirmDialog: optional `icon` prop rendered before the header text ([@meissnerdemos](https://github.com/meissnerdemos))
+
 ## v0.22.0 - 2026-05-18
 
 ### Added

--- a/src/components/DpConfirmDialog/DpConfirmDialog.vue
+++ b/src/components/DpConfirmDialog/DpConfirmDialog.vue
@@ -11,7 +11,14 @@
       v-if="header"
       v-slot:header
     >
-      <span>{{ header }}</span>
+      <span class="inline-flex items-center gap-2">
+        <dp-icon
+          v-if="icon"
+          aria-hidden="true"
+          :icon="icon"
+        />
+        <span>{{ header }}</span>
+      </span>
     </template>
     <p
       id="dialogDescription"
@@ -45,6 +52,7 @@
 import { de } from '~/components/shared/translations'
 import DpButton from '~/components/DpButton'
 import DpButtonRow from '~/components/DpButtonRow'
+import DpIcon from '~/components/DpIcon'
 import DpModal from '~/components/DpModal'
 import { PropType } from 'vue'
 
@@ -56,6 +64,7 @@ export default {
   components: {
     DpButton,
     DpButtonRow,
+    DpIcon,
     DpModal,
   },
 
@@ -85,6 +94,15 @@ export default {
     },
 
     header: {
+      type: String,
+      required: false,
+      default: '',
+    },
+
+    /**
+     * Optional icon rendered before the header text.
+     */
+    icon: {
       type: String,
       required: false,
       default: '',


### PR DESCRIPTION
### Description
Adds an optional `icon` prop to `DpConfirmDialog`, rendered before the header text (e.g. `icon="warning"` for a warning triangle). Backwards compatible — no icon shown when the prop is omitted.

### Related PR
demos-europe/demosplan-core#6385

### How to test
DpConfirmDialog: pass `icon="warning"` together with a `header`; the icon renders left of the title.