### PR TITLE
feat(refs DPLAN-17637): add padded and highlightToggledTrigger props to DpAccordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 ## UNRELEASED
 
 ### Added
-- DpAccordion: add `padded` prop to apply inset spacing to the toggle trigger and `highlightToggledTrigger` prop to give it a background color while its section is expanded ([@riechedemos](https://github.com/riechedemos))
+- ([#1543](https://github.com/demos-europe/demosplan-ui/pull/1543)) DpAccordion: add `padded` prop to apply inset spacing to the toggle trigger and `highlightToggledTrigger` prop to give it a background color while its section is expanded ([@riechedemos](https://github.com/riechedemos))
 
 ## v0.27.0 - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+- DpAccordion: add `padded` prop to apply inset spacing to the toggle trigger and `highlightToggledTrigger` prop to give it a background color while its section is expanded ([@riechedemos](https://github.com/riechedemos))
+
 ## v0.27.0 - 2026-07-24
 
 ### Changed

--- a/src/components/DpAccordion/DpAccordion.vue
+++ b/src/components/DpAccordion/DpAccordion.vue
@@ -5,7 +5,7 @@
       :aria-expanded="isVisible.toString()"
       :data-cy="dataCy"
       class="flex items-center justify-between w-full text-default hover:text-interactive hover:cursor-pointer active:text-interactive-hover"
-      :class="{ 'border-b border-neutral pb-2': showBorder }"
+      :class="triggerClasses"
       type="button"
       @click="() => toggle()"
     >
@@ -57,8 +57,21 @@ export default {
       default: false,
     },
 
+    // Adds background color to a toggled trigger
+    highlightToggledTrigger: {
+      type: Boolean,
+      default: false,
+    },
+
     // Needed if you want to toggle the accordion from outside
     isOpen: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+
+    // Apply inset spacing to the toggle trigger
+    padded: {
       type: Boolean,
       required: false,
       default: false,
@@ -96,6 +109,32 @@ export default {
 
     iconSize () {
       return this.compressed ? 'medium' : 'large'
+    },
+
+    triggerClasses () {
+      const classes = []
+
+      if (this.padded) {
+        /*
+         * The left inset is kept small on purpose so the title lines up with content
+         * rendered below it, which sits closer to the edge than the other insets.
+         */
+        classes.push('py-2 pr-2 pl-1.5')
+      } else if (this.showBorder) {
+        // Without inset spacing, the bottom spacing stays coupled to the border.
+        classes.push('pb-2')
+      }
+
+      if (this.showBorder) {
+        classes.push('border-b border-neutral')
+      }
+
+      // Highlight the trigger of the section that is currently expanded.
+      if (this.highlightToggledTrigger && this.isVisible) {
+        classes.push('bg-surface-light')
+      }
+
+      return classes
     },
   },
 

--- a/tests/DpAccordion.spec.js
+++ b/tests/DpAccordion.spec.js
@@ -63,4 +63,19 @@ describe('DpAccordion', () => {
     await wrapper.setProps({ compressed: true })
     expect(wrapper.find('span').classes()).toContain('text-base')
   })
+
+  it('adds inset trigger spacing if "padded" is set to true', async () => {
+    await wrapper.setProps({ padded: true })
+    expect(wrapper.find('button').classes()).toContain('py-2')
+    expect(wrapper.find('button').classes()).toContain('pr-2')
+    expect(wrapper.find('button').classes()).toContain('pl-1.5')
+  })
+
+  it('highlights the trigger if "highlightToggledTrigger" is true and accordion is open', async () => {
+    await wrapper.setProps({
+      highlightToggledTrigger: true,
+      isOpen: true,
+    })
+    expect(wrapper.find('button').classes()).toContain('bg-surface-light')
+  })
 })


### PR DESCRIPTION
[### DPLAN-17637](https://demoseurope.youtrack.cloud/issue/DPLAN-17637/Einreichende-Suche-aus-ROBOB-in-EWM-freischalten-anpassen)

The cross-procedure submitter search renders one accordion per procedure, stacked in a list. Two props were needed for that:

- `padded` applies inset spacing to the toggle trigger. The left inset is deliberately smaller than the others so the title lines up with the content rendered below it.
- `highlightToggledTriggurface-light` backgroundwhile its section is expanded, so the currently open section stands out among
its siblings.

Both default to `false`,r current appearance. The trigger classes moved from an inline `:class` object into a `triggerClasses`
computed, which also decm `showBorder` when`padded` is set.

### How to review/test
- login as Masteruser
- Click on "Einreichende suchen" in side menu ans search a username
- this should show you all statements made by this user in all procedures
- delete a statement
- it should work if the statement isn't claimed by an other user

### Linked PR

https://github.com/demos-europe/demosplan-core/pull/6632