### PR TITLE
feat(refs DPLAN-18229): replace robot icon with sparkle icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Changed
+- ([#1541](https://github.com/demos-europe/demosplan-ui/pull/1541)) DpIcon: Replace robot icon with sparkle icon as AI icon ([@hwiem](https://github.com/hwiem))
+
 ## v0.26.0 - 2026-07-23
 
 ### Added

--- a/src/components/DpIcon/util/iconConfig.ts
+++ b/src/components/DpIcon/util/iconConfig.ts
@@ -52,8 +52,8 @@ import {
   PhPlus,
   PhProhibit,
   PhQuestion,
-  PhRobot,
   PhSignOut,
+  PhSparkle,
   PhTag,
   PhTrash,
   PhUploadSimple,
@@ -125,13 +125,13 @@ const mappedIcons: Record<PhosphorIconName | AliasedPhosphorIconName, Component>
   'lock-simple-open': PhLockSimpleOpen, // Alias: unlock
   'magnifying-glass': PhMagnifyingGlass, // Alias: search
   'pencil-simple': PhPencilSimple, // Alias: edit
-  'robot': PhRobot, // Alias: ai
+  'sparkle': PhSparkle, // Alias: ai
   'warning-diamond': PhWarningDiamond, // Alias: severe
 }
 
 // Icon names that are used as aliases - the phosphor icon has a different name
 const mappedIconAliases: Record<IconAlias, Component> = {
-  'ai': PhRobot,
+  'ai': PhSparkle,
   'cancel': PhX,
   'chevron-down': PhCaretDown,
   'chevron-left': PhCaretLeft,

--- a/types/icons.ts
+++ b/types/icons.ts
@@ -1,5 +1,5 @@
 export type IconAlias =
-  'ai' // Alias for 'robot'
+  'ai' // Alias for 'sparkle'
   | 'cancel' // Alias for 'xmark' -> 'x'
   | 'chevron-down' // Alias for 'caret-down'
   | 'chevron-left' // Alias for 'caret-left'
@@ -44,7 +44,8 @@ export type AliasedPhosphorIconName =
   | 'lock-simple-open'
   | 'magnifying-glass'
   | 'pencil-simple'
-  | 'robot'
+  | 'prohibit'
+  | 'sparkle'
   | 'warning-diamond'
 
 export type PhosphorIconName =


### PR DESCRIPTION
**Ticket:** [DPLAN-18229](https://demoseurope.youtrack.cloud/issue/DPLAN-18229/Beta-Version-Label-bei-Ahnliche-Erwiderung-entfernen-Tooltip-Hinweis-erhalten)

The sparkle icon is now generally established as the ai icon, so we decided to replace the robot icon