### PR TITLE
feat(refs: DPLAN-18152): add transparent button and bulk edit header design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+- ([#1549](https://github.com/demos-europe/demosplan-ui/pull/1549)) DpButton: add `transparent` variant ([@huellnerdemos](https://github.com/huellnerdemos))
+- ([#1549](https://github.com/demos-europe/demosplan-ui/pull/1549)) DpDataTable: emit `columns-reordered` when the user drags a column into a new position ([@huellnerdemos](https://github.com/huellnerdemos))
+
+### Changed
+- ([#1549](https://github.com/demos-europe/demosplan-ui/pull/1549)) DpBulkEditHeader: changed the old design to a new one ([@huellnerdemos](https://github.com/huellnerdemos))
+
 ## v0.27.0 - 2026-07-24
 
 ### Changed

--- a/src/components/DpBulkEditHeader/DpBulkEditHeader.vue
+++ b/src/components/DpBulkEditHeader/DpBulkEditHeader.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    class="flex items-center flex-wrap gap-y-4 py-2 px-3 rounded-md"
-    :class="isCopied ? 'border-l-4 border-interactive bg-surface-light' : 'bg-selected'"
-  >
+  <div class="flex items-center flex-wrap gap-y-4 py-2 px-3 rounded-md border-l-4 border-interactive bg-surface-light">
     <span>
       {{ selectedItemsText }}
     </span>
@@ -10,7 +7,7 @@
       <slot name="buttonRowStart" />
       <dp-button
         :text="deselect"
-        :variant="isCopied ? 'outline' : 'solid'"
+        variant="outline"
         color="secondary"
         data-cy="resetSelection"
         @click="$emit('reset-selection')"
@@ -32,11 +29,6 @@ export default {
   },
 
   props: {
-    isCopied: {
-      type: Boolean,
-      default: false,
-    },
-
     selectedItemsText: {
       type: String,
       required: true,

--- a/src/components/DpBulkEditHeader/DpBulkEditHeader.vue
+++ b/src/components/DpBulkEditHeader/DpBulkEditHeader.vue
@@ -1,13 +1,18 @@
 <template>
-  <div class="flex items-center justify-between p-2 bg-selected">
+  <div
+    class="flex items-center flex-wrap gap-y-4 py-2 px-3 rounded-md"
+    :class="isCopied ? 'border-l-4 border-interactive bg-surface-light' : 'bg-selected'"
+  >
     <span>
       {{ selectedItemsText }}
     </span>
-    <div class="flex items-center gap-[16px]">
+    <div class="flex items-center gap-[16px] ml-auto whitespace-nowrap">
+      <slot name="buttonRowStart" />
       <dp-button
+        :text="deselect"
+        :variant="isCopied ? 'outline' : 'solid'"
         color="secondary"
         data-cy="resetSelection"
-        :text="deselect"
         @click="$emit('reset-selection')"
       />
       <slot />
@@ -27,6 +32,11 @@ export default {
   },
 
   props: {
+    isCopied: {
+      type: Boolean,
+      default: false,
+    },
+
     selectedItemsText: {
       type: String,
       required: true,

--- a/src/components/DpButton/DpButton.stories.tsx
+++ b/src/components/DpButton/DpButton.stories.tsx
@@ -23,7 +23,7 @@ const meta: Meta<typeof DpButton> = {
       },
     },
     variant: {
-      options: ['solid', 'outline', 'subtle'],
+      options: ['solid', 'outline', 'subtle', 'transparent'],
       control: {type: 'select'},
     },
     iconSize: {
@@ -80,6 +80,13 @@ export const Outline: Story = {
 export const Subtle: Story = {
   args: {
     variant: 'subtle',
+    text: 'Save',
+  }
+}
+
+export const Transparent: Story = {
+  args: {
+    variant: 'transparent',
     text: 'Save',
   }
 }

--- a/src/components/DpButton/DpButton.vue
+++ b/src/components/DpButton/DpButton.vue
@@ -302,7 +302,12 @@ const allColorClasses = {
       focus:border-interactive-subtle-hover\
       focus-visible:border-interactive-subtle-hover\
       active:border-interactive-subtle-active `,
-    // Transparent: classes that only apply to "transparent" button color variant. No background in any state.
+    /**
+     * Transparent: classes that only apply to "transparent" button color variant.
+     *
+     * No background outside the busy state — the "bg-busy" overlay still applies like on every
+     * other variant.
+     */
     transparent: `
       border border-transparent bg-transparent text-interactive\
       hover:text-interactive-hover hover:no-underline\

--- a/src/components/DpButton/DpButton.vue
+++ b/src/components/DpButton/DpButton.vue
@@ -45,7 +45,7 @@ import { Tooltip } from '~/directives'
 
 type ButtonColor = 'primary' | 'secondary' | 'warning'
 type ButtonType = 'button' | 'submit'
-type ButtonVariant = 'solid' | 'outline' | 'subtle'
+type ButtonVariant = 'solid' | 'outline' | 'subtle' | 'transparent'
 
 const props = defineProps({
   /**
@@ -159,14 +159,14 @@ const props = defineProps({
   },
 
   /**
-   * The button may have a variant of `solid`, `outline`, or `subtle`.
+   * The button may have a variant of `solid`, `outline`, `subtle`, or `transparent`.
    * When not specified, the `solid` variant (white on colored background) is applied.
    */
   variant: {
     type: String as PropType<ButtonVariant>,
     required: false,
     default: 'solid',
-    validator: (prop: ButtonVariant) => ['solid', 'outline', 'subtle'].includes(prop),
+    validator: (prop: ButtonVariant) => ['solid', 'outline', 'subtle', 'transparent'].includes(prop),
   },
 })
 
@@ -201,6 +201,9 @@ const colorClasses = computed(() => {
     break
   case 'subtle':
     renderedColors.push(colors.outlineSubtle, colors.subtle)
+    break
+  case 'transparent':
+    renderedColors.push(colors.transparent)
     break
   default:
     break
@@ -299,6 +302,13 @@ const allColorClasses = {
       focus:border-interactive-subtle-hover\
       focus-visible:border-interactive-subtle-hover\
       active:border-interactive-subtle-active `,
+    // Transparent: classes that only apply to "transparent" button color variant. No background in any state.
+    transparent: `
+      border border-transparent bg-transparent text-interactive\
+      hover:text-interactive-hover hover:no-underline\
+      focus:text-interactive-hover\
+      focus-visible:text-interactive-hover\
+      active:text-interactive-active `,
   },
   secondary: {
     solidOutlineSubtle: ' outline-4 outline-offset-0 outline-transparent focus-visible:outline-[#595959]/50 ',
@@ -326,6 +336,12 @@ const allColorClasses = {
       focus:border-interactive-secondary-subtle-hover\
       focus-visible:border-interactive-secondary-subtle-hover\
       active:border-interactive-secondary-subtle-active `,
+    transparent: `
+      border border-transparent bg-transparent text-interactive-secondary\
+      hover:text-interactive-secondary-hover hover:no-underline\
+      focus:text-interactive-secondary-hover\
+      focus-visible:text-interactive-secondary-hover\
+      active:text-interactive-secondary-active `,
   },
   warning: {
     solidOutlineSubtle: ' outline-4 outline-offset-0 outline-transparent focus-visible:outline-[#B20000]/50 ',
@@ -353,6 +369,12 @@ const allColorClasses = {
       focus:border-interactive-warning-subtle-hover\
       focus-visible:border-interactive-warning-subtle-hover\
       active:border-interactive-warning-subtle-active `,
+    transparent: `
+      border border-transparent bg-transparent text-interactive-warning\
+      hover:text-interactive-warning-hover hover:no-underline\
+      focus:text-interactive-warning-hover\
+      focus-visible:text-interactive-warning-hover\
+      active:text-interactive-warning-active `,
   },
 }
 </script>

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -499,6 +499,7 @@ export default {
 
   emits: [
     'changed-order',
+    'columns-reordered',
     'items-selected',
     'items-toggled',
     'selectAll',
@@ -661,6 +662,8 @@ export default {
           JSON.stringify(nonFixedOrder),
         )
       }
+
+      this.$emit('columns-reordered', this.orderedHeaderFields.map(headerField => headerField.field))
     },
 
     /**


### PR DESCRIPTION
### Ticket
DPLAN-18152

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

This PR adds a transparent variant to DpButton and adjusts the design of bulk edit header depending on a isCopied prop.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Login as admin and go to a procedure with segmented statements
2. Go to the segments list
3. Choose which columns should be shown in the list
4. Select at least one segment
5. The bulk edit header appears, including a button to copy to clipboard
6. Push the button and check if bulk edit header design changes and the copy button has a transparent background


### Linked PRs
Core: https://github.com/demos-europe/demosplan-core/pull/6658
### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Run `yarn lint`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [x] Update changelog 