### PR TITLE
fix: align notification icon with text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Fixed
+- ([#1515](https://github.com/demos-europe/demosplan-ui/pull/1515)) DpNotification: Vertically align icon with notification text ([@hwiem](https://github.com/hwiem))
+
+
 ## v0.24.0 - 2026-06-12
 
 ### Added

--- a/src/components/DpNotification/DpNotification.vue
+++ b/src/components/DpNotification/DpNotification.vue
@@ -20,14 +20,14 @@
       />
     </button>
 
-    <div :class="prefixClass('flow-root')">
+    <div :class="prefixClass('flex items-start gap-1')">
       <dp-icon
-        :class="prefixClass('c-notify__icon mt-px mr-1 float-left')"
+        :class="prefixClass('c-notify__icon shrink-0 mt-[2px]')"
         :icon="messageIcon"
         aria-hidden="true"
         weight="fill"
       />
-      <div :class="prefixClass('c-notify__text u-ml mt-2 break-words')">
+      <div :class="prefixClass('c-notify__text break-words')">
         {{ message.text }}
         <a
           v-if="message.linkUrl"

--- a/tests/DpNotification.spec.js
+++ b/tests/DpNotification.spec.js
@@ -72,7 +72,7 @@ describe('DpNotification', () => {
       },
     })
 
-    expect(wrapper.find('.flow-root > .u-ml').text()).toBe('MessageText')
+    expect(wrapper.find('.c-notify__text').text()).toBe('MessageText')
   })
 
   it('renders a link if link attributes are given', () => {
@@ -87,7 +87,7 @@ describe('DpNotification', () => {
       },
     })
 
-    expect(wrapper.find('.flow-root > .u-ml').text()).toBe('MessageText LinkText')
+    expect(wrapper.find('.c-notify__text').text()).toBe('MessageText LinkText')
   })
 
   /*

--- a/tests/__snapshots__/DpNotification.spec.js.snap
+++ b/tests/__snapshots__/DpNotification.spec.js.snap
@@ -6,12 +6,12 @@ exports[`DpNotification > always renders with closemark 1`] = `
         <path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm37.66,130.34a8,8,0,0,1-11.32,11.32L128,139.31l-26.34,26.35a8,8,0,0,1-11.32-11.32L116.69,128,90.34,101.66a8,8,0,0,1,11.32-11.32L128,116.69l26.34-26.35a8,8,0,0,1,11.32,11.32L139.31,128Z"></path>
       </g>
     </svg></button>
-  <div class="flow-root"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="20" height="20" fill="currentColor" class="square c-notify__icon mt-px mr-1 float-left" aria-hidden="true">
+  <div class="flex items-start gap-1"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="20" height="20" fill="currentColor" class="square c-notify__icon shrink-0 mt-[2px]" aria-hidden="true">
       <g>
         <path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm-8,56a8,8,0,0,1,16,0v56a8,8,0,0,1-16,0Zm8,104a12,12,0,1,1,12-12A12,12,0,0,1,128,184Z"></path>
       </g>
     </svg>
-    <div class="c-notify__text u-ml mt-2 break-words">
+    <div class="c-notify__text break-words">
       <!--v-if-->
     </div>
   </div>
@@ -24,12 +24,12 @@ exports[`DpNotification > always renders with closemark 2`] = `
         <path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm37.66,130.34a8,8,0,0,1-11.32,11.32L128,139.31l-26.34,26.35a8,8,0,0,1-11.32-11.32L116.69,128,90.34,101.66a8,8,0,0,1,11.32-11.32L128,116.69l26.34-26.35a8,8,0,0,1,11.32,11.32L139.31,128Z"></path>
       </g>
     </svg></button>
-  <div class="flow-root"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="20" height="20" fill="currentColor" class="square c-notify__icon mt-px mr-1 float-left" aria-hidden="true">
+  <div class="flex items-start gap-1"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="20" height="20" fill="currentColor" class="square c-notify__icon shrink-0 mt-[2px]" aria-hidden="true">
       <g>
         <path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm45.66,85.66-56,56a8,8,0,0,1-11.32,0l-24-24a8,8,0,0,1,11.32-11.32L112,148.69l50.34-50.35a8,8,0,0,1,11.32,11.32Z"></path>
       </g>
     </svg>
-    <div class="c-notify__text u-ml mt-2 break-words">
+    <div class="c-notify__text break-words">
       <!--v-if-->
     </div>
   </div>


### PR DESCRIPTION
The notification icon is aligned with the text, and float is replaced with flexbox layout.

**Before:**
<img width="463" height="106" alt="notification_icon_before" src="https://github.com/user-attachments/assets/67d93531-9108-4d12-bf45-94824588fc0a" />

**After:**
<img width="466" height="83" alt="notification_icon_after" src="https://github.com/user-attachments/assets/bf2e492c-52de-4370-adde-b4cce64c8bbf" />
