### PR TITLE
fix: ensure tailwind utility classes with arbitrary values are prefixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+## Fixed
+- ([#1516](https://github.com/demos-europe/demosplan-ui/pull/1516)) prefixClass: Ensure tailwind utility classes containing arbitrary values are prefixed ([@hwiem](https://github.com/hwiem))
+
+
 ## v0.24.0 - 2026-06-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
-## Fixed
+### Fixed
 - ([#1516](https://github.com/demos-europe/demosplan-ui/pull/1516)) prefixClass: Ensure tailwind utility classes containing arbitrary values are prefixed ([@hwiem](https://github.com/hwiem))
 
 

--- a/src/utils/prefixClass.js
+++ b/src/utils/prefixClass.js
@@ -25,14 +25,16 @@ export default function prefixClass (classList = '') {
   }
 
   /*
-   * Assume a querySelector is passed when a `.`, `#` or `[` either starts a token
-   * (string start or after whitespace, e.g. `.foo`, `#id`, `[data-x]`) or attaches
-   * directly to a type selector (a letter, e.g. `div.foo`, `div#main`, `a[href]`).
-   * In that case only the class selector parts are prefixed.
-   * The letter requirement is what tells these apart from Tailwind utilities, which always
-   * have a `-` or a digit before `.`/`#`/`[` (e.g. `mt-[2px]`, `grid-cols-[1fr]`, `mb-0.5`,
-   * `bg-[#fff]`) — those must stay in classList mode, otherwise they would be left unprefixed
-   * in prefixed builds.
+   * Assume a querySelector is passed when a `.`, `#` or `[` either starts a token (string start or after whitespace,
+   * e.g. `.foo`, `#id`, `[data-x]`) or attaches directly to a type selector, i.e. follows a letter (e.g. `div.foo`,
+   * `div#main`, `a[href]`). In that case only the class selector parts are prefixed.
+   * The "follows a letter" rule is what tells selectors apart from tailwind utility classes: a tailwind utility class
+   * never has a letter immediately before `.`/`#`/`[` - it's always a `-` or a digit (`mt-[2px]`, `grid-cols-[1fr]`,
+   * `mb-0.5`), or `[` itself for hex colors (`bg-[#fff]`).
+   *
+   * Known limitation: a token that *starts* with `[` is always treated as a selector, so tailwind arbitrary variants/properties
+   * (`[&>svg]:size-4`, `[mask-type:luminance]`) are not prefixed. They are indistinguishable from a real attribute
+   * selector by position alone and are currently not supported by prefixClass
    */
   const checkClassList = /(?:^|\s)[.#[]|[a-zA-Z][.#[]/
 

--- a/src/utils/prefixClass.js
+++ b/src/utils/prefixClass.js
@@ -27,13 +27,14 @@ export default function prefixClass (classList = '') {
   /*
    * Assume a querySelector is passed when a `.`, `#` or `[` either starts a token
    * (string start or after whitespace, e.g. `.foo`, `#id`, `[data-x]`) or attaches
-   * directly to a type selector (a letter, e.g. `div.foo`, `a[href]`). In that case
-   * only the class selector parts are prefixed.
+   * directly to a type selector (a letter, e.g. `div.foo`, `div#main`, `a[href]`).
+   * In that case only the class selector parts are prefixed.
    * The letter requirement is what tells these apart from Tailwind utilities, which always
-   * have a `-` or a digit before `.`/`[` (e.g. `mt-[2px]`, `grid-cols-[1fr]`, `mb-0.5`) — those
-   * must stay in classList mode, otherwise they would be left unprefixed in prefixed builds.
+   * have a `-` or a digit before `.`/`#`/`[` (e.g. `mt-[2px]`, `grid-cols-[1fr]`, `mb-0.5`,
+   * `bg-[#fff]`) — those must stay in classList mode, otherwise they would be left unprefixed
+   * in prefixed builds.
    */
-  const checkClassList = /(?:^|\s)[.#[]|[a-zA-Z][.[]/
+  const checkClassList = /(?:^|\s)[.#[]|[a-zA-Z][.#[]/
 
   if (checkClassList.test(classList)) {
     prefixed = classList.replace(/(\.)(\S+)/gi, (cl, m1, m2) => `.${prefix}${m2}`)

--- a/src/utils/prefixClass.js
+++ b/src/utils/prefixClass.js
@@ -24,10 +24,13 @@ export default function prefixClass (classList = '') {
   }
 
   /*
-   * Assuming that a querySelector is passed when classList contains a dot, only the class selector parts are prefixed.
-   * In the unlikely case that classes contain dots as part of their names, they will not be prefixed.
+   * Assuming that a querySelector is passed when a token *starts* with `.`, `#` or `[`
+   * (at the string start or right after whitespace), only the class selector parts are prefixed.
+   * Matching these characters only at a token boundary avoids misreading Tailwind utilities that
+   * legitimately contain them mid-token (e.g. `mt-[2px]`, `grid-cols-[1fr]`, `mb-0.5`) as selectors,
+   * which would otherwise leave them unprefixed in prefixed builds.
    */
-  const checkClassList = /[.#[]/gi
+  const checkClassList = /(?:^|\s)[.#[]/
   if (checkClassList.test(classList)) {
     prefixed = classList.replace(/(\.)(\S+)/gi, (cl, m1, m2) => `.${prefix}${m2}`)
   } else {

--- a/src/utils/prefixClass.js
+++ b/src/utils/prefixClass.js
@@ -7,6 +7,7 @@
  */
 export default function prefixClass (classList = '') {
   let prefix = ''
+
   if (typeof dplan !== 'undefined' && dplan.settings && dplan.settings.publicCSSClassPrefix) {
     prefix = dplan.settings.publicCSSClassPrefix
   }
@@ -24,13 +25,16 @@ export default function prefixClass (classList = '') {
   }
 
   /*
-   * Assuming that a querySelector is passed when a token *starts* with `.`, `#` or `[`
-   * (at the string start or right after whitespace), only the class selector parts are prefixed.
-   * Matching these characters only at a token boundary avoids misreading Tailwind utilities that
-   * legitimately contain them mid-token (e.g. `mt-[2px]`, `grid-cols-[1fr]`, `mb-0.5`) as selectors,
-   * which would otherwise leave them unprefixed in prefixed builds.
+   * Assume a querySelector is passed when a `.`, `#` or `[` either starts a token
+   * (string start or after whitespace, e.g. `.foo`, `#id`, `[data-x]`) or attaches
+   * directly to a type selector (a letter, e.g. `div.foo`, `a[href]`). In that case
+   * only the class selector parts are prefixed.
+   * The letter requirement is what tells these apart from Tailwind utilities, which always
+   * have a `-` or a digit before `.`/`[` (e.g. `mt-[2px]`, `grid-cols-[1fr]`, `mb-0.5`) — those
+   * must stay in classList mode, otherwise they would be left unprefixed in prefixed builds.
    */
-  const checkClassList = /(?:^|\s)[.#[]/
+  const checkClassList = /(?:^|\s)[.#[]|[a-zA-Z][.[]/
+
   if (checkClassList.test(classList)) {
     prefixed = classList.replace(/(\.)(\S+)/gi, (cl, m1, m2) => `.${prefix}${m2}`)
   } else {

--- a/tests/prefixClass.spec.js
+++ b/tests/prefixClass.spec.js
@@ -26,4 +26,10 @@ describe('prefixClass', () => {
     expect(prefixClass('font-[700] mb-2')).toEqual('dp-font-[700] dp-mb-2')
     expect(prefixClass('mb-0.5 text-muted')).toEqual('dp-mb-0.5 dp-text-muted')
   })
+
+  it('should treat compound selectors with a type selector as querySelectors', () => {
+    expect(prefixClass('div.foo')).toEqual('div.dp-foo')
+    expect(prefixClass('a[href]')).toEqual('a[href]')
+    expect(prefixClass('td.bar > .baz')).toEqual('td.dp-bar > .dp-baz')
+  })
 })

--- a/tests/prefixClass.spec.js
+++ b/tests/prefixClass.spec.js
@@ -29,6 +29,7 @@ describe('prefixClass', () => {
 
   it('should treat compound selectors with a type selector as querySelectors', () => {
     expect(prefixClass('div.foo')).toEqual('div.dp-foo')
+    expect(prefixClass('div#main')).toEqual('div#main')
     expect(prefixClass('a[href]')).toEqual('a[href]')
     expect(prefixClass('td.bar > .baz')).toEqual('td.dp-bar > .dp-baz')
   })

--- a/tests/prefixClass.spec.js
+++ b/tests/prefixClass.spec.js
@@ -19,4 +19,11 @@ describe('prefixClass', () => {
   it('should return the same string if there are no points at the beginning of a word', () => {
     expect(prefixClass('[data-some-stuff="its all right"] > a:hover > label')).toEqual('[data-some-stuff="its all right"] > a:hover > label')
   })
+
+  it('should prefix Tailwind utilities that contain arbitrary values or fractional spacing', () => {
+    expect(prefixClass('c-notify__icon shrink-0 mt-[2px]')).toEqual('dp-c-notify__icon dp-shrink-0 dp-mt-[2px]')
+    expect(prefixClass('grid grid-cols-[repeat(auto-fit,minmax(300px,1fr))] gap-4')).toEqual('dp-grid dp-grid-cols-[repeat(auto-fit,minmax(300px,1fr))] dp-gap-4')
+    expect(prefixClass('font-[700] mb-2')).toEqual('dp-font-[700] dp-mb-2')
+    expect(prefixClass('mb-0.5 text-muted')).toEqual('dp-mb-0.5 dp-text-muted')
+  })
 })


### PR DESCRIPTION
### The issue
When using `prefixClass` on tailwind classes like `mt-[2px]`, `grid-cols-[1fr]` or `mb-0.5`, prefixClass skipped them because it treated every string containing `.`, `#` or `[` as querySelectors.

### The fix

Now, prefixClass only treats strings as querySelectors if they start with `.`, `#` or `[` or if these characters follow a whitespace. That way tailwind utility classes like the ones mentioned above will now be prefixed if a prefix is defined.