### PR TITLE
feat(refs DPLAN-18149): slots for DpAccordion, hidden label for DpCheckbox, cut flag for DpEditor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 - ([#1550](https://github.com/demos-europe/demosplan-ui/pull/1550)) DpEditor: Add `cut` toolbar item to hide the cut button where content may only be altered, not removed ([@riechedemos](https://github.com/riechedemos))
 
 ### Changed
-- ([#1550](https://github.com/demos-europe/demosplan-ui/pull/1550)) DpSlidebar: Move the close button to the right, the edge the slidebar docks to, in line with DpModal ([@riechedemos](https://github.com/riechedemos))
+- ([#1550](https://github.com/demos-europe/demosplan-ui/pull/1550)) DpSlidebar: Move the close button to the right, the edge the slidebar docks to, and give it an accessible name, both in line with DpModal ([@riechedemos](https://github.com/riechedemos))
 
 ## v0.27.0 - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 
 ## UNRELEASED
 
+### Added
+- ([#1550](https://github.com/demos-europe/demosplan-ui/pull/1550)) DpAccordion: Add `titlePrefix` and `titleSuffix` slots to place content next to the title, the prefix outside the toggle button so interactive content is not nested within it ([@riechedemos](https://github.com/riechedemos))
+- ([#1550](https://github.com/demos-europe/demosplan-ui/pull/1550)) DpCheckbox: Accept `hide` in the `label` prop to name the checkbox for screen readers without displaying the text ([@riechedemos](https://github.com/riechedemos))
+- ([#1550](https://github.com/demos-europe/demosplan-ui/pull/1550)) DpEditor: Add `cut` toolbar item to hide the cut button where content may only be altered, not removed ([@riechedemos](https://github.com/riechedemos))
+
 ## v0.27.0 - 2026-07-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 - ([#1550](https://github.com/demos-europe/demosplan-ui/pull/1550)) DpCheckbox: Accept `hide` in the `label` prop to name the checkbox for screen readers without displaying the text ([@riechedemos](https://github.com/riechedemos))
 - ([#1550](https://github.com/demos-europe/demosplan-ui/pull/1550)) DpEditor: Add `cut` toolbar item to hide the cut button where content may only be altered, not removed ([@riechedemos](https://github.com/riechedemos))
 
+### Changed
+- ([#1550](https://github.com/demos-europe/demosplan-ui/pull/1550)) DpSlidebar: Move the close button to the right, the edge the slidebar docks to, in line with DpModal ([@riechedemos](https://github.com/riechedemos))
+
 ## v0.27.0 - 2026-07-24
 
 ### Changed

--- a/src/components/DpAccordion/DpAccordion.vue
+++ b/src/components/DpAccordion/DpAccordion.vue
@@ -1,21 +1,34 @@
 <template>
   <div>
-    <button
+    <div
       v-if="title !== ''"
-      :aria-expanded="isVisible.toString()"
-      :data-cy="dataCy"
-      class="flex items-center justify-between w-full text-default hover:text-interactive hover:cursor-pointer active:text-interactive-hover"
+      class="flex items-start"
       :class="{ 'border-b border-neutral pb-2': showBorder }"
-      type="button"
-      @click="() => toggle()"
     >
-      <span :class="titleClasses">{{ title }}</span>
-      <dp-icon
-        aria-hidden="true"
-        :icon="isVisible ? 'caret-up' : 'caret-down'"
-        :size="iconSize"
-      />
-    </button>
+      <!--
+        Rendered beside the toggle button instead of inside it, so that interactive content
+        (e.g. a checkbox) does not end up nested within a button.
+      -->
+      <slot name="titlePrefix" />
+      <button
+        :aria-expanded="isVisible.toString()"
+        :data-cy="dataCy"
+        class="flex items-center justify-between grow text-default hover:text-interactive hover:cursor-pointer active:text-interactive-hover"
+        type="button"
+        @click="() => toggle()"
+      >
+        <span class="flex items-center gap-1">
+          <span :class="titleClasses">{{ title }}</span>
+          <!-- Additional non-interactive information displayed next to the title. -->
+          <slot name="titleSuffix" />
+        </span>
+        <dp-icon
+          aria-hidden="true"
+          :icon="isVisible ? 'caret-up' : 'caret-down'"
+          :size="iconSize"
+        />
+      </button>
+    </div>
     <dp-transition-expand>
       <div v-show="isVisible">
         <!-- This is where the accordion content goes. -->

--- a/src/components/DpCheckbox/DpCheckbox.vue
+++ b/src/components/DpCheckbox/DpCheckbox.vue
@@ -83,7 +83,7 @@ export default {
       type: Object,
       default: () => ({}),
       validator: (prop) => {
-        return Object.keys(prop).every(key => ['bold', 'hint', 'text', 'tooltip'].includes(key))
+        return Object.keys(prop).every(key => ['bold', 'hide', 'hint', 'text', 'tooltip'].includes(key))
       },
     },
 

--- a/src/components/DpEditor/DpEditor.vue
+++ b/src/components/DpEditor/DpEditor.vue
@@ -34,21 +34,23 @@
         <div :class="[isFullscreen ? 'fullscreen': '', prefixClass('editor')]">
           <div :class="[readonly ? prefixClass('readonly'): '', prefixClass('menubar')]">
             <!-- Cut -->
-            <button
-              v-tooltip="translations.cut"
-              :aria-label="translations.cut"
-              :class="prefixClass('menubar__button')"
-              data-cy="editor:cut"
-              :disabled="readonly"
-              type="button"
-              @click="cut"
-            >
-              <i
-                :class="prefixClass('fa fa-scissors')"
-                aria-hidden="true"
-              />
-            </button>
-            &#10072;
+            <template v-if="toolbar.cut">
+              <button
+                v-tooltip="translations.cut"
+                :aria-label="translations.cut"
+                :class="prefixClass('menubar__button')"
+                data-cy="editor:cut"
+                :disabled="readonly"
+                type="button"
+                @click="cut"
+              >
+                <i
+                  :class="prefixClass('fa fa-scissors')"
+                  aria-hidden="true"
+                />
+              </button>
+              &#10072;
+            </template>
             <!-- Undo -->
             <button
               v-tooltip="translations.undo"
@@ -663,6 +665,11 @@ export default {
         ],
       },
       toolbar: Object.assign({
+        /**
+         * Enables a menu button to cut out the current text selection.
+         * Set to false where content may only be altered, not removed.
+         */
+        cut: true,
         /**
          * Array with numbers 1-6 defining which heading-buttons we want to show
          */

--- a/src/components/DpSlidebar/DpSlidebar.vue
+++ b/src/components/DpSlidebar/DpSlidebar.vue
@@ -13,17 +13,20 @@
 
       <div class="c-slidebar__scroll-container">
         <div class="u-ml-1_5">
-          <button
-            type="button"
-            class="btn--blank o-link--default u-mt-0_5 u-n-ml u-mb"
-            data-slidebar-hide=""
-            @click="$emit('close')"
-          >
-            <dp-icon
-              icon="close"
-              size="large"
-            />
-          </button>
+          <!-- The slidebar always docks to the right, so the close button sits at that outer edge. -->
+          <div class="flex justify-end u-mt-0_5">
+            <button
+              type="button"
+              class="btn--blank o-link--default"
+              data-slidebar-hide=""
+              @click="$emit('close')"
+            >
+              <dp-icon
+                icon="close"
+                size="large"
+              />
+            </button>
+          </div>
           <slot />
         </div>
       </div>

--- a/src/components/DpSlidebar/DpSlidebar.vue
+++ b/src/components/DpSlidebar/DpSlidebar.vue
@@ -16,6 +16,8 @@
           <!-- The slidebar always docks to the right, so the close button sits at that outer edge. -->
           <div class="flex justify-end pt-2 pr-1">
             <button
+              :aria-label="translations.close"
+              :title="translations.close"
               type="button"
               class="btn--blank o-link--default"
               data-slidebar-hide=""
@@ -35,6 +37,7 @@
 </template>
 
 <script>
+import { de } from '~/components/shared/translations'
 import DpIcon from '~/components/DpIcon'
 import { hasOwnProp } from '~/utils'
 import { SideNav } from '~/lib'
@@ -53,6 +56,9 @@ export default {
   data () {
     return {
       sideNav: {},
+      translations: {
+        close: de.window.close,
+      },
     }
   },
 

--- a/src/components/DpSlidebar/DpSlidebar.vue
+++ b/src/components/DpSlidebar/DpSlidebar.vue
@@ -14,7 +14,7 @@
       <div class="c-slidebar__scroll-container">
         <div class="u-ml-1_5">
           <!-- The slidebar always docks to the right, so the close button sits at that outer edge. -->
-          <div class="flex justify-end u-mt-0_5">
+          <div class="flex justify-end pt-2 pr-1">
             <button
               type="button"
               class="btn--blank o-link--default"

--- a/tests/DpAccordion.spec.js
+++ b/tests/DpAccordion.spec.js
@@ -26,7 +26,7 @@ describe('DpAccordion', () => {
   })
 
   it('displays the title as "bold" if "fontWeight" is set to "bold"', () => {
-    expect(wrapper.find('button > span').classes()).toContain('weight--bold')
+    expect(wrapper.find('button > span > span').classes()).toContain('weight--bold')
   })
 
   it('sets "aria-expanded" to false if "isOpen" is false', () => {
@@ -61,6 +61,29 @@ describe('DpAccordion', () => {
 
   it('displays a reduced font size if "compressed" is set to "true"', async () => {
     await wrapper.setProps({ compressed: true })
-    expect(wrapper.find('span').classes()).toContain('text-base')
+    expect(wrapper.find('button > span > span').classes()).toContain('text-base')
+  })
+
+  /*
+   * The prefix must stay outside of the toggle button, otherwise interactive slot content
+   * ends up nested within a button, which is invalid and swallows its own clicks.
+   */
+  it('renders "titlePrefix" content next to the toggle button, not inside it', () => {
+    const wrapperWithPrefix = shallowMount(DpAccordion, {
+      props: { title: 'Test Title' },
+      slots: { titlePrefix: '<input id="prefix" type="checkbox">' },
+    })
+
+    expect(wrapperWithPrefix.find('#prefix').exists()).toBe(true)
+    expect(wrapperWithPrefix.find('button #prefix').exists()).toBe(false)
+  })
+
+  it('renders "titleSuffix" content inside the toggle button, next to the title', () => {
+    const wrapperWithSuffix = shallowMount(DpAccordion, {
+      props: { title: 'Test Title' },
+      slots: { titleSuffix: '<span id="suffix">Suffix</span>' },
+    })
+
+    expect(wrapperWithSuffix.find('button #suffix').exists()).toBe(true)
   })
 })

--- a/tests/DpLabel.spec.js
+++ b/tests/DpLabel.spec.js
@@ -25,4 +25,11 @@ describe('DpLabel', () => {
 
     expect(wrapper.vm.hints).toEqual(expect.arrayContaining(['test hint']))
   })
+
+  it('hides the label visually while keeping it in the document if "hide" is set', async () => {
+    await wrapper.setProps({ hide: true })
+
+    expect(wrapper.classes()).toContain('sr-only')
+    expect(wrapper.text()).toContain('test text')
+  })
 })


### PR DESCRIPTION
[### DPLAN-18149](https://demoseurope.youtrack.cloud/issue/DPLAN-18149/Abschnitte-und-Erwiderungen-per-E-Mail-versenden)

Sending a segment via email opens a form in the slidebar that lists the segment text and the recommendation, each behind an accordion with a checkbox in its header, and each in an editor that may only obscure content. Three small additions were needed for that:

- **DpAccordion**: `titlePrefix` and `titleSuffix` slots. The prefix is rendered beside the toggle button rather than inside it, so that interactive content such as a checkbox does not end up nested within a button. The suffix sits next to the title inside the button and is meant for non-interactive information. Without either slot the component renders as before.
- **DpCheckbox**: `hide` is now accepted in the `label` prop. `DpLabel` already supports hiding a label visually while keeping it available to screen readers; only the validator kept the key from being passed through. This lets a checkbox be named for assistive technology when adjacent content already shows that text.
- **DpEditor**: `cut` toolbar flag, defaulting to `true` so the button stays visible everywhere it is used today. Set it to `false` where content may only be altered, not removed.

While working in the slidebar, one inconsistency became apparent and is fixed here as well:

- **DpSlidebar**: the close button moved from the top left to the top right. The slidebar always docks to the right, and `DpModal` already closes at the top right. **This one is visible wherever the slidebar is used**, not only in the new form — see the review notes below.

### How to review/test
- Storybook: DpAccordion still looks unchanged without the new slots, and places slot content correctly with them.
- Any existing DpEditor keeps its cut button; passing `:toolbar-items="{ cut: false }"` hides it together with its separator.
- Any existing DpCheckbox is unaffected; passing `:label="{ text: '…', hide: true }"` hides the label visually but keeps it readable for screen readers.
- The moved close button affects six places in demosplan-core, worth a look at a few of them: assessment table (`DpTable`), recommendation screen (`StatementSegmentsList`), map (`WmsGetFeatureInfo`), cluster detail, statement detail and the segment list.

### Linked PR

https://github.com/demos-europe/demosplan-core/pull/6659
