### PR TITLE
feat(DPLAN-17748):  allow a request body on delete for JSON:API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 - ([#1516](https://github.com/demos-europe/demosplan-ui/pull/1516)) prefixClass: Ensure tailwind utility classes containing arbitrary values are prefixed ([@hwiem](https://github.com/hwiem))
 
 ### Changed
-- ([#1533](https://github.com/demos-europe/demosplan-ui/pull/NNN)) DpApi: `dpApi.delete` accepts an optional request body for JSON:API relationship endpoints ([@riechedemos](https://github.com/riechedemos))
+- ([#1533](https://github.com/demos-europe/demosplan-ui/pull/1533)) DpApi: `dpApi.delete` accepts an optional request body for JSON:API relationship endpoints ([@riechedemos](https://github.com/riechedemos))
 
 ## v0.24.0 - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 - ([#1515](https://github.com/demos-europe/demosplan-ui/pull/1515)) DpNotification: Vertically align icon with notification text ([@hwiem](https://github.com/hwiem))
 - ([#1516](https://github.com/demos-europe/demosplan-ui/pull/1516)) prefixClass: Ensure tailwind utility classes containing arbitrary values are prefixed ([@hwiem](https://github.com/hwiem))
 
+### Changed
+- ([#1533](https://github.com/demos-europe/demosplan-ui/pull/NNN)) DpApi: `dpApi.delete` accepts an optional request body for JSON:API relationship endpoints ([@riechedemos](https://github.com/riechedemos))
 
 ## v0.24.0 - 2026-06-12
 

--- a/src/lib/DpApi.js
+++ b/src/lib/DpApi.js
@@ -128,7 +128,7 @@ dpApi.patch = (url, params = {}, data = {}, options = {}) => doRequest({ method:
  * normally has no request body, so this method originally had no `data` param. JSON:API relationship endpoints,
  * however, remove linkage by sending a body even on DELETE, e.g. DELETE /StatementGroup/{id}/relationships/statements
  * { "data": [ { "type": "Statement", "id": "…" } ] } so a body is needed. Keeping `data` last preserves existing
- * callers that pass `options` as the 3rd argument (e.g. store/map/Layers.js). For consistency with the other verbs
+ * callers that pass `options` as the 3rd argument (e.g. store/map/Layers.js). For consistency with the other post/put/patch
  * `data` should eventually move to the 3rd position — a breaking change that requires updating every such caller.
  */
 dpApi.delete = (url, params = {}, options = {}, data = {}) => doRequest({ method: 'DELETE', url, data, params, options })

--- a/src/lib/DpApi.js
+++ b/src/lib/DpApi.js
@@ -124,14 +124,12 @@ dpApi.get = (url, params = {}, options = {}) => doRequest({ method: 'GET', url, 
 dpApi.put = (url, params = {}, data = {}, options = {}) => doRequest({ method: 'PUT', url, data, params, options })
 dpApi.patch = (url, params = {}, data = {}, options = {}) => doRequest({ method: 'PATCH', url, data, params, options })
 /*
- * `data` is intentionally the 4th param here (after `options`), unlike post/put/patch where it is
- * the 3rd. A DELETE normally has no request body, so this method originally had no `data` param.
- * JSON:API relationship endpoints, however, remove linkage by sending a body even on DELETE, e.g.
- *   DELETE /StatementGroup/{id}/relationships/statements
- *   { "data": [ { "type": "Statement", "id": "…" } ] }
- * so a body is needed. Keeping `data` last preserves existing callers that pass `options` as the
- * 3rd argument (e.g. store/map/Layers.js). For consistency with the other verbs `data` should
- * eventually move to the 3rd position — a breaking change that requires updating every such caller.
+ * `data` is intentionally the 4th param here (after `options`), unlike post/put/patch where it is the 3rd. A DELETE
+ * normally has no request body, so this method originally had no `data` param. JSON:API relationship endpoints,
+ * however, remove linkage by sending a body even on DELETE, e.g. DELETE /StatementGroup/{id}/relationships/statements
+ * { "data": [ { "type": "Statement", "id": "…" } ] } so a body is needed. Keeping `data` last preserves existing
+ * callers that pass `options` as the 3rd argument (e.g. store/map/Layers.js). For consistency with the other verbs
+ * `data` should eventually move to the 3rd position — a breaking change that requires updating every such caller.
  */
 dpApi.delete = (url, params = {}, options = {}, data = {}) => doRequest({ method: 'DELETE', url, data, params, options })
 

--- a/src/lib/DpApi.js
+++ b/src/lib/DpApi.js
@@ -123,7 +123,17 @@ dpApi.post = (url, params = {}, data = {}, options = {}) => doRequest({ method: 
 dpApi.get = (url, params = {}, options = {}) => doRequest({ method: 'GET', url, params, options })
 dpApi.put = (url, params = {}, data = {}, options = {}) => doRequest({ method: 'PUT', url, data, params, options })
 dpApi.patch = (url, params = {}, data = {}, options = {}) => doRequest({ method: 'PATCH', url, data, params, options })
-dpApi.delete = (url, params = {}, options = {}) => doRequest({ method: 'DELETE', url, params, options })
+/*
+ * `data` is intentionally the 4th param here (after `options`), unlike post/put/patch where it is
+ * the 3rd. A DELETE normally has no request body, so this method originally had no `data` param.
+ * JSON:API relationship endpoints, however, remove linkage by sending a body even on DELETE, e.g.
+ *   DELETE /StatementGroup/{id}/relationships/statements
+ *   { "data": [ { "type": "Statement", "id": "…" } ] }
+ * so a body is needed. Keeping `data` last preserves existing callers that pass `options` as the
+ * 3rd argument (e.g. store/map/Layers.js). For consistency with the other verbs `data` should
+ * eventually move to the 3rd position — a breaking change that requires updating every such caller.
+ */
+dpApi.delete = (url, params = {}, options = {}, data = {}) => doRequest({ method: 'DELETE', url, data, params, options })
 
 /**
  * Submit a request to the rpc_generic_post API, which implements JSON-RPC 2.0.


### PR DESCRIPTION
## Ticket [DPLAN-17748](url)

dpApi.delete could not send a request body, unlike post/put/patch. This adds an optional data parameter so DELETE requests can carry a JSON:API relationship document.

Why: JSON:API relationship endpoints remove linkage by sending a body — even on DELETE, e.g.:

DELETE /StatementGroup/{id}/relationships/statements
{ "data": [ { "type": "Statement", "id": "…" } ] }

The id of the resource to detach is in the body, not the URL. Without a data parameter the body was dropped and the backend responded 400 – no data array.

How: data was added as the 4th parameter (after options), not the 3rd as in post/put/patch:

dpApi.delete = (url, params = {}, options = {}, data = {}) => …

This keeps the change non-breaking: existing callers that pass options as the 3rd argument (e.g. store/map/Layers.js) are unaffected. A code comment documents the JSON:API rationale and notes that, for consistency with the other verbs, data should eventually move to the 3rd position — a follow-up breaking change requiring every such caller to be updated.

Backward compatibility

Non-breaking. No existing caller changes behavior.