### PR TITLE
feat(DPLAN-17747): change deselect btn variant to outline in bulkshare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Changed
+- ([#1526](https://github.com/demos-europe/demosplan-ui/pull/1526)) DpBulkEditHeader: use `outline` variant for the deselect button ([@riechedemos](https://github.com/riechedemos))
+
 ## v0.24.0 - 2026-06-12
 
 ### Added

--- a/src/components/DpBulkEditHeader/DpBulkEditHeader.vue
+++ b/src/components/DpBulkEditHeader/DpBulkEditHeader.vue
@@ -5,9 +5,9 @@
     </span>
     <div class="flex items-center gap-[16px]">
       <dp-button
-        color="secondary"
-        data-cy="resetSelection"
         :text="deselect"
+        data-cy="resetSelection"
+        variant="outline"
         @click="$emit('reset-selection')"
       />
       <slot />


### PR DESCRIPTION
### Ticket

[DPLAN-17747](https://demoseurope.youtrack.cloud/issue/DPLAN-17747/Ado-issue-54799-Erstellen-einer-Gruppe)
This PR changes the color of the confirm button in bulkshare to a blue background.