### PR TITLE
Feat( refs: DPLAN-17995) Show OCR review hint when box recognition was skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 ## UNRELEASED
 
 ### Added
-- ([#1535](https://github.com/demos-europe/demosplan-ui/pull/1535)) DpInlineNotification: add optinal bold title ([@riechedemos](https://github.com/riechedemos))
+- ([#1535](https://github.com/demos-europe/demosplan-ui/pull/1535)) DpInlineNotification: add optional semi-bold title ([@riechedemos](https://github.com/riechedemos))
 
 ## v0.25.0 - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+- ([#1535](https://github.com/demos-europe/demosplan-ui/pull/1535)) DpInlineNotification: add optinal bold title ([@riechedemos](https://github.com/riechedemos))
+
 ## v0.25.0 - 2026-07-10
 
 ### Fixed

--- a/src/components/DpInlineNotification/DpInlineNotification.vue
+++ b/src/components/DpInlineNotification/DpInlineNotification.vue
@@ -96,7 +96,7 @@ export default {
     },
 
     /**
-     * An optional bold headline, rendered above the message/slot content.
+     * An optional semi-bold headline, rendered above the message/slot content.
      */
     title: {
       type: String,

--- a/src/components/DpInlineNotification/DpInlineNotification.vue
+++ b/src/components/DpInlineNotification/DpInlineNotification.vue
@@ -15,7 +15,7 @@
       <p
         v-if="title"
         :data-cy="`${dataCy}:title`"
-        class="weight--bold"
+        class="font-semibold"
         v-text="title"
       />
       <div

--- a/src/components/DpInlineNotification/DpInlineNotification.vue
+++ b/src/components/DpInlineNotification/DpInlineNotification.vue
@@ -12,6 +12,12 @@
       weight="fill"
     />
     <div class="space-stack-xs">
+      <p
+        v-if="title"
+        :data-cy="`${dataCy}:title`"
+        class="weight--bold"
+        v-text="title"
+      />
       <div
         v-if="message"
         :data-cy="`${dataCy}:message`"
@@ -84,6 +90,15 @@ export default {
     },
 
     message: {
+      type: String,
+      required: false,
+      default: null,
+    },
+
+    /**
+     * An optional bold headline, rendered above the message/slot content.
+     */
+    title: {
       type: String,
       required: false,
       default: null,

--- a/tests/DpInlineNotification.spec.js
+++ b/tests/DpInlineNotification.spec.js
@@ -38,6 +38,19 @@ describe('', () => {
     expect(wrapper.find('[data-cy="inlineNotification:hideHint"]').exists()).toBe(true)
   })
 
+  it('renders title when given', () => {
+    wrapper = createWrapper({ title: 'Test Title' })
+
+    expect(wrapper.find('[data-cy="inlineNotification:title"]').exists()).toBe(true)
+    expect(wrapper.find('[data-cy="inlineNotification:title"]').text()).toBe('Test Title')
+  })
+
+  it('does not render title when not given', () => {
+    wrapper = createWrapper()
+
+    expect(wrapper.find('[data-cy="inlineNotification:title"]').exists()).toBe(false)
+  })
+
   it('renders correct styling and icon for different types', () => {
     const types = [
       { type: 'confirm', class: 'flash-confirm', icon: 'check-circle' },


### PR DESCRIPTION
### Ticket
[DPLAN-17795](https://demoseurope.youtrack.cloud/issue/DPLAN-17995/Optionale-Uberspringung-der-Boxenerkennung-beim-PDF-Import-rechtlicher-Prufhinweis)

This PR adds an semi-bold optional title to DpInlineNotification.

### How to review
You need to have the addon demospipes installed. If you us the umber dump you should be able to see this as Motoko:

http://ewm.dplan.local/app_dev.php/verfahren/f222e27c-ecd0-46a5-82bd-2c3403cbf7da/uebersicht
and  ready_to_convert: http://ewm.dplan.local/app_dev.php/verfahren/a97390f2-bd3c-462d-940e-4eef1bcc61c7/uebersicht

- Open the PDF import tab, check "Boxenerkennung überspringen" → warning notification appears below
- Uncheck it → warning disappears                                             
-  Import a PDF with the checkbox checked, then open its confirmation page (`.../annotatedStatementPdf/{id}/umwandeln`) → warning appears there too

### Linked PRs
- demos-europe/demosplan-core#6606 (confirmation page notification)