### PR TITLE
feat(refs DPLAN-18003, #AB55977): add sorting procedure phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ Since v0.0.10, this Changelog is formatted according to the [Common Changelog][c
 ## UNRELEASED
 
 ### Added
+- ([#1552](https://github.com/demos-europe/demosplan-ui/pull/1552)) DpDataTable, DpTableRow:
+  - add props to exclude individual rows from dragging
+  - keep row dragging inside its own table ([@rafelddemos](https://github.com/rafelddemos))
 - ([#1543](https://github.com/demos-europe/demosplan-ui/pull/1543)) DpAccordion: add `padded` prop to apply inset spacing to the toggle trigger and `highlightToggledTrigger` prop to give it a background color while its section is expanded ([@riechedemos](https://github.com/riechedemos))
+
+### Fixed
+- ([#1552](https://github.com/demos-europe/demosplan-ui/pull/1552)) DpDataTable: pass `handle` through to SortableJS so rows are dragged by the drag handle only instead of from anywhere in the row ([@rafelddemos](https://github.com/rafelddemos))
 
 ## v0.27.0 - 2026-07-24
 

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -139,9 +139,7 @@
         v-if="isDraggable && !isLoading"
         draggable-tag="tbody"
         :content-data="items"
-        handle="c-data-table__drag-handle"
-        ghost-class="sortable-ghost"
-        chosen-class="sortable-chosen"
+        :opts="draggableOptions"
         @end="(event, item) => $emit('changed-order', event, item)"
       >
         <template
@@ -555,6 +553,15 @@ export default {
       })
 
       return this.headerCellCount + tableCellCount
+    },
+
+    // SortableJS options for row dragging, so they reach SortableJS via `opts`.
+    draggableOptions () {
+      return {
+        chosenClass: 'sortable-chosen',
+        ghostClass: 'sortable-ghost',
+        handle: '.c-data-table__drag-handle',
+      }
     },
 
     /**

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -155,6 +155,8 @@
             :has-flyout="hasFlyout"
             :header-fields="orderedHeaderFields"
             :index="idx"
+            :is-drag-and-drop-locked="lockDragAndDropBy ? item[lockDragAndDropBy] : false"
+            :is-drag-and-drop-locked-message="lockDragAndDropHint"
             :is-draggable="isDraggable"
             :is-expandable="isExpandable"
             :is-loading="isLoading"
@@ -336,6 +338,17 @@ export default {
     },
 
     /**
+     * Set it on the table the row is dragged *from*, since SortableJS reads the option
+     * from the source list.
+     * This should only be set if `isDraggable` is true.
+     */
+    isDraggableAcrossTables: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+
+    /**
      * Rows may be expandable to show additional content inside another row.
      * The `#expandedContent` slot can be utilized to style the content area.
      */
@@ -433,6 +446,23 @@ export default {
      * This should only be set if `isSelectable` is true.
      */
     lockCheckboxHint: {
+      type: String,
+      required: false,
+      default: null,
+    },
+
+    /**
+     * Name of a Boolean item property. Makes the row non-draggable.
+     * This should only be set if `isDraggable` is true.
+     */
+    lockDragAndDropBy: {
+      type: String,
+      required: false,
+      default: null,
+    },
+
+    // An optional string to be displayed as a tooltip in place of the drag handle of a locked row.
+    lockDragAndDropHint: {
       type: String,
       required: false,
       default: null,
@@ -561,6 +591,13 @@ export default {
         chosenClass: 'sortable-chosen',
         ghostClass: 'sortable-ghost',
         handle: '.c-data-table__drag-handle',
+
+        // SortableJS feature: on drop outside own table, put the row back at its original position
+        revertOnSpill: true,
+
+        // Allow the move only within the same table && not to a locked item position
+        onMove: event => (this.isDraggableAcrossTables || event.from === event.to) &&
+          !event.related?.classList.contains('is-drag-and-drop-locked'),
       }
     },
 

--- a/src/components/DpDataTable/DpDataTable.vue
+++ b/src/components/DpDataTable/DpDataTable.vue
@@ -338,17 +338,6 @@ export default {
     },
 
     /**
-     * Set it on the table the row is dragged *from*, since SortableJS reads the option
-     * from the source list.
-     * This should only be set if `isDraggable` is true.
-     */
-    isDraggableAcrossTables: {
-      type: Boolean,
-      required: false,
-      default: false,
-    },
-
-    /**
      * Rows may be expandable to show additional content inside another row.
      * The `#expandedContent` slot can be utilized to style the content area.
      */
@@ -595,9 +584,11 @@ export default {
         // SortableJS feature: on drop outside own table, put the row back at its original position
         revertOnSpill: true,
 
-        // Allow the move only within the same table && not to a locked item position
-        onMove: event => (this.isDraggableAcrossTables || event.from === event.to) &&
-          !event.related?.classList.contains('is-drag-and-drop-locked'),
+        /*
+         * Allow the move only within the same table && not to a locked item position.
+         * SortableJS reads onMove from the list the row is dragged from, so `from` is the source table.
+         */
+        onMove: event => event.from === event.to && !event.related?.classList.contains('is-drag-and-drop-locked'),
       }
     },
 

--- a/src/components/DpDataTable/DpTableRow.vue
+++ b/src/components/DpDataTable/DpTableRow.vue
@@ -2,14 +2,17 @@
   <tr
     class="row"
     :data-cy="dataCy !== '' ? dataCy : false"
-    :class="[{ 'opacity-70': isLoading }, { 'is-expanded-row': expanded }]"
+    :class="[{ 'opacity-70': isLoading }, { 'is-expanded-row': expanded }, { 'is-drag-and-drop-locked': isDragAndDropLocked }]"
   >
     <td
       v-if="isDraggable"
+      v-tooltip="isDragAndDropLocked ? isDragAndDropLockedMessage : null"
+      :aria-label="isDragAndDropLocked ? isDragAndDropLockedMessage : null"
       :class="[{ 'border-r border-neutral-light-3': hasBorders }, { 'p-[16px]': density === 'spacious' }]"
       class="c-data-table__cell--narrow"
     >
       <dp-icon
+        v-if="!isDragAndDropLocked"
         icon="drag-handle"
         class="c-data-table__drag-handle cursor-grab"
       />
@@ -183,9 +186,17 @@ export default {
       required: true,
     },
 
-    item: {
-      type: Object,
-      required: true,
+    // The row can be blocked from dragging. Instead of the drag handle, a tooltip is rendered.
+    isDragAndDropLocked: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+
+    isDragAndDropLockedMessage: {
+      type: String,
+      required: false,
+      default: null,
     },
 
     isDraggable: {
@@ -245,6 +256,11 @@ export default {
       type: Boolean,
       required: false,
       default: false,
+    },
+
+    item: {
+      type: Object,
+      required: true,
     },
 
     searchTerm: {

--- a/src/components/DpDataTable/DpTableRow.vue
+++ b/src/components/DpDataTable/DpTableRow.vue
@@ -11,7 +11,7 @@
     >
       <dp-icon
         icon="drag-handle"
-        class="c-data-table__drag-handle"
+        class="c-data-table__drag-handle cursor-grab"
       />
     </td>
 


### PR DESCRIPTION
[DPLAN-18003](https://demoseurope.youtrack.cloud/issue/DPLAN-18003/ADO-55977-Verfahrensschritte-sortieren)

This PR adds props for the drag and drop functionality:
- allows to block a particular row from being dragged
- disable dragging across tables --> when attempting it, item is placed back at its original position (using `SortableJS` built-in `revertOnSpill`)

It also fixes an existing bug due to incomplete `vuedraggable` → `vueuse/useSortable` migration:
- `handle="c-data-table__drag-handle"` was previously passed as a plain attribute to `DpDraggable`,
which has no `handle` prop — it fell through to the `<tbody>` as a DOM attribute and SortableJS
never saw it. Rows were draggable from anywhere. Now it reaches SortableJS via `opts`, and with
the required `.` selector prefix.

related core-PR: https://github.com/demos-europe/demosplan-core/pull/6660